### PR TITLE
Add automatic schema migration for product_sizes barcode column

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,10 @@ python -m magazyn.app init_db
 No data is removed during this step. The application can then be started as
 before using the same database file.
 
+Running a newer version of the application on an older database file will
+automatically add missing columns (for example the `barcode` column in the
+`product_sizes` table) during startup.
+
 ## License
 
 This project is licensed under the terms of the [MIT License](LICENSE).

--- a/magazyn/app.py
+++ b/magazyn/app.py
@@ -12,6 +12,7 @@ from .forms import LoginForm
 from .db import (
     get_session,
     init_db,
+    ensure_schema,
     register_default_user,
     record_purchase,
     consume_stock,
@@ -94,6 +95,7 @@ def _init_db_if_missing():
         raise SystemExit(1)
     if not os.path.isfile(DB_PATH):
         init_db()
+    ensure_schema()
     register_default_user()
 
 
@@ -197,6 +199,7 @@ if __name__ == "__main__":
         raise SystemExit(1)
     if not os.path.isfile(DB_PATH):
         init_db()
+    ensure_schema()
     register_default_user()
     debug = os.getenv("FLASK_DEBUG") == "1"
     app.run(host="0.0.0.0", port=80, debug=debug)

--- a/magazyn/db.py
+++ b/magazyn/db.py
@@ -1,7 +1,7 @@
 import datetime
 from contextlib import contextmanager
 
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, text
 from sqlalchemy.orm import sessionmaker
 from werkzeug.security import generate_password_hash
 
@@ -32,6 +32,17 @@ def init_db():
     """Initialize the SQLite database and create required tables."""
     Base.metadata.drop_all(engine)
     Base.metadata.create_all(engine)
+
+
+def ensure_schema():
+    """Add missing columns to existing tables if necessary."""
+    with engine.begin() as conn:
+        result = conn.execute(text("PRAGMA table_info('product_sizes')"))
+        cols = [row[1] for row in result.fetchall()]
+        if "barcode" not in cols:
+            conn.execute(
+                text("ALTER TABLE product_sizes ADD COLUMN barcode TEXT UNIQUE")
+            )
 
 
 def register_default_user():


### PR DESCRIPTION
## Summary
- update `db` module with `ensure_schema` helper
- call `ensure_schema` on startup in the Flask app
- document automatic schema updates in README

## Testing
- `pip install -r magazyn/requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c62412ba4832abf1ea6829e5a939b