### PR TITLE
Add printer Dockerfile and compose integration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,40 @@
+version: '3'
+
+services:
+  magazyn_app:
+    build:
+      context: ./magazyn
+      dockerfile: Dockerfile
+    volumes:
+      - ./magazyn:/app
+    environment:
+      - FLASK_ENV=development
+    command: ["python", "app.py"]
+    restart: always
+    networks:
+      - proxy
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.magazyn.rule=Host(`magazyn.retrievershop.pl`)"
+      - "traefik.http.routers.magazyn.entrypoints=https"
+      - "traefik.http.routers.magazyn.tls=true"
+      - "traefik.http.services.magazyn.loadbalancer.server.port=80"
+      - "traefik.http.services.magazyn.loadbalancer.server.scheme=http"
+
+  printer_agent:
+    build:
+      context: ./printer
+      dockerfile: Dockerfile
+    environment:
+      API_TOKEN: ${API_TOKEN}
+      PAGE_ACCESS_TOKEN: ${PAGE_ACCESS_TOKEN}
+      RECIPIENT_ID: ${RECIPIENT_ID}
+      PRINTER_NAME: ${PRINTER_NAME}
+    command: ["python3", "bl_api_print_agent.py"]
+    restart: always
+    networks:
+      - proxy
+
+networks:
+  proxy:
+    external: true

--- a/printer/Dockerfile
+++ b/printer/Dockerfile
@@ -1,0 +1,10 @@
+FROM debian:bullseye-slim
+RUN apt-get update && apt-get install -y \
+    python3 \
+    python3-pip \
+    cups-client \
+    && rm -rf /var/lib/apt/lists/*
+WORKDIR /app
+COPY . /app
+RUN pip3 install --no-cache-dir -r requirements.txt
+CMD ["python3", "bl_api_print_agent.py"]


### PR DESCRIPTION
## Summary
- set up Docker build for the print agent
- consolidate services in a root docker-compose file

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68509fa87198832ab2906701c2d894c6