### PR TITLE
Fix login authentication and add regression test

### DIFF
--- a/magazyn/app.py
+++ b/magazyn/app.py
@@ -119,7 +119,7 @@ def login():
         with get_session() as db:
             user = db.query(User).filter_by(username=username).first()
 
-        if user and check_password_hash(user["password"], password):
+        if user and check_password_hash(user.password, password):
             session["username"] = username
             return redirect(url_for("home"))
         else:

--- a/magazyn/tests/test_login.py
+++ b/magazyn/tests/test_login.py
@@ -1,0 +1,40 @@
+import importlib
+import sys
+
+from werkzeug.security import generate_password_hash
+from magazyn.models import User
+
+
+def setup_app(tmp_path, monkeypatch):
+    monkeypatch.setenv("DB_PATH", ":memory:")
+    import werkzeug
+    monkeypatch.setattr(werkzeug, "__version__", "0", raising=False)
+    init = importlib.import_module("magazyn.__init__")
+    importlib.reload(init)
+    monkeypatch.setitem(sys.modules, "__init__", init)
+    pa = importlib.import_module("magazyn.print_agent")
+    monkeypatch.setitem(sys.modules, "print_agent", pa)
+    monkeypatch.setattr(pa, "start_agent_thread", lambda: None)
+    monkeypatch.setattr(pa, "ensure_db_init", lambda: None)
+    monkeypatch.setattr(pa, "validate_env", lambda: None)
+    import magazyn.app as app_mod
+    importlib.reload(app_mod)
+    import magazyn.db as db_mod
+    from sqlalchemy.orm import sessionmaker
+    db_mod.SessionLocal = sessionmaker(bind=db_mod.engine, autoflush=False, expire_on_commit=False)
+    app_mod.app.config["WTF_CSRF_ENABLED"] = False
+    app_mod.init_db()
+    return app_mod
+
+
+def test_login_route_authenticates_user(tmp_path, monkeypatch):
+    app_mod = setup_app(tmp_path, monkeypatch)
+    client = app_mod.app.test_client()
+    hashed = generate_password_hash("secret")
+    with app_mod.get_session() as db:
+        db.add(User(username="tester", password=hashed))
+
+    resp = client.post("/login", data={"username": "tester", "password": "secret"})
+    assert resp.status_code == 302
+    with client.session_transaction() as sess:
+        assert sess["username"] == "tester"


### PR DESCRIPTION
## Summary
- correct login view to check `user.password`
- add regression test verifying login

## Testing
- `pip install -r magazyn/requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c7e1f8194832a924691fa5e174561