### PR TITLE
Add settings page with env management

### DIFF
--- a/magazyn/print_agent.py
+++ b/magazyn/print_agent.py
@@ -52,6 +52,29 @@ HEADERS = {
     "Content-Type": "application/x-www-form-urlencoded",
 }
 
+
+def reload_env():
+    """Reload environment variables and update globals."""
+    load_dotenv(override=True)
+    global API_TOKEN, PAGE_ACCESS_TOKEN, RECIPIENT_ID, STATUS_ID, PRINTER_NAME
+    global CUPS_SERVER, CUPS_PORT, POLL_INTERVAL, QUIET_HOURS_START, QUIET_HOURS_END
+    global PRINTED_EXPIRY_DAYS, LOG_LEVEL, LOG_FILE, DB_FILE, HEADERS
+    API_TOKEN = os.getenv("API_TOKEN")
+    PAGE_ACCESS_TOKEN = os.getenv("PAGE_ACCESS_TOKEN")
+    RECIPIENT_ID = os.getenv("RECIPIENT_ID")
+    STATUS_ID = int(os.getenv("STATUS_ID", "91618"))
+    PRINTER_NAME = os.getenv("PRINTER_NAME", "Xprinter")
+    CUPS_SERVER = os.getenv("CUPS_SERVER")
+    CUPS_PORT = os.getenv("CUPS_PORT")
+    POLL_INTERVAL = int(os.getenv("POLL_INTERVAL", "60"))
+    QUIET_HOURS_START = int(os.getenv("QUIET_HOURS_START", "10"))
+    QUIET_HOURS_END = int(os.getenv("QUIET_HOURS_END", "22"))
+    PRINTED_EXPIRY_DAYS = int(os.getenv("PRINTED_EXPIRY_DAYS", "5"))
+    LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO").upper()
+    LOG_FILE = os.getenv("LOG_FILE", os.path.join(os.path.dirname(__file__), "agent.log"))
+    DB_FILE = DB_PATH
+    HEADERS["X-BLToken"] = API_TOKEN
+
 last_order_data = {}
 _agent_thread = None
 

--- a/magazyn/templates/base.html
+++ b/magazyn/templates/base.html
@@ -19,6 +19,7 @@
                 <li><a href="{{ url_for('items') }}">Przedmioty</a></li>
                 <li><a href="{{ url_for('print_history') }}">Historia drukowania</a></li>
                 <li><a href="{{ url_for('agent_logs') }}">Logi</a></li>
+                <li><a href="{{ url_for('settings') }}">Ustawienia</a></li>
                 <li><a href="{{ url_for('test_print') }}">Testuj drukarkę</a></li>
             </ul>
         </nav>

--- a/magazyn/templates/settings.html
+++ b/magazyn/templates/settings.html
@@ -1,0 +1,14 @@
+{% extends "base.html" %}
+
+{% block content %}
+<h2>Ustawienia</h2>
+<form method="post">
+    {% for key, value in settings.items() %}
+        <div class="form-group">
+            <label for="{{ key }}">{{ key }}</label>
+            <input type="text" class="form-control" id="{{ key }}" name="{{ key }}" value="{{ value }}">
+        </div>
+    {% endfor %}
+    <button type="submit" class="btn btn-primary">Zapisz</button>
+</form>
+{% endblock %}


### PR DESCRIPTION
## Summary
- implement helper functions to load and update `.env`
- add `/settings` route protected with login_required
- reload print agent configuration after saving settings
- create `settings.html` form template
- link to "Ustawienia" in navigation bar

## Testing
- `pip install -q -r magazyn/requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b03b0b2e4832a8f83182a4f99177c