### PR TITLE
Add Bootstrap navbar with sidebar

### DIFF
--- a/magazyn/static/styles.css
+++ b/magazyn/static/styles.css
@@ -189,4 +189,15 @@ th {
     }
 }
 
+/* Adjust layout for fixed navbar */
+body {
+    padding-top: 70px;
+}
+
+/* Offcanvas sidebar width */
+#sidebarMenu {
+    width: 250px;
+}
+
+
 

--- a/magazyn/templates/base.html
+++ b/magazyn/templates/base.html
@@ -5,27 +5,42 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Retriever Shop - Magazyn</title>
     <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
-	<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
 </head>
 <body>
-    <header class="bg-dark text-white text-center py-4">
-    <img src="https://retrievershop.pl/wp-content/uploads/2024/08/retriver-2.png" alt="Logo" style="height: 80px;">
-    <h2>Witaj w aplikacji magazynowej</h2>
-    <a href="{{ url_for('logout') }}" class="btn btn-danger mt-3">Wyloguj się</a>
-        <nav>
-            <ul>
-                <li><a href="{{ url_for('home') }}">Strona główna</a></li>
-                <li><a href="{{ url_for('products.add_item') }}">Dodaj przedmiot</a></li>
-                <li><a href="{{ url_for('products.items') }}">Przedmioty</a></li>
-                <li><a href="{{ url_for('products.add_delivery') }}">Dostawy</a></li>
-                <li><a href="{{ url_for('history.print_history') }}">Historia drukowania</a></li>
-                <li><a href="{{ url_for('agent_logs') }}">Logi</a></li>
-                <li><a href="{{ url_for('settings') }}">Ustawienia</a></li>
-                <li><a href="{{ url_for('test_print') }}">Testuj drukarkę</a></li>
+    <nav class="navbar navbar-dark bg-dark fixed-top">
+        <div class="container-fluid">
+            <button class="navbar-toggler" type="button" data-bs-toggle="offcanvas" data-bs-target="#sidebarMenu" aria-controls="sidebarMenu">
+                <span class="navbar-toggler-icon"></span>
+            </button>
+            <span class="navbar-brand mx-auto d-flex align-items-center">
+                <img src="https://retrievershop.pl/wp-content/uploads/2024/08/retriver-2.png" alt="Logo" style="height: 40px;">
+                <span class="ms-2">Witaj w aplikacji magazynowej</span>
+            </span>
+            <a href="{{ url_for('logout') }}" class="btn btn-danger">Wyloguj się</a>
+        </div>
+    </nav>
+
+    <div class="offcanvas offcanvas-start text-bg-dark" tabindex="-1" id="sidebarMenu" aria-labelledby="sidebarLabel">
+        <div class="offcanvas-header">
+            <h5 class="offcanvas-title" id="sidebarLabel">Menu</h5>
+            <button type="button" class="btn-close btn-close-white" data-bs-dismiss="offcanvas" aria-label="Close"></button>
+        </div>
+        <div class="offcanvas-body">
+            <ul class="nav flex-column">
+                <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('home') }}">Strona główna</a></li>
+                <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('products.add_item') }}">Dodaj przedmiot</a></li>
+                <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('products.items') }}">Przedmioty</a></li>
+                <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('products.add_delivery') }}">Dostawy</a></li>
+                <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('history.print_history') }}">Historia drukowania</a></li>
+                <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('agent_logs') }}">Logi</a></li>
+                <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('settings') }}">Ustawienia</a></li>
+                <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('test_print') }}">Testuj drukarkę</a></li>
             </ul>
-        </nav>
-    </header>
-    <main>
+        </div>
+    </div>
+
+    <main class="container mt-5 pt-4">
 	{% with messages = get_flashed_messages() %}
   {% if messages %}
     <div class="alert alert-info" role="alert">
@@ -41,5 +56,6 @@
     <footer>
         <p>&copy; 2024 <a href="https://retrievershop.pl/">Retriever Shop</a> - Magazyn</p>
     </footer>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- integrate Bootstrap 5
- add a fixed navbar and offcanvas sidebar
- load Bootstrap JS for the navbar toggle
- adjust layout in custom CSS

## Testing
- `pip install -r magazyn/requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c2491ae80832a852ea7aeea83fbf1