### PR TITLE
Update settings view to load variables from env

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,11 @@ This repository contains the code for the RetrieverShop warehouse application an
 
 After starting the application you can edit the values in your `.env` file
 without touching the filesystem. Log in to the web interface and open the
-**Ustawienia** tab from the navigation bar. The form lists all configurable
-variables. Update the desired entries and click **Zapisz**. The application
-writes the new values to `.env` and automatically reloads the configuration so
-changes take effect immediately.
+**Ustawienia** tab from the navigation bar. The form now lists all variables
+defined in `.env.example` so newly introduced options automatically appear on
+the page. Update the desired entries and click **Zapisz**. The application
+writes the new values to `.env`, reloads the configuration and the printing
+agent picks up the changes immediately.
 
 ## Running Tests
 

--- a/magazyn/db.py
+++ b/magazyn/db.py
@@ -12,17 +12,6 @@ engine = create_engine(f"sqlite:///{DB_PATH}", future=True)
 SessionLocal = sessionmaker(bind=engine, autoflush=False)
 
 
-def ensure_settings_table():
-    """Create the settings table if it does not already exist."""
-    conn = engine.raw_connection()
-    try:
-        conn.execute(
-            "CREATE TABLE IF NOT EXISTS settings(key TEXT PRIMARY KEY, value TEXT)"
-        )
-        conn.commit()
-    finally:
-        conn.close()
-
 
 @contextmanager
 def get_session():

--- a/magazyn/models.py
+++ b/magazyn/models.py
@@ -39,11 +39,6 @@ class LabelQueue(Base):
     ext = Column(String)
     last_order_data = Column(Text)
 
-class Settings(Base):
-    __tablename__ = 'settings'
-    key = Column(String, primary_key=True)
-    value = Column(String)
-
 class PurchaseBatch(Base):
     __tablename__ = 'purchase_batches'
     id = Column(Integer, primary_key=True)

--- a/magazyn/templates/settings.html
+++ b/magazyn/templates/settings.html
@@ -3,18 +3,12 @@
 {% block content %}
 <h2 class="mb-3">Ustawienia drukarki</h2>
 <form method="post" class="row g-3">
+    {% for key, value in settings.items() %}
     <div class="col-md-6">
-        <label for="PRINTER_NAME">PRINTER_NAME</label>
-        <input type="text" class="form-control" id="PRINTER_NAME" name="PRINTER_NAME" value="{{ settings.PRINTER_NAME }}">
+        <label for="{{ key }}">{{ key }}</label>
+        <input type="text" class="form-control" id="{{ key }}" name="{{ key }}" value="{{ value }}">
     </div>
-    <div class="col-md-6">
-        <label for="CUPS_SERVER">CUPS_SERVER</label>
-        <input type="text" class="form-control" id="CUPS_SERVER" name="CUPS_SERVER" value="{{ settings.CUPS_SERVER }}">
-    </div>
-    <div class="col-md-6">
-        <label for="CUPS_PORT">CUPS_PORT</label>
-        <input type="text" class="form-control" id="CUPS_PORT" name="CUPS_PORT" value="{{ settings.CUPS_PORT }}">
-    </div>
+    {% endfor %}
     <div class="col-12">
         <button type="submit" class="btn btn-primary">Zapisz</button>
     </div>


### PR DESCRIPTION
## Summary
- remove unused Settings table
- read values from `.env.example` using `load_settings`
- write updates to `.env` and reload print agent config
- render settings dynamically in template
- update regression tests
- refresh README docs

## Testing
- `pip install -r magazyn/requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c7f6d0360832aa805ea82b8572c50