### PR TITLE
Improve log view

### DIFF
--- a/magazyn/app.py
+++ b/magazyn/app.py
@@ -460,12 +460,12 @@ def settings():
 @login_required
 def agent_logs():
     try:
-        with open(print_agent.LOG_FILE, 'r') as f:
+        with open(print_agent.LOG_FILE, "r") as f:
             lines = f.readlines()[-200:]
-        log_text = ''.join(lines)
+        log_text = "<br>".join(line.rstrip() for line in lines[::-1])
     except Exception as e:
-        log_text = f'Błąd czytania logów: {e}'
-    return render_template('logs.html', logs=log_text)
+        log_text = f"Błąd czytania logów: {e}"
+    return render_template("logs.html", logs=log_text)
 
 
 @app.route('/testprint', methods=['GET', 'POST'])

--- a/magazyn/static/styles.css
+++ b/magazyn/static/styles.css
@@ -162,4 +162,19 @@ th {
     }
 }
 
+.log-container {
+    max-height: 600px;
+    overflow-y: auto;
+    padding: 10px;
+    border: 1px solid #ccc;
+    background-color: #f8f8f8;
+    margin: 20px auto;
+    width: 90%;
+}
+
+.log-content {
+    font-family: monospace;
+    white-space: pre-wrap;
+}
+
 

--- a/magazyn/templates/logs.html
+++ b/magazyn/templates/logs.html
@@ -1,5 +1,7 @@
 {% extends "base.html" %}
 {% block content %}
 <h2>Logi</h2>
-<pre style="white-space: pre-wrap;">{{ logs }}</pre>
+<div class="log-container">
+    <div class="log-content">{{ logs|safe }}</div>
+</div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- display most recent agent logs in reverse chronological order
- style log output container for improved readability

## Testing
- `pip install -r magazyn/requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b1092865c832ab9e77d5ec65ae6de