### PR TITLE
Add printer settings page

### DIFF
--- a/magazyn/templates/settings.html
+++ b/magazyn/templates/settings.html
@@ -1,14 +1,20 @@
 {% extends "base.html" %}
 
 {% block content %}
-<h2>Ustawienia</h2>
+<h2>Ustawienia drukarki</h2>
 <form method="post">
-    {% for key, value in settings.items() %}
-        <div class="form-group">
-            <label for="{{ key }}">{{ key }}</label>
-            <input type="text" class="form-control" id="{{ key }}" name="{{ key }}" value="{{ value }}">
-        </div>
-    {% endfor %}
+    <div class="form-group">
+        <label for="PRINTER_NAME">PRINTER_NAME</label>
+        <input type="text" class="form-control" id="PRINTER_NAME" name="PRINTER_NAME" value="{{ settings.PRINTER_NAME }}">
+    </div>
+    <div class="form-group">
+        <label for="CUPS_SERVER">CUPS_SERVER</label>
+        <input type="text" class="form-control" id="CUPS_SERVER" name="CUPS_SERVER" value="{{ settings.CUPS_SERVER }}">
+    </div>
+    <div class="form-group">
+        <label for="CUPS_PORT">CUPS_PORT</label>
+        <input type="text" class="form-control" id="CUPS_PORT" name="CUPS_PORT" value="{{ settings.CUPS_PORT }}">
+    </div>
     <button type="submit" class="btn btn-primary">Zapisz</button>
 </form>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add a `settings` table to hold printer configuration
- store PRINTER_NAME, CUPS_SERVER and CUPS_PORT in the DB through `/settings`
- update settings template with specific printer/CUPS fields

## Testing
- `pip install -q -r magazyn/requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685bd879e400832a8d555818832d93a8