### PR TITLE
Initialize database at runtime

### DIFF
--- a/magazyn/Dockerfile
+++ b/magazyn/Dockerfile
@@ -17,9 +17,6 @@ COPY . /app
 # Instalujemy wymagane pakiety z requirements.txt
 RUN pip install --no-cache-dir -r requirements.txt
 
-# Tworzymy bazę danych
-RUN python -c "from app import init_db; init_db()"
-
 # Ustawiamy port, na którym aplikacja będzie dostępna
 EXPOSE 80
 

--- a/magazyn/app.py
+++ b/magazyn/app.py
@@ -14,6 +14,13 @@ app.secret_key = os.environ.get('SECRET_KEY', 'default_secret_key')
 
 
 @app.before_first_request
+def _init_db_if_missing():
+    if not os.path.exists(DB_PATH):
+        init_db()
+    register_default_user()
+
+
+@app.before_first_request
 def _start_agent():
     try:
         print_agent.validate_env()


### PR DESCRIPTION
## Summary
- create the database on startup instead of during build
- remove database init step from Dockerfile

## Testing
- `pip install -r magazyn/requirements.txt`
- `PYTHONPATH=. pytest -q`
- ❌ `docker build` *(fails: `docker` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859c00c6f50832a8daf94e03a233cf2