### PR TITLE
Add deliveries and purchase tracking

### DIFF
--- a/magazyn/app.py
+++ b/magazyn/app.py
@@ -5,7 +5,13 @@ from dotenv import load_dotenv, dotenv_values
 from collections import OrderedDict
 from pathlib import Path
 
-from .db import get_db_connection, init_db, register_default_user
+from .db import (
+    get_db_connection,
+    init_db,
+    register_default_user,
+    record_purchase,
+    consume_stock,
+)
 from .products import (
     bp as products_bp,
     add_item,
@@ -17,6 +23,7 @@ from .products import (
     barcode_scan_page,
     export_products,
     import_products,
+    add_delivery,
 )
 from .history import bp as history_bp, print_history
 from .auth import login_required

--- a/magazyn/templates/add_delivery.html
+++ b/magazyn/templates/add_delivery.html
@@ -1,0 +1,28 @@
+{% extends "base.html" %}
+
+{% block content %}
+<h2>Dodaj dostawę</h2>
+<form action="{{ url_for('products.add_delivery') }}" method="post">
+    <label for="product_id">Produkt:</label>
+    <select name="product_id" id="product_id">
+        {% for p in products %}
+        <option value="{{ p['id'] }}">{{ p['name'] }}</option>
+        {% endfor %}
+    </select>
+
+    <label for="size">Rozmiar:</label>
+    <select name="size" id="size">
+        {% for s in ['XS','S','M','L','XL','Uniwersalny'] %}
+        <option value="{{ s }}">{{ s }}</option>
+        {% endfor %}
+    </select>
+
+    <label for="quantity">Ilość:</label>
+    <input type="number" name="quantity" id="quantity" value="1" min="1">
+
+    <label for="price">Cena:</label>
+    <input type="number" step="0.01" name="price" id="price" value="0">
+
+    <button type="submit">Dodaj</button>
+</form>
+{% endblock %}

--- a/magazyn/templates/base.html
+++ b/magazyn/templates/base.html
@@ -17,6 +17,7 @@
                 <li><a href="{{ url_for('home') }}">Strona główna</a></li>
                 <li><a href="{{ url_for('products.add_item') }}">Dodaj przedmiot</a></li>
                 <li><a href="{{ url_for('products.items') }}">Przedmioty</a></li>
+                <li><a href="{{ url_for('products.add_delivery') }}">Dostawy</a></li>
                 <li><a href="{{ url_for('history.print_history') }}">Historia drukowania</a></li>
                 <li><a href="{{ url_for('agent_logs') }}">Logi</a></li>
                 <li><a href="{{ url_for('settings') }}">Ustawienia</a></li>

--- a/magazyn/tests/test_deliveries.py
+++ b/magazyn/tests/test_deliveries.py
@@ -1,0 +1,87 @@
+import importlib
+import sys
+
+
+def setup_app(tmp_path, monkeypatch):
+    monkeypatch.setenv("DB_PATH", str(tmp_path / "db.sqlite"))
+    init = importlib.import_module("magazyn.__init__")
+    importlib.reload(init)
+    monkeypatch.setitem(sys.modules, "__init__", init)
+    pa = importlib.import_module("magazyn.print_agent")
+    monkeypatch.setitem(sys.modules, "print_agent", pa)
+    monkeypatch.setattr(pa, "start_agent_thread", lambda: None)
+    monkeypatch.setattr(pa, "ensure_db_init", lambda: None)
+    monkeypatch.setattr(pa, "validate_env", lambda: None)
+    import magazyn.app as app_mod
+    importlib.reload(app_mod)
+    app_mod.init_db()
+    return app_mod
+
+
+def test_record_delivery(tmp_path, monkeypatch):
+    app_mod = setup_app(tmp_path, monkeypatch)
+    with app_mod.get_db_connection() as conn:
+        cur = conn.cursor()
+        cur.execute("INSERT INTO products (name, color) VALUES (?, ?)", ("Prod", "Red"))
+        pid = cur.lastrowid
+        cur.execute(
+            "INSERT INTO product_sizes (product_id, size, quantity) VALUES (?, ?, ?)",
+            (pid, "M", 0),
+        )
+        conn.commit()
+
+    data = {
+        "product_id": str(pid),
+        "size": "M",
+        "quantity": "3",
+        "price": "4.5",
+    }
+    with app_mod.app.test_request_context("/deliveries", method="POST", data=data):
+        from flask import session
+        session["username"] = "x"
+        app_mod.add_delivery.__wrapped__()
+
+    with app_mod.get_db_connection() as conn:
+        batch = conn.execute(
+            "SELECT quantity, price FROM purchase_batches WHERE product_id=? AND size=?",
+            (pid, "M"),
+        ).fetchone()
+        qty = conn.execute(
+            "SELECT quantity FROM product_sizes WHERE product_id=? AND size=?",
+            (pid, "M"),
+        ).fetchone()
+    assert batch["quantity"] == 3
+    assert abs(batch["price"] - 4.5) < 0.001
+    assert qty["quantity"] == 3
+
+
+def test_consume_stock_cheapest(tmp_path, monkeypatch):
+    app_mod = setup_app(tmp_path, monkeypatch)
+    with app_mod.get_db_connection() as conn:
+        cur = conn.cursor()
+        cur.execute("INSERT INTO products (name, color) VALUES (?, ?)", ("Prod", "Red"))
+        pid = cur.lastrowid
+        cur.execute(
+            "INSERT INTO product_sizes (product_id, size, quantity) VALUES (?, ?, ?)",
+            (pid, "M", 0),
+        )
+        conn.commit()
+
+    app_mod.record_purchase(pid, "M", 2, 5.0)
+    app_mod.record_purchase(pid, "M", 1, 4.0)
+    consumed = app_mod.consume_stock(pid, "M", 2)
+
+    with app_mod.get_db_connection() as conn:
+        qty = conn.execute(
+            "SELECT quantity FROM product_sizes WHERE product_id=? AND size=?",
+            (pid, "M"),
+        ).fetchone()["quantity"]
+        batches = conn.execute(
+            "SELECT price, quantity FROM purchase_batches WHERE product_id=? AND size=? ORDER BY price",
+            (pid, "M"),
+        ).fetchall()
+    assert consumed == 2
+    assert qty == 1
+    assert len(batches) == 1
+    assert batches[0]["price"] == 5.0
+    assert batches[0]["quantity"] == 1


### PR DESCRIPTION
## Summary
- track product purchases in new `purchase_batches` table
- add helpers `record_purchase` and `consume_stock`
- update quantity endpoint to deduct from cheapest batch
- provide new `/deliveries` route and form
- link deliveries from navigation
- tests for deliveries and stock consumption

## Testing
- `pip install -q -r magazyn/requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685bfee1551c832ab86581d9849b1b37