### PR TITLE
Pin Flask version

### DIFF
--- a/magazyn/requirements.txt
+++ b/magazyn/requirements.txt
@@ -1,4 +1,4 @@
-flask
+flask==2.2.5
 werkzeug
 pandas
 openpyxl


### PR DESCRIPTION
## Summary
- pin Flask to <2.3

## Testing
- `pip install -r magazyn/requirements.txt`
- `PYTHONPATH=. pytest -q`
- start app with `python magazyn/app.py`

------
https://chatgpt.com/codex/tasks/task_e_6859ca4d04c4832a9af80a55ad460484