### PR TITLE
Unify DB access for print agent

### DIFF
--- a/magazyn/__init__.py
+++ b/magazyn/__init__.py
@@ -1,0 +1,10 @@
+
+import os
+
+# Path to the SQLite database shared between the application and the
+# printing agent.  It defaults to ``database.db`` located in this
+# package directory but can be overridden with the ``DB_PATH``
+# environment variable.
+DB_PATH = os.getenv(
+    "DB_PATH", os.path.join(os.path.dirname(__file__), "database.db")
+)

--- a/magazyn/app.py
+++ b/magazyn/app.py
@@ -5,13 +5,12 @@ import pandas as pd
 from functools import wraps
 from werkzeug.security import generate_password_hash, check_password_hash
 from dotenv import load_dotenv
-from . import print_agent
+from . import print_agent, DB_PATH
 
 load_dotenv()
 
 app = Flask(__name__)
 app.secret_key = os.environ.get('SECRET_KEY', 'default_secret_key')
-DB_PATH = 'database.db'
 
 
 @app.before_first_request
@@ -66,6 +65,26 @@ def init_db():
     cursor.execute('''
         CREATE INDEX IF NOT EXISTS idx_product_id ON product_sizes (product_id);
     ''')
+
+    # Tables used by the printing agent
+    cursor.execute(
+        """
+        CREATE TABLE IF NOT EXISTS printed_orders(
+            order_id TEXT PRIMARY KEY,
+            printed_at TEXT
+        )
+        """
+    )
+    cursor.execute(
+        """
+        CREATE TABLE IF NOT EXISTS label_queue(
+            order_id TEXT,
+            label_data TEXT,
+            ext TEXT,
+            last_order_data TEXT
+        )
+        """
+    )
 
     conn.commit()
     conn.close()


### PR DESCRIPTION
## Summary
- share DB path via `magazyn.DB_PATH`
- use new constant in print agent
- migrate data from legacy `printer/data.db`
- create agent tables in `init_db`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68594c4836bc832aa9891b69c624f59c