### PR TITLE
Fix import paths

### DIFF
--- a/magazyn/app.py
+++ b/magazyn/app.py
@@ -9,7 +9,7 @@ from .db import get_db_connection, init_db, register_default_user
 from .products import bp as products_bp, add_item, update_quantity, delete_item, edit_item, items, barcode_scan, barcode_scan_page, export_products, import_products
 from .history import bp as history_bp, print_history
 from .auth import login_required
-import print_agent
+from . import print_agent
 from __init__ import DB_PATH
 ROOT_DIR = Path(__file__).resolve().parents[1]
 ENV_PATH = ROOT_DIR / '.env'

--- a/magazyn/history.py
+++ b/magazyn/history.py
@@ -1,5 +1,5 @@
 from flask import Blueprint, render_template, session, redirect, url_for
-import print_agent
+from . import print_agent
 
 from .auth import login_required
 bp = Blueprint('history', __name__)

--- a/magazyn/products.py
+++ b/magazyn/products.py
@@ -7,7 +7,7 @@ import pandas as pd
 
 from .db import get_db_connection
 from .auth import login_required
-import print_agent
+from . import print_agent
 
 bp = Blueprint('products', __name__)
 


### PR DESCRIPTION
## Summary
- fix `print_agent` imports in magazyn modules

## Testing
- `pip install -r magazyn/requirements.txt`
- `python -m magazyn.app` *(fails due to missing env vars but no ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_685bf38a7220832a876f9f770e15a5fe