### PR TITLE
Add reload_config helper for settings

### DIFF
--- a/magazyn/app.py
+++ b/magazyn/app.py
@@ -470,7 +470,7 @@ def settings():
         updated = {key: request.form.get(key, "") for key in dotenv_values(EXAMPLE_PATH).keys()}
         write_env(updated)
         load_dotenv(override=True)
-        print_agent.reload_env()
+        print_agent.reload_config()
         flash('Zapisano ustawienia.')
         return redirect(url_for('settings'))
     values = load_settings()

--- a/magazyn/print_agent.py
+++ b/magazyn/print_agent.py
@@ -75,6 +75,11 @@ def reload_env():
     DB_FILE = DB_PATH
     HEADERS["X-BLToken"] = API_TOKEN
 
+
+def reload_config():
+    """Reload configuration from .env and update globals."""
+    reload_env()
+
 last_order_data = {}
 _agent_thread = None
 


### PR DESCRIPTION
## Summary
- add `reload_config()` in `print_agent`
- call `reload_config()` after saving settings

## Testing
- `pip install -q python-dotenv`
- `pip install -q requests`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685bca676318832a851834575eaed509