### PR TITLE
Switch to FLASK_DEBUG flag

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,6 +27,6 @@ DB_PATH=magazyn/database.db
 
 # Web app settings
 SECRET_KEY=changeme
-FLASK_ENV=development
+FLASK_DEBUG=1
 ENABLE_HTTP_SERVER=1
 HTTP_PORT=8082

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,8 +5,7 @@ services:
       dockerfile: Dockerfile
     volumes:
       - ./magazyn/database.db:/app/database.db
-    environment:
-      - FLASK_ENV=development
+    env_file: .env
     command: ["python", "app.py"]
     restart: always
     networks:

--- a/magazyn/app.py
+++ b/magazyn/app.py
@@ -439,4 +439,5 @@ if __name__ == '__main__':
     if not os.path.exists(DB_PATH):
         init_db()
     register_default_user()
-    app.run(host='0.0.0.0', port=80, debug=os.environ.get('FLASK_ENV') == 'development')
+    debug = os.getenv("FLASK_DEBUG") == "1"
+    app.run(host="0.0.0.0", port=80, debug=debug)


### PR DESCRIPTION
## Summary
- use `.env` file in docker compose and remove old environment variable
- switch app to read `FLASK_DEBUG` and update example env file

## Testing
- `pip install -r magazyn/requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859d3a07568832a99cc954bb1f8365e