### PR TITLE
Fix imports for Docker execution

### DIFF
--- a/magazyn/__init__.py
+++ b/magazyn/__init__.py
@@ -8,3 +8,7 @@ import os
 DB_PATH = os.getenv(
     "DB_PATH", os.path.join(os.path.dirname(__file__), "database.db")
 )
+
+# Allow ``from __init__ import DB_PATH`` when running modules as scripts.
+import sys
+sys.modules.setdefault("__init__", sys.modules[__name__])

--- a/magazyn/app.py
+++ b/magazyn/app.py
@@ -5,7 +5,8 @@ import pandas as pd
 from functools import wraps
 from werkzeug.security import generate_password_hash, check_password_hash
 from dotenv import load_dotenv
-from . import print_agent, DB_PATH
+import print_agent
+from __init__ import DB_PATH
 
 load_dotenv()
 

--- a/magazyn/print_agent.py
+++ b/magazyn/print_agent.py
@@ -10,7 +10,7 @@ from datetime import datetime, timedelta
 from dotenv import load_dotenv
 import requests
 
-from . import DB_PATH
+from __init__ import DB_PATH
 
 load_dotenv()
 


### PR DESCRIPTION
## Summary
- adjust imports for running `app.py` as a script
- update `print_agent` imports
- expose DB_PATH when running modules directly

## Testing
- `PYTHONPATH=. pytest -q`
- `docker build ./magazyn -t test-image` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859c2e3f824832abe34ad4444337516