### PR TITLE
Improve templates and layout

### DIFF
--- a/magazyn/templates/add_delivery.html
+++ b/magazyn/templates/add_delivery.html
@@ -1,28 +1,38 @@
 {% extends "base.html" %}
 
 {% block content %}
-<h2>Dodaj dostawę</h2>
-<form action="{{ url_for('products.add_delivery') }}" method="post">
-    <label for="product_id">Produkt:</label>
-    <select name="product_id" id="product_id">
-        {% for p in products %}
-        <option value="{{ p['id'] }}">{{ p['name'] }}</option>
-        {% endfor %}
-    </select>
+<h2 class="mb-3">Dodaj dostawę</h2>
+<form action="{{ url_for('products.add_delivery') }}" method="post" class="row g-3">
+    <div class="col-md-6">
+        <label for="product_id" class="form-label">Produkt:</label>
+        <select name="product_id" id="product_id" class="form-select">
+            {% for p in products %}
+            <option value="{{ p['id'] }}">{{ p['name'] }}</option>
+            {% endfor %}
+        </select>
+    </div>
 
-    <label for="size">Rozmiar:</label>
-    <select name="size" id="size">
-        {% for s in ['XS','S','M','L','XL','Uniwersalny'] %}
-        <option value="{{ s }}">{{ s }}</option>
-        {% endfor %}
-    </select>
+    <div class="col-md-6">
+        <label for="size" class="form-label">Rozmiar:</label>
+        <select name="size" id="size" class="form-select">
+            {% for s in ['XS','S','M','L','XL','Uniwersalny'] %}
+            <option value="{{ s }}">{{ s }}</option>
+            {% endfor %}
+        </select>
+    </div>
 
-    <label for="quantity">Ilość:</label>
-    <input type="number" name="quantity" id="quantity" value="1" min="1">
+    <div class="col-md-6">
+        <label for="quantity" class="form-label">Ilość:</label>
+        <input type="number" name="quantity" id="quantity" value="1" min="1" class="form-control">
+    </div>
 
-    <label for="price">Cena:</label>
-    <input type="number" step="0.01" name="price" id="price" value="0">
+    <div class="col-md-6">
+        <label for="price" class="form-label">Cena:</label>
+        <input type="number" step="0.01" name="price" id="price" value="0" class="form-control">
+    </div>
 
-    <button type="submit">Dodaj</button>
+    <div class="col-12">
+        <button type="submit" class="btn btn-primary">Dodaj</button>
+    </div>
 </form>
 {% endblock %}

--- a/magazyn/templates/add_item.html
+++ b/magazyn/templates/add_item.html
@@ -1,32 +1,42 @@
 {% extends "base.html" %}
 
 {% block content %}
-<h2>Dodaj nowy przedmiot</h2>
-    <form action="{{ url_for('products.add_item') }}" method="post">
-        <label for="name">Nazwa produktu:</label>
-        <input type="text" id="name" name="name" required>
+<h2 class="mb-3">Dodaj nowy przedmiot</h2>
+    <form action="{{ url_for('products.add_item') }}" method="post" class="row g-3">
+        <div class="col-md-6">
+            <label for="name" class="form-label">Nazwa produktu:</label>
+            <input type="text" id="name" name="name" required class="form-control">
+        </div>
 
-        <label for="color">Kolor:</label>
-        <select id="color" name="color" required>
-            <option value="Czerwony">Czerwony</option>
-            <option value="Niebieski">Niebieski</option>
-            <option value="Zielony">Zielony</option>
-            <option value="Czarny">Czarny</option>
-            <option value="Biały">Biały</option>
-        </select>
+        <div class="col-md-6">
+            <label for="color" class="form-label">Kolor:</label>
+            <select id="color" name="color" required class="form-select">
+                <option value="Czerwony">Czerwony</option>
+                <option value="Niebieski">Niebieski</option>
+                <option value="Zielony">Zielony</option>
+                <option value="Czarny">Czarny</option>
+                <option value="Biały">Biały</option>
+            </select>
+        </div>
 
-        <label for="barcode">Kod kreskowy:</label>
-        <input type="text" id="barcode" name="barcode">
-        <button type="button" onclick="startBarcodeScan()">Skanuj kod kreskowy</button>
+        <div class="col-md-6">
+            <label for="barcode" class="form-label">Kod kreskowy:</label>
+            <input type="text" id="barcode" name="barcode" class="form-control">
+            <button type="button" class="btn btn-secondary mt-2" onclick="startBarcodeScan()">Skanuj kod kreskowy</button>
+        </div>
 
         {% for size in ['XS', 'S', 'M', 'L', 'XL', 'Uniwersalny'] %}
