### PR TITLE
Add responsive mobile menu

### DIFF
--- a/magazyn/static/styles.css
+++ b/magazyn/static/styles.css
@@ -201,5 +201,36 @@ body {
     width: 250px;
 }
 
+/* Mobile slide-in menu */
+@media (max-width: 768px) {
+    #sidebarMenu {
+        display: none;
+    }
+    #mobileMenuBtn {
+        margin-right: 1rem;
+    }
+    .mobile-menu {
+        position: fixed;
+        top: 0;
+        right: 0;
+        width: 250px;
+        height: 100%;
+        background-color: #17383E;
+        padding: 1rem;
+        transform: translateX(100%);
+        transition: transform 0.3s ease;
+        z-index: 1050;
+    }
+    .mobile-menu.open {
+        transform: translateX(0);
+    }
+    .mobile-menu a {
+        color: #fff;
+        text-decoration: none;
+        display: block;
+        padding: 8px 0;
+    }
+}
+
 
 

--- a/magazyn/templates/base.html
+++ b/magazyn/templates/base.html
@@ -10,7 +10,10 @@
 <body>
     <nav class="navbar navbar-dark bg-dark fixed-top">
         <div class="container-fluid">
-            <button class="navbar-toggler" type="button" data-bs-toggle="offcanvas" data-bs-target="#sidebarMenu" aria-controls="sidebarMenu">
+            <button class="navbar-toggler d-none d-md-block" type="button" data-bs-toggle="offcanvas" data-bs-target="#sidebarMenu" aria-controls="sidebarMenu">
+                <span class="navbar-toggler-icon"></span>
+            </button>
+            <button id="mobileMenuBtn" class="navbar-toggler d-md-none" type="button">
                 <span class="navbar-toggler-icon"></span>
             </button>
             <span class="navbar-brand mx-auto d-flex align-items-center">
@@ -40,6 +43,19 @@
         </div>
     </div>
 
+    <div id="mobileMenu" class="mobile-menu d-md-none">
+        <ul class="nav flex-column">
+            <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('home') }}">Strona główna</a></li>
+            <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('products.add_item') }}">Dodaj przedmiot</a></li>
+            <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('products.items') }}">Przedmioty</a></li>
+            <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('products.add_delivery') }}">Dostawy</a></li>
+            <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('history.print_history') }}">Historia drukowania</a></li>
+            <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('agent_logs') }}">Logi</a></li>
+            <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('settings') }}">Ustawienia</a></li>
+            <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('test_print') }}">Testuj drukarkę</a></li>
+        </ul>
+    </div>
+
     <main class="container mt-5 pt-4">
 	{% with messages = get_flashed_messages() %}
   {% if messages %}
@@ -57,5 +73,12 @@
         <p>&copy; 2024-{{ current_year }} <a href="https://retrievershop.pl/">Retriever Shop</a> - Magazyn</p>
     </footer>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+    <script>
+        const btn = document.getElementById('mobileMenuBtn');
+        const menu = document.getElementById('mobileMenu');
+        if (btn && menu) {
+            btn.addEventListener('click', () => menu.classList.toggle('open'));
+        }
+    </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add hamburger menu button with custom JS handler
- create hidden mobile menu container
- style menu to slide in from the right

## Testing
- `python -m pip install -r magazyn/requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c4241d45c832a897d8e06f79192fd