### PR TITLE
Remove unused HTTP server env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,5 +28,3 @@ DB_PATH=magazyn/database.db
 # Web app settings
 SECRET_KEY=changeme
 FLASK_DEBUG=1
-ENABLE_HTTP_SERVER=1
-HTTP_PORT=8082


### PR DESCRIPTION
## Summary
- drop `ENABLE_HTTP_SERVER` and `HTTP_PORT` from the example env file
- confirm no other obsolete variables remain

## Testing
- `pip install -r magazyn/requirements.txt`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6859dc71181c832aacd841a4d4831e66