-            <label for="barcode_{{ size }}">Kod kreskowy ({{ size }}):</label>
-            <input type="text" id="barcode_{{ size }}" name="barcode_{{ size }}">
-            <label for="quantity_{{ size }}">Ilość ({{ size }}):</label>
-            <input type="number" id="quantity_{{ size }}" name="quantity_{{ size }}" min="0" value="0">
+            <div class="col-md-6">
+                <label for="barcode_{{ size }}" class="form-label">Kod kreskowy ({{ size }}):</label>
+                <input type="text" id="barcode_{{ size }}" name="barcode_{{ size }}" class="form-control">
+                <label for="quantity_{{ size }}" class="form-label mt-1">Ilość ({{ size }}):</label>
+                <input type="number" id="quantity_{{ size }}" name="quantity_{{ size }}" min="0" value="0" class="form-control">
+            </div>
         {% endfor %}
 
-        <button type="submit">Dodaj produkt</button>
+        <div class="col-12">
+            <button type="submit" class="btn btn-primary">Dodaj produkt</button>
+        </div>
     </form>
 
     <!-- Kontener skanera kodów kreskowych -->

--- a/magazyn/templates/edit_item.html
+++ b/magazyn/templates/edit_item.html
@@ -3,29 +3,39 @@
 {% block content %}
 <div class="container mt-4">
     <h3 class="text-center">Edytuj przedmiot</h3>
-    <form method="POST" action="{{ url_for('products.edit_item', product_id=product['id']) }}">
-        <label for="name">Nazwa:</label>
-        <input type="text" id="name" name="name" value="{{ product['name'] }}" class="form-control" required>
-
-        <label for="color">Kolor:</label>
-        <input type="text" id="color" name="color" value="{{ product['color'] }}" class="form-control" required>
-
-        <label for="barcode">Kod kreskowy:</label>
-        <input type="text" id="barcode" name="barcode" value="{{ product['barcode'] }}" class="form-control">
-        <button type="button" class="btn btn-secondary mt-2" onclick="startBarcodeScan()">Skanuj kod kreskowy</button>
-
-        <label for="sizes">Ilości dla rozmiarów:</label>
-        <div style="display: flex; flex-wrap: wrap; gap: 10px;">
-            {% for size, info in product_sizes.items() %}
-                <div style="display: flex; flex-direction: column; width: 120px;">
-                    <label>{{ size }}:</label>
-                    <input type="text" name="barcode_{{ size }}" value="{{ info['barcode'] }}" class="form-control" placeholder="Kod kreskowy">
-                    <input type="number" name="quantity_{{ size }}" value="{{ info['quantity'] }}" min="0" class="form-control mt-1">
-                </div>
-            {% endfor %}
+    <form method="POST" action="{{ url_for('products.edit_item', product_id=product['id']) }}" class="row g-3">
+        <div class="col-md-6">
+            <label for="name" class="form-label">Nazwa:</label>
+            <input type="text" id="name" name="name" value="{{ product['name'] }}" class="form-control" required>
         </div>
 
-        <button type="submit" class="btn btn-primary mt-3">Zapisz zmiany</button>
+        <div class="col-md-6">
+            <label for="color" class="form-label">Kolor:</label>
+            <input type="text" id="color" name="color" value="{{ product['color'] }}" class="form-control" required>
+        </div>
+
+        <div class="col-md-6">
+            <label for="barcode" class="form-label">Kod kreskowy:</label>
+            <input type="text" id="barcode" name="barcode" value="{{ product['barcode'] }}" class="form-control">
+            <button type="button" class="btn btn-secondary mt-2" onclick="startBarcodeScan()">Skanuj kod kreskowy</button>
+        </div>
+
+        <div class="col-12">
+            <label for="sizes" class="form-label">Ilości dla rozmiarów:</label>
+            <div class="row g-2">
+                {% for size, info in product_sizes.items() %}
+                    <div class="col-sm-6 col-md-4 col-lg-3">
+                        <label class="form-label">{{ size }}:</label>
+                        <input type="text" name="barcode_{{ size }}" value="{{ info['barcode'] }}" class="form-control" placeholder="Kod kreskowy">
+                        <input type="number" name="quantity_{{ size }}" value="{{ info['quantity'] }}" min="0" class="form-control mt-1">
+                    </div>
+                {% endfor %}
+            </div>
+        </div>
+
+        <div class="col-12">
+            <button type="submit" class="btn btn-primary mt-3">Zapisz zmiany</button>
+        </div>
     </form>
 </div>
 

