### PR TITLE
Improve table responsiveness

### DIFF
--- a/magazyn/static/styles.css
+++ b/magazyn/static/styles.css
@@ -104,10 +104,15 @@ table {
 /* Ustawienie węższej szerokości dla kolumn rozmiarów */
 th:nth-child(n+3):nth-child(-n+8),
 td:nth-child(n+3):nth-child(-n+8) {
-    width: 300px; /* Dostosuj szerokość kolumn według potrzeb */
-    max-width: 300px;
+    width: 120px; /* Dostosuj szerokość kolumn według potrzeb */
+    max-width: 120px;
     text-align: center;
     padding: 0; /* Usuń nadmiarowe odstępy */
+}
+
+/* Ensure long tables remain usable on small screens */
+.table-responsive {
+    overflow-x: auto;
 }
 
 /* Nagłówki tabeli */


### PR DESCRIPTION
## Summary
- shrink product table columns to 120px
- allow `.table-responsive` containers to scroll horizontally

## Testing
- `pip install -r magazyn/requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c81546140832a8bf4e32e58647594