### PR TITLE
Add Flask client tests for product CRUD and barcode scanning

### DIFF
--- a/magazyn/tests/test_products.py
+++ b/magazyn/tests/test_products.py
@@ -1,0 +1,87 @@
+import importlib
+import sys
+from magazyn.models import Product, ProductSize
+
+
+def setup_app(tmp_path, monkeypatch):
+    monkeypatch.setenv("DB_PATH", ":memory:")
+    import werkzeug
+    monkeypatch.setattr(werkzeug, "__version__", "0", raising=False)
+    init = importlib.import_module("magazyn.__init__")
+    importlib.reload(init)
+    monkeypatch.setitem(sys.modules, "__init__", init)
+    pa = importlib.import_module("magazyn.print_agent")
+    monkeypatch.setitem(sys.modules, "print_agent", pa)
+    monkeypatch.setattr(pa, "start_agent_thread", lambda: None)
+    monkeypatch.setattr(pa, "ensure_db_init", lambda: None)
+    monkeypatch.setattr(pa, "validate_env", lambda: None)
+    import magazyn.app as app_mod
+    importlib.reload(app_mod)
+    import magazyn.db as db_mod
+    from sqlalchemy.orm import sessionmaker
+    db_mod.SessionLocal = sessionmaker(
+        bind=db_mod.engine, autoflush=False, expire_on_commit=False
+    )
+    app_mod.app.config["WTF_CSRF_ENABLED"] = False
+    app_mod.init_db()
+    return app_mod
+
+
+def login(client):
+    with client.session_transaction() as sess:
+        sess["username"] = "tester"
+
+
+def test_product_crud_and_barcode_scan(tmp_path, monkeypatch):
+    app_mod = setup_app(tmp_path, monkeypatch)
+    client = app_mod.app.test_client()
+    login(client)
+
+    # add product
+    data_add = {
+        "name": "Prod",
+        "color": "Czerwony",
+        "barcode": "",
+        "quantity_M": "2",
+        "barcode_M": "111",
+    }
+    resp = client.post("/add_item", data=data_add)
+    assert resp.status_code == 302
+
+    with app_mod.get_session() as db:
+        prod = db.query(Product).filter_by(name="Prod").first()
+        assert prod is not None
+        prod_id = prod.id
+        ps = db.query(ProductSize).filter_by(product_id=prod_id, size="M").first()
+        assert ps.quantity == 2
+        assert ps.barcode == "111"
+
+    # edit product
+    data_edit = {
+        "name": "Prod2",
+        "color": "Zielony",
+        "barcode": "",
+        "quantity_M": "5",
+        "barcode_M": "111",
+    }
+    resp = client.post(f"/edit_item/{prod_id}", data=data_edit)
+    assert resp.status_code == 302
+
+    with app_mod.get_session() as db:
+        prod = db.get(Product, prod_id)
+        assert prod.name == "Prod2"
+        assert prod.color == "Zielony"
+        ps = db.query(ProductSize).filter_by(product_id=prod_id, size="M").first()
+        assert ps.quantity == 5
+
+    # barcode scan
+    resp = client.post("/barcode_scan", json={"barcode": "111"})
+    assert resp.status_code == 200
+    assert resp.get_json() == {"name": "Prod2", "color": "Zielony", "size": "M"}
+
+    # delete product
+    resp = client.post(f"/delete_item/{prod_id}")
+    assert resp.status_code == 302
+    with app_mod.get_session() as db:
+        assert db.get(Product, prod_id) is None
+        assert not db.query(ProductSize).filter_by(product_id=prod_id).first()


### PR DESCRIPTION
## Summary
- add integration test using Flask's test client for product add/edit/delete
- verify barcode scanning returns JSON using existing product
- patch SQLAlchemy session to keep objects active

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c4b9bb6fc832ab59a3e50005de1ef