--- a/magazyn/templates/history.html
+++ b/magazyn/templates/history.html
@@ -1,7 +1,8 @@
 {% extends "base.html" %}
 {% block content %}
 <h2>Historia drukowania</h2>
-<table class="table">
+<div class="table-responsive">
+<table class="table table-striped">
     <thead><tr><th>ID zamówienia</th><th>Czas</th></tr></thead>
     <tbody>
     {% for oid, ts in printed.items() %}
@@ -12,4 +13,5 @@
     {% endfor %}
     </tbody>
 </table>
+</div>
 {% endblock %}

--- a/magazyn/templates/home.html
+++ b/magazyn/templates/home.html
@@ -3,10 +3,12 @@
 {% block content %}
 <div class="container text-center mt-5">
     <h3>Zalogowany jako {{ username }}</h3>
-    <a href="{{ url_for('products.add_item') }}" class="btn btn-primary mt-3">Dodaj nowy przedmiot</a>
-    <a href="{{ url_for('products.items') }}" class="btn btn-primary mt-3">Wyświetl przedmioty</a>
-    <a href="{{ url_for('products.barcode_scan_page') }}" class="btn btn-primary mt-3">Skanuj kod kreskowy</a>
-    <a href="{{ url_for('products.export_products') }}" class="btn btn-primary mt-3">Eksportuj produkty do Excel</a>
-    <a href="{{ url_for('products.import_products') }}" class="btn btn-primary mt-3">Importuj produkty z Excel</a>
+    <div class="d-grid gap-2 col-md-6 mx-auto mt-4">
+        <a href="{{ url_for('products.add_item') }}" class="btn btn-primary">Dodaj nowy przedmiot</a>
+        <a href="{{ url_for('products.items') }}" class="btn btn-primary">Wyświetl przedmioty</a>
+        <a href="{{ url_for('products.barcode_scan_page') }}" class="btn btn-primary">Skanuj kod kreskowy</a>
+        <a href="{{ url_for('products.export_products') }}" class="btn btn-primary">Eksportuj produkty do Excel</a>
+        <a href="{{ url_for('products.import_products') }}" class="btn btn-primary">Importuj produkty z Excel</a>
+    </div>
 </div>
 {% endblock %}

--- a/magazyn/templates/import_products.html
+++ b/magazyn/templates/import_products.html
@@ -1,19 +1,14 @@
 {% extends "base.html" %}
 
 {% block content %}
-<!DOCTYPE html>
-<html lang="pl">
-<head>
-    <meta charset="UTF-8">
-    <title>Import produktów</title>
-</head>
-<body>
-    <h2>Import produktów z pliku Excel</h2>
-    <form action="{{ url_for('products.import_products') }}" method="POST" enctype="multipart/form-data">
-        <input type="file" name="file" required>
-        <button type="submit">Zaimportuj</button>
+    <h2 class="mb-3">Import produktów z pliku Excel</h2>
+    <form action="{{ url_for('products.import_products') }}" method="POST" enctype="multipart/form-data" class="row g-3">
+        <div class="col-auto">
+            <input type="file" name="file" required class="form-control">
+        </div>
+        <div class="col-auto">
+            <button type="submit" class="btn btn-primary">Zaimportuj</button>
+        </div>
     </form>
-    <a href="{{ url_for('home') }}">Powrót do strony głównej</a>
-</body>
-</html>
+    <a href="{{ url_for('home') }}" class="btn btn-link mt-3">Powrót do strony głównej</a>
 {% endblock %}

--- a/magazyn/templates/items.html
+++ b/magazyn/templates/items.html
@@ -3,9 +3,9 @@
 {% block content %}
 
 <div class="container text-center mt-5">
-<div class="table-container">
-    
- <table>
+<div class="table-responsive">
+
+ <table class="table table-striped align-middle">
     <thead>
         <tr>
             <th>Nazwa produktu</th>
@@ -46,7 +46,7 @@
 
 </div>
 </div>
-<a href="{{ url_for('products.barcode_scan_page') }}" class="btn btn-primary">Skanuj kod kreskowy</a>
+<a href="{{ url_for('products.barcode_scan_page') }}" class="btn btn-primary mt-3">Skanuj kod kreskowy</a>
 
 <footer>
     <a href="{{ url_for('home') }}">Powrót do strony głównej</a>

--- a/magazyn/templates/login.html
+++ b/magazyn/templates/login.html
@@ -1,14 +1,20 @@
 {% extends "base.html" %}
 
 {% block content %}
