### PR TITLE
Add PYTHONPATH note for tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ This repository contains the code for the RetrieverShop warehouse application an
 
 ## Running Tests
 
-Install the dependencies and run the test suite using `pytest`:
+Install the dependencies and run the test suite using `pytest`. Tests rely on
+modules within this repository, so run them with `PYTHONPATH=.`:
 ```bash
 pip install -r magazyn/requirements.txt
 PYTHONPATH=. pytest -q


### PR DESCRIPTION
## Summary
- document `PYTHONPATH` requirement in README's test section

## Testing
- `python3 -m pip install -r magazyn/requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ab28196ac832ab5237f868fbe8783