### PR TITLE
Add persistent database mounts to compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
       dockerfile: Dockerfile
     volumes:
       - ./magazyn:/app
+      - ./data/database.db:/app/database.db
     environment:
       - FLASK_ENV=development
     command: ["python", "app.py"]
@@ -21,10 +22,13 @@ services:
       - "traefik.http.services.magazyn.loadbalancer.server.port=80"
       - "traefik.http.services.magazyn.loadbalancer.server.scheme=http"
 
-  printer_agent:
+  print_agent:
     build:
       context: ./printer
       dockerfile: Dockerfile
+    volumes:
+      - ./printer:/app
+      - ./data/data.db:/app/data.db
     environment:
       API_TOKEN: ${API_TOKEN}
       PAGE_ACCESS_TOKEN: ${PAGE_ACCESS_TOKEN}


### PR DESCRIPTION
## Summary
- rename `printer_agent` service to `print_agent`
- mount `database.db` and `data.db` for persistent storage in Docker

## Testing
- `pip install -r printer/requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6850a0bd44b4832aac0d16bf18620f12