### PR TITLE
Update footer year and layout

### DIFF
--- a/magazyn/app.py
+++ b/magazyn/app.py
@@ -1,5 +1,6 @@
 from flask import Flask, render_template, request, redirect, url_for, session, flash
 import os
+from datetime import datetime
 from werkzeug.security import check_password_hash
 from dotenv import load_dotenv, dotenv_values
 from collections import OrderedDict
@@ -42,6 +43,11 @@ app.secret_key = os.environ.get("SECRET_KEY", "default_secret_key")
 
 app.register_blueprint(products_bp)
 app.register_blueprint(history_bp)
+
+
+@app.context_processor
+def inject_current_year():
+    return {"current_year": datetime.now().year}
 
 
 def start_print_agent():

--- a/magazyn/static/styles.css
+++ b/magazyn/static/styles.css
@@ -1,11 +1,13 @@
+html, body {
+    height: 100%;
+}
 body {
-    font-family: Arial, sans-serif;
+    display: flex;
+    flex-direction: column;
     margin: 0;
-    padding: 0;
-    justify-content: center;
-    align-items: center;
-    height: 100vh;
-    background-color: #f9f9f9;
+}
+main {
+    flex: 1;
 }
 
 h2, h3 {

--- a/magazyn/templates/base.html
+++ b/magazyn/templates/base.html
@@ -54,7 +54,7 @@
         {% block content %}{% endblock %}
     </main>
     <footer>
-        <p>&copy; 2024 <a href="https://retrievershop.pl/">Retriever Shop</a> - Magazyn</p>
+        <p>&copy; 2024-{{ current_year }} <a href="https://retrievershop.pl/">Retriever Shop</a> - Magazyn</p>
     </footer>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- inject current year into templates
- show dynamic year in footer
- convert base body CSS to flexbox so footer sticks to bottom

## Testing
- `pip install -q -r magazyn/requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c2ad477a4832ab2a69da395c29194