### PR TITLE
Fix log alignment

### DIFF
--- a/magazyn/static/styles.css
+++ b/magazyn/static/styles.css
@@ -160,6 +160,7 @@ th {
 
 .log-content {
     font-family: monospace;
+    text-align: left;
     white-space: pre-wrap;
 }
 


### PR DESCRIPTION
## Summary
- add `text-align:left` to log content

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c5a163f74832aaa884217d8ed5b28