-<h2>Logowanie</h2>
-<form action="{{ url_for('login') }}" method="POST">
-    <label for="username">Nazwa użytkownika:</label>
-    <input type="text" name="username" required>
-    
-    <label for="password">Hasło:</label>
-    <input type="password" name="password" required>
-    
-    <input type="submit" value="Zaloguj się">
+<h2 class="mb-3">Logowanie</h2>
+<form action="{{ url_for('login') }}" method="POST" class="row g-3">
+    <div class="col-12">
+        <label for="username" class="form-label">Nazwa użytkownika:</label>
+        <input type="text" name="username" required class="form-control">
+    </div>
+
+    <div class="col-12">
+        <label for="password" class="form-label">Hasło:</label>
+        <input type="password" name="password" required class="form-control">
+    </div>
+
+    <div class="col-12">
+        <button type="submit" class="btn btn-primary">Zaloguj się</button>
+    </div>
 </form>
 {% endblock %}

--- a/magazyn/templates/scan_barcode.html
+++ b/magazyn/templates/scan_barcode.html
@@ -1,9 +1,11 @@
 {% extends "base.html" %}
 {% block content %}
     <script src="https://cdnjs.cloudflare.com/ajax/libs/quagga/0.12.1/quagga.min.js"></script>
-    <h2>Skanuj kod kreskowy</h2>
-    <div id="scanner-container"></div>
-    <p id="barcode-result">Kod kreskowy: </p>
+    <div class="container text-center">
+        <h2 class="mb-3">Skanuj kod kreskowy</h2>
+        <div id="scanner-container"></div>
+        <p id="barcode-result" class="mt-2">Kod kreskowy: </p>
+    </div>
 
     <!-- Element audio do odtworzenia dźwięku -->
     <audio id="beep-sound" src="{{ url_for('static', filename='beep.mp3') }}" preload="auto"></audio>

--- a/magazyn/templates/settings.html
+++ b/magazyn/templates/settings.html
@@ -1,20 +1,22 @@
 {% extends "base.html" %}
 
 {% block content %}
-<h2>Ustawienia drukarki</h2>
-<form method="post">
-    <div class="form-group">
+<h2 class="mb-3">Ustawienia drukarki</h2>
+<form method="post" class="row g-3">
+    <div class="col-md-6">
         <label for="PRINTER_NAME">PRINTER_NAME</label>
         <input type="text" class="form-control" id="PRINTER_NAME" name="PRINTER_NAME" value="{{ settings.PRINTER_NAME }}">
     </div>
-    <div class="form-group">
+    <div class="col-md-6">
         <label for="CUPS_SERVER">CUPS_SERVER</label>
         <input type="text" class="form-control" id="CUPS_SERVER" name="CUPS_SERVER" value="{{ settings.CUPS_SERVER }}">
     </div>
-    <div class="form-group">
+    <div class="col-md-6">
         <label for="CUPS_PORT">CUPS_PORT</label>
         <input type="text" class="form-control" id="CUPS_PORT" name="CUPS_PORT" value="{{ settings.CUPS_PORT }}">
     </div>
-    <button type="submit" class="btn btn-primary">Zapisz</button>
+    <div class="col-12">
+        <button type="submit" class="btn btn-primary">Zapisz</button>
+    </div>
 </form>
 {% endblock %}

--- a/magazyn/templates/test.html
+++ b/magazyn/templates/test.html
@@ -1,8 +1,8 @@
 {% extends "base.html" %}
 {% block content %}
-<h2>Test wiadomości</h2>
+<h2 class="mb-3">Test wiadomości</h2>
 <form method="post" class="mb-3">
-    <button type="submit" class="btn btn-primary">Wy\u015blij testow\u0105 wiadom\u201a\u0107</button>
+    <button type="submit" class="btn btn-primary">Wyślij testową wiadomość</button>
 </form>
 {% if message %}
 <p>{{ message }}</p>

--- a/magazyn/templates/testprint.html
+++ b/magazyn/templates/testprint.html
@@ -1,8 +1,8 @@
 {% extends "base.html" %}
 {% block content %}
-<h2>Test wydruku</h2>
+<h2 class="mb-3">Test wydruku</h2>
 <form method="post" class="mb-3">
-    <button type="submit" class="btn btn-primary">Wydrukuj stron\u0119 testow\u0105</button>
+    <button type="submit" class="btn btn-primary">Wydrukuj stronę testową</button>
 </form>
 {% if message %}
 <p>{{ message }}</p>


### PR DESCRIPTION
## Summary
- refactor templates for responsive Bootstrap layout
- remove stray HTML tags from `import_products.html`
- keep beep.mp3 in static and load via `url_for()`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_685c25b7e3f0832aa3b9b764eb92640a