### PR TITLE
Enable barcode scan page with speech feedback

### DIFF
--- a/magazyn/app.py
+++ b/magazyn/app.py
@@ -1,4 +1,4 @@
-from flask import Flask, render_template, request, redirect, url_for, session, flash, send_file
+from flask import Flask, render_template, request, redirect, url_for, session, flash, send_file, jsonify
 import sqlite3
 import os
 import pandas as pd
@@ -369,6 +369,7 @@ def barcode_scan():
 
         if product:
             flash(f'Znaleziono produkt: {product["name"]}')
+            return jsonify({'name': product['name']})
         else:
             flash('Nie znaleziono produktu o podanym kodzie kreskowym')
 

--- a/magazyn/templates/home.html
+++ b/magazyn/templates/home.html
@@ -5,7 +5,8 @@
     <h3>Zalogowany jako {{ username }}</h3>
     <a href="{{ url_for('add_item') }}" class="btn btn-primary mt-3">Dodaj nowy przedmiot</a>
     <a href="{{ url_for('items') }}" class="btn btn-primary mt-3">Wyświetl przedmioty</a>
-	<a href="{{ url_for('export_products') }}" class="btn btn-primary mt-3">Eksportuj produkty do Excel</a>
-	<a href="{{ url_for('import_products') }}" class="btn btn-primary mt-3">Importuj produkty z Excel</a>
+    <a href="{{ url_for('barcode_scan_page') }}" class="btn btn-primary mt-3">Skanuj kod kreskowy</a>
+    <a href="{{ url_for('export_products') }}" class="btn btn-primary mt-3">Eksportuj produkty do Excel</a>
+    <a href="{{ url_for('import_products') }}" class="btn btn-primary mt-3">Importuj produkty z Excel</a>
 </div>
 {% endblock %}

--- a/magazyn/templates/scan_barcode.html
+++ b/magazyn/templates/scan_barcode.html
@@ -51,10 +51,18 @@
                     'Content-Type': 'application/json'
                 },
                 body: JSON.stringify({ barcode: data.codeResult.code })
-            }).then(response => {
-                if (response.ok) {
-                    window.location.href = "/items";  // Przekierowanie po zakończeniu skanowania
+            })
+            .then(res => res.json().catch(() => null))
+            .then(result => {
+                if (result && result.name) {
+                    const parts = result.name.trim().split(/\s+/);
+                    let toSpeak = result.name;
+                    if (parts.length >= 3) {
+                        toSpeak = `${parts[0]} ${parts.slice(-2).join(' ')}`;
+                    }
+                    speechSynthesis.speak(new SpeechSynthesisUtterance(toSpeak));
                 }
+                window.location.href = "/items";
             });
         });
     </script>


### PR DESCRIPTION
## Summary
- add barcode scan button on home page
- return JSON with product name from `/barcode_scan`
- read JSON in scan barcode page and speak product name

## Testing
- `pip install -q -r magazyn/requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685bd32e6ed0832a8f86b6b6886945ce