### PR TITLE
Use bootstrap container for navbar

### DIFF
--- a/magazyn/static/styles.css
+++ b/magazyn/static/styles.css
@@ -35,6 +35,10 @@ label, input, button {
     width: 100%;
 }
 
+.navbar .container {
+    margin: 0 auto;
+}
+
 .actions {
     margin-top: 20px;
 }

--- a/magazyn/templates/base.html
+++ b/magazyn/templates/base.html
@@ -10,7 +10,7 @@
 <body>
     <div class="page-wrapper">
     <nav class="navbar navbar-dark bg-dark fixed-top">
-        <div class="container-fluid">
+        <div class="container" style="max-width: 75%">
             <button id="mobileMenuBtn" class="navbar-toggler d-md-none" type="button">
                 <span class="navbar-toggler-icon"></span>
             </button>

--- a/magazyn/tests/test_base_template.py
+++ b/magazyn/tests/test_base_template.py
@@ -1,0 +1,48 @@
+import importlib
+import sys
+from magazyn.models import User
+from werkzeug.security import generate_password_hash
+
+
+def setup_app(tmp_path, monkeypatch):
+    monkeypatch.setenv("DB_PATH", ":memory:")
+    import werkzeug
+    monkeypatch.setattr(werkzeug, "__version__", "0", raising=False)
+    init = importlib.import_module("magazyn.__init__")
+    importlib.reload(init)
+    monkeypatch.setitem(sys.modules, "__init__", init)
+    pa = importlib.import_module("magazyn.print_agent")
+    monkeypatch.setitem(sys.modules, "print_agent", pa)
+    monkeypatch.setattr(pa, "start_agent_thread", lambda: None)
+    monkeypatch.setattr(pa, "ensure_db_init", lambda: None)
+    monkeypatch.setattr(pa, "validate_env", lambda: None)
+    import magazyn.app as app_mod
+    importlib.reload(app_mod)
+    import magazyn.db as db_mod
+    from sqlalchemy.orm import sessionmaker
+    db_mod.SessionLocal = sessionmaker(bind=db_mod.engine, autoflush=False, expire_on_commit=False)
+    app_mod.app.config["WTF_CSRF_ENABLED"] = False
+    app_mod.init_db()
+    return app_mod
+
+
+def login(client):
+    with client.session_transaction() as sess:
+        sess["username"] = "tester"
+
+
+def test_nav_container_class(tmp_path, monkeypatch):
+    app_mod = setup_app(tmp_path, monkeypatch)
+    client = app_mod.app.test_client()
+    hashed = generate_password_hash("secret")
+    with app_mod.get_session() as db:
+        db.add(User(username="tester", password=hashed))
+    login(client)
+    resp = client.get("/")
+    html = resp.get_data(as_text=True)
+    import re
+    nav_match = re.search(r"<nav[^>]*>(.*?)</nav>", html, re.S)
+    assert nav_match, "nav section missing"
+    nav_html = nav_match.group(1)
+    assert "container-fluid" not in nav_html
+    assert "class=\"container\"" in nav_html


### PR DESCRIPTION
## Summary
- switch navbar wrapper to a `.container`
- keep navbar centered via CSS
- verify new markup with a unit test

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c8b0be4fc832a82dba14b969ff4d2