### PR TITLE
Update DB_PATH docs for Docker

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,10 +23,10 @@ LOG_LEVEL=INFO
 LOG_FILE=agent.log
 
 # Database location
+DB_PATH=/app/database.db
 # When running inside Docker the database is mounted at ``/app/database.db``.
 # If you are running locally you may adjust this path or remove the variable
 # to rely on the package's default.
-DB_PATH=/app/database.db
 
 # Web app settings
 SECRET_KEY=changeme

--- a/README.md
+++ b/README.md
@@ -34,3 +34,6 @@ docker compose up
 
 The application uses a SQLite database stored in `magazyn/database.db`. This
 file is created automatically on first startup if it does not already exist.
+When running the stack in Docker, this file is mounted inside the container as
+`/app/database.db` and the `DB_PATH` variable in your `.env` file should point
+to that location.


### PR DESCRIPTION
## Summary
- keep DB_PATH example inline with container path
- clarify README that DB_PATH inside container is `/app/database.db`

## Testing
- `pip install -q -r magazyn/requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a7fb085c4832aa0835822b2b2a48f