### PR TITLE
Fix DB_PATH in sample env for Docker

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,8 +22,11 @@ PRINTED_EXPIRY_DAYS=5
 LOG_LEVEL=INFO
 LOG_FILE=agent.log
 
-# Database locations
-DB_PATH=magazyn/database.db
+# Database location
+# When running inside Docker the database is mounted at ``/app/database.db``.
+# If you are running locally you may adjust this path or remove the variable
+# to rely on the package's default.
+DB_PATH=/app/database.db
 
 # Web app settings
 SECRET_KEY=changeme


### PR DESCRIPTION
## Summary
- document Docker database path in `.env.example`

## Testing
- `pip install -r magazyn/requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859dee23c9c832ab0972178311b853a