### PR TITLE
Add env template and README instructions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,33 @@
+# Global environment configuration for retrievershop-suite
+# Copy this file to `.env` and update the values as needed
+
+# API credentials
+API_TOKEN=changeme
+PAGE_ACCESS_TOKEN=changeme
+RECIPIENT_ID=changeme
+
+# Optional order status and printer details
+STATUS_ID=91618
+PRINTER_NAME=Xprinter
+
+# CUPS printing server configuration
+CUPS_SERVER=192.168.1.107
+CUPS_PORT=631
+
+# General behaviour
+POLL_INTERVAL=60
+QUIET_HOURS_START=10
+QUIET_HOURS_END=22
+PRINTED_EXPIRY_DAYS=5
+LOG_LEVEL=INFO
+LOG_FILE=agent.log
+
+# Database locations
+DB_PATH=magazyn/database.db
+DATA_DB=printer/data.db
+
+# Web app settings
+SECRET_KEY=changeme
+FLASK_ENV=development
+ENABLE_HTTP_SERVER=1
+HTTP_PORT=8082

--- a/README.md
+++ b/README.md
@@ -1,0 +1,25 @@
+# RetrieverShop Suite
+
+This repository contains the code for the RetrieverShop warehouse and printing utilities.
+
+## Configuration
+
+1. Copy `.env.example` to `.env` in the repository root:
+   ```bash
+   cp .env.example .env
+   ```
+2. Edit `.env` and provide your API credentials. The printing agents require values such as `API_TOKEN`, `PAGE_ACCESS_TOKEN` and `RECIPIENT_ID`.
+3. Set the CUPS printing server address. For the provided infrastructure use:
+   ```env
+   CUPS_SERVER=192.168.1.107
+   CUPS_PORT=631
+   ```
+   This points the agents at the CUPS server running at `192.168.1.107:631`.
+
+## Running Tests
+
+Install the dependencies and run the test suite using `pytest`:
+```bash
+pip install -r magazyn/requirements.txt -r printer/requirements.txt
+PYTHONPATH=. pytest -q
+```


### PR DESCRIPTION
## Summary
- document required env vars in `.env.example`
- add README with setup instructions

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859568fdf38832a97a1c5d311b3c367