### PR TITLE
Ensure settings table exists

### DIFF
--- a/magazyn/app.py
+++ b/magazyn/app.py
@@ -13,6 +13,7 @@ from .db import (
     get_session,
     init_db,
     ensure_schema,
+    ensure_settings_table,
     register_default_user,
     record_purchase,
     consume_stock,
@@ -40,7 +41,9 @@ ENV_PATH = ROOT_DIR / ".env"
 EXAMPLE_PATH = ROOT_DIR / ".env.example"
 
 
+
 load_dotenv()
+ensure_settings_table()
 
 app = Flask(__name__)
 app.secret_key = os.environ.get("SECRET_KEY", "default_secret_key")
@@ -199,6 +202,7 @@ if __name__ == "__main__":
         raise SystemExit(1)
     if not os.path.isfile(DB_PATH):
         init_db()
+    ensure_settings_table()
     ensure_schema()
     register_default_user()
     debug = os.getenv("FLASK_DEBUG") == "1"

--- a/magazyn/db.py
+++ b/magazyn/db.py
@@ -12,6 +12,18 @@ engine = create_engine(f"sqlite:///{DB_PATH}", future=True)
 SessionLocal = sessionmaker(bind=engine, autoflush=False)
 
 
+def ensure_settings_table():
+    """Create the settings table if it does not already exist."""
+    conn = engine.raw_connection()
+    try:
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS settings(key TEXT PRIMARY KEY, value TEXT)"
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
 @contextmanager
 def get_session():
     session = SessionLocal()


### PR DESCRIPTION
## Summary
- add `ensure_settings_table` helper for creating settings table
- call it during application startup

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c70d155dc832aa049258e84ef945f