### PR TITLE
Support barcodes per product size

### DIFF
--- a/magazyn/db.py
+++ b/magazyn/db.py
@@ -58,6 +58,7 @@ def init_db():
                 product_id INTEGER,
                 size TEXT CHECK(size IN ('XS', 'S', 'M', 'L', 'XL', 'Uniwersalny')) NOT NULL,
                 quantity INTEGER NOT NULL DEFAULT 0,
+                barcode TEXT UNIQUE,
                 FOREIGN KEY (product_id) REFERENCES products (id),
                 UNIQUE(product_id, size)
             )

--- a/magazyn/migrations/add_barcode_to_product_sizes.py
+++ b/magazyn/migrations/add_barcode_to_product_sizes.py
@@ -1,0 +1,17 @@
+import sqlite3
+from __init__ import DB_PATH
+
+def migrate():
+    with sqlite3.connect(DB_PATH) as conn:
+        cur = conn.cursor()
+        cur.execute("PRAGMA table_info(product_sizes)")
+        cols = [row[1] for row in cur.fetchall()]
+        if 'barcode' not in cols:
+            cur.execute("ALTER TABLE product_sizes ADD COLUMN barcode TEXT")
+            conn.commit()
+            print('Added barcode column to product_sizes')
+        else:
+            print('barcode column already exists')
+
+if __name__ == '__main__':
+    migrate()

--- a/magazyn/templates/add_item.html
+++ b/magazyn/templates/add_item.html
@@ -20,6 +20,8 @@
         <button type="button" onclick="startBarcodeScan()">Skanuj kod kreskowy</button>
 
         {% for size in ['XS', 'S', 'M', 'L', 'XL', 'Uniwersalny'] %}
+            <label for="barcode_{{ size }}">Kod kreskowy ({{ size }}):</label>
+            <input type="text" id="barcode_{{ size }}" name="barcode_{{ size }}">
             <label for="quantity_{{ size }}">Ilość ({{ size }}):</label>
             <input type="number" id="quantity_{{ size }}" name="quantity_{{ size }}" min="0" value="0">
         {% endfor %}

--- a/magazyn/templates/edit_item.html
+++ b/magazyn/templates/edit_item.html
@@ -16,10 +16,11 @@
 
         <label for="sizes">Ilości dla rozmiarów:</label>
         <div style="display: flex; flex-wrap: wrap; gap: 10px;">
-            {% for size_info in product['sizes'] %}
-                <div style="display: flex; flex-direction: column; width: 80px;">
-                    <label>{{ size_info['size'] }}:</label>
-                    <input type="number" name="sizes[{{ size_info['size'] }}]" value="{{ size_info['quantity'] }}" min="0" class="form-control">
+            {% for size, info in product_sizes.items() %}
+                <div style="display: flex; flex-direction: column; width: 120px;">
+                    <label>{{ size }}:</label>
+                    <input type="text" name="barcode_{{ size }}" value="{{ info['barcode'] }}" class="form-control" placeholder="Kod kreskowy">
+                    <input type="number" name="quantity_{{ size }}" value="{{ info['quantity'] }}" min="0" class="form-control mt-1">
                 </div>
             {% endfor %}
         </div>


### PR DESCRIPTION
## Summary
- add `barcode` column to `product_sizes`
- allow barcode entry per size when creating or editing a product
- migrate existing databases to include new column
- store and update per-size barcodes on item creation/update
- export and import barcode values for each size
- adapt tests for new barcode location

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c1dbf651c832abb2deaa8d7142f03