### PR TITLE
Add print management pages to navigation

### DIFF
--- a/magazyn/app.py
+++ b/magazyn/app.py
@@ -405,22 +405,26 @@ def agent_logs():
     return render_template('logs.html', logs=log_text)
 
 
-@app.route('/testprint')
+@app.route('/testprint', methods=['GET', 'POST'])
 @login_required
 def test_print():
-    success = print_agent.print_test_page()
-    message = 'Testowy wydruk wysłany.' if success else 'Błąd testowego wydruku.'
+    message = None
+    if request.method == 'POST':
+        success = print_agent.print_test_page()
+        message = 'Testowy wydruk wysłany.' if success else 'Błąd testowego wydruku.'
     return render_template('testprint.html', message=message)
 
 
-@app.route('/test')
+@app.route('/test', methods=['GET', 'POST'])
 @login_required
 def test_message():
-    if print_agent.last_order_data:
-        print_agent.send_messenger_message(print_agent.last_order_data)
-        msg = 'Testowa wiadomość została wysłana.'
-    else:
-        msg = 'Brak danych ostatniego zamówienia.'
+    msg = None
+    if request.method == 'POST':
+        if print_agent.last_order_data:
+            print_agent.send_messenger_message(print_agent.last_order_data)
+            msg = 'Testowa wiadomość została wysłana.'
+        else:
+            msg = 'Brak danych ostatniego zamówienia.'
     return render_template('test.html', message=msg)
 
 if __name__ == '__main__':

--- a/magazyn/templates/base.html
+++ b/magazyn/templates/base.html
@@ -17,6 +17,9 @@
                 <li><a href="{{ url_for('home') }}">Strona główna</a></li>
                 <li><a href="{{ url_for('add_item') }}">Dodaj przedmiot</a></li>
                 <li><a href="{{ url_for('items') }}">Przedmioty</a></li>
+                <li><a href="{{ url_for('print_history') }}">Historia drukowania</a></li>
+                <li><a href="{{ url_for('agent_logs') }}">Logi</a></li>
+                <li><a href="{{ url_for('test_print') }}">Testuj drukarkę</a></li>
             </ul>
         </nav>
     </header>

--- a/magazyn/templates/test.html
+++ b/magazyn/templates/test.html
@@ -1,5 +1,10 @@
 {% extends "base.html" %}
 {% block content %}
 <h2>Test wiadomości</h2>
+<form method="post" class="mb-3">
+    <button type="submit" class="btn btn-primary">Wy\u015blij testow\u0105 wiadom\u201a\u0107</button>
+</form>
+{% if message %}
 <p>{{ message }}</p>
+{% endif %}
 {% endblock %}

--- a/magazyn/templates/testprint.html
+++ b/magazyn/templates/testprint.html
@@ -1,5 +1,10 @@
 {% extends "base.html" %}
 {% block content %}
 <h2>Test wydruku</h2>
+<form method="post" class="mb-3">
+    <button type="submit" class="btn btn-primary">Wydrukuj stron\u0119 testow\u0105</button>
+</form>
+{% if message %}
 <p>{{ message }}</p>
+{% endif %}
 {% endblock %}


### PR DESCRIPTION
## Summary
- link print history, logs and test printing from the main layout
- show buttons on test pages for sending test print and messenger message
- update Flask routes to handle POST for tests

## Testing
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685950c72c2c832a8ea6741b63382977