### PR TITLE
Add .dockerignore for magazyn

### DIFF
--- a/magazyn/.dockerignore
+++ b/magazyn/.dockerignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.pyc
+*.db
+*.log
+.env


### PR DESCRIPTION
## Summary
- add `.dockerignore` file to exclude caches, logs, databases, and env file from the Docker build context

## Testing
- `pip install -q -r magazyn/requirements.txt`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6859dbecf0c0832abdd828cde37f01fb