### PR TITLE
Fix app module path in Docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - ./magazyn/database.db:/app/database.db
       - /var/run/cups/cups.sock:/var/run/cups/cups.sock
     env_file: .env
-    command: ["python", "app.py"]
+    command: ["python", "-m", "magazyn.app"]
     restart: always
     networks:
       - proxy

--- a/magazyn/Dockerfile
+++ b/magazyn/Dockerfile
@@ -11,14 +11,14 @@ RUN apt-get update && apt-get install -y \
     cups-client \
     && rm -rf /var/lib/apt/lists/*
 
-# Kopiujemy pliki aplikacji do kontenera
-COPY . /app
+# Kopiujemy pliki aplikacji do kontenera w podkatalogu
+COPY . /app/magazyn
 
 # Instalujemy wymagane pakiety z requirements.txt
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install --no-cache-dir -r /app/magazyn/requirements.txt
 
 # Ustawiamy port, na którym aplikacja będzie dostępna
 EXPOSE 80
 
 # Uruchamiamy aplikację
-CMD ["python", "app.py"]
+CMD ["python", "-m", "magazyn.app"]


### PR DESCRIPTION
## Summary
- copy source into /app/magazyn during build
- install requirements from the copied directory
- use `python -m magazyn.app` both in Dockerfile and docker-compose

## Testing
- `PYTHONPATH=. pytest -q`
- `docker compose version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bedb61280832a891f6d2a1e2c46a5