### PR TITLE
Add sticky footer wrapper

### DIFF
--- a/magazyn/static/styles.css
+++ b/magazyn/static/styles.css
@@ -2,9 +2,12 @@ html, body {
     height: 100%;
 }
 body {
+    margin: 0;
+}
+.page-wrapper {
+    min-height: 100vh;
     display: flex;
     flex-direction: column;
-    margin: 0;
 }
 main {
     flex: 1;
@@ -68,7 +71,7 @@ header .logo img {
 
 
 footer {
-    margin-top: 30px;
+    margin-top: auto;
     text-align: center;
 }
 

--- a/magazyn/templates/base.html
+++ b/magazyn/templates/base.html
@@ -8,6 +8,7 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
 </head>
 <body>
+    <div class="page-wrapper">
     <nav class="navbar navbar-dark bg-dark fixed-top">
         <div class="container-fluid">
             <button id="mobileMenuBtn" class="navbar-toggler d-md-none" type="button">
@@ -69,5 +70,6 @@
             btn.addEventListener('click', () => menu.classList.toggle('open'));
         }
     </script>
+    </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a `.page-wrapper` around all page contents
- style `.page-wrapper` and sticky `footer`

## Testing
- `pip install -q -r magazyn/requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c550a64d4832ab3e0c43050e38394