### PR TITLE
Update barcode scanning template

### DIFF
--- a/magazyn/static/styles.css
+++ b/magazyn/static/styles.css
@@ -177,4 +177,16 @@ th {
     white-space: pre-wrap;
 }
 
+#scanner-container {
+    width: 100%;
+    height: 60vh;
+    margin: 0 auto;
+}
+
+@media (max-width: 768px) {
+    #scanner-container {
+        height: 80vh;
+    }
+}
+
 

--- a/magazyn/templates/scan_barcode.html
+++ b/magazyn/templates/scan_barcode.html
@@ -1,16 +1,10 @@
-<!DOCTYPE html>
-<html lang="pl">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Skanowanie kodu kreskowego</title>
+{% extends "base.html" %}
+{% block content %}
     <script src="https://cdnjs.cloudflare.com/ajax/libs/quagga/0.12.1/quagga.min.js"></script>
-</head>
-<body>
     <h2>Skanuj kod kreskowy</h2>
     <div id="scanner-container"></div>
     <p id="barcode-result">Kod kreskowy: </p>
-    
+
     <!-- Element audio do odtworzenia dźwięku -->
     <audio id="beep-sound" src="beep.mp3" preload="auto"></audio>
 
@@ -66,5 +60,4 @@
             });
         });
     </script>
-</body>
-</html>
+{% endblock %}


### PR DESCRIPTION
## Summary
- extend `scan_barcode.html` from `base.html`
- keep existing viewport meta in the base layout
- make the scanner container responsive

## Testing
- `pip install -r magazyn/requirements.txt`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685bf1a4247c832a8cdf39fd11c23a28