### PR TITLE
Fix magazyn port mismatch and debug

### DIFF
--- a/magazyn/Dockerfile
+++ b/magazyn/Dockerfile
@@ -20,7 +20,7 @@ RUN pip install --no-cache-dir -r requirements.txt
 RUN python -c "from app import init_db; init_db()"
 
 # Ustawiamy port, na którym aplikacja będzie dostępna
-EXPOSE 5001
+EXPOSE 80
 
 # Uruchamiamy aplikację
 CMD ["python", "app.py"]

--- a/magazyn/app.py
+++ b/magazyn/app.py
@@ -355,4 +355,4 @@ if __name__ == '__main__':
     if not os.path.exists(DB_PATH):
         init_db()
     register_default_user()
-    app.run(host='0.0.0.0', port=80, debug=True)
+    app.run(host='0.0.0.0', port=80, debug=os.environ.get('FLASK_ENV') == 'development')


### PR DESCRIPTION
## Summary
- run Flask debug mode only in development
- expose port 80 in Dockerfile for magazyn service

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68509e6ca5c8832ab8f287f4a8a70495