### PR TITLE
Fix admin user creation check

### DIFF
--- a/magazyn/app.py
+++ b/magazyn/app.py
@@ -112,7 +112,7 @@ def init_db():
 def register_default_user():
     conn = get_db_connection()
     cursor = conn.cursor()
-    cursor.execute("SELECT 1 FROM users WHERE username = ?", ("admin",))
+    cursor.execute("SELECT id FROM users WHERE username='admin'")
     if cursor.fetchone() is None:
         hashed_password = generate_password_hash(
             "admin123", method="pbkdf2:sha256", salt_length=16


### PR DESCRIPTION
## Summary
- only insert the default `admin` user when not found

## Testing
- `pip install -r magazyn/requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a82d7ca14832a8f4a7da9e53fde3c