### PR TITLE
Include color and sizes in barcode scan

### DIFF
--- a/magazyn/templates/scan_barcode.html
+++ b/magazyn/templates/scan_barcode.html
@@ -48,13 +48,11 @@
             })
             .then(res => res.json().catch(() => null))
             .then(result => {
-                if (result && result.name) {
-                    const parts = result.name.trim().split(/\s+/);
-                    let toSpeak = result.name;
-                    if (parts.length >= 3) {
-                        toSpeak = `${parts[0]} ${parts.slice(-2).join(' ')}`;
-                    }
-                    speechSynthesis.speak(new SpeechSynthesisUtterance(toSpeak));
+                if (result) {
+                    const text =
+                        `${result.name}, kolor ${result.color}, rozmiar ` +
+                        result.sizes.join(" ");
+                    speechSynthesis.speak(new SpeechSynthesisUtterance(text));
                 }
                 window.location.href = "/items";
             });


### PR DESCRIPTION
## Summary
- extend `/barcode_scan` endpoint to return product color and available sizes
- announce name, color and all sizes after scanning a barcode

## Testing
- `pip install -r magazyn/requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c0dbe7d88832a9e9ac33d33c68779