### PR TITLE
Fix global form CSS

### DIFF
--- a/magazyn/static/styles.css
+++ b/magazyn/static/styles.css
@@ -17,12 +17,12 @@ h2, h3 {
     text-align: center;
 }
 
-form {
-    display: flex;
-    flex-direction: column;
-    width: 300px;
+/* Centered layout for the login page form */
+.login-form {
+    max-width: 300px;
     margin: auto;
 }
+
 
 label, input, button {
     margin: 5px 0;

--- a/magazyn/templates/login.html
+++ b/magazyn/templates/login.html
@@ -2,7 +2,7 @@
 
 {% block content %}
 <h2 class="mb-3">Logowanie</h2>
-<form action="{{ url_for('login') }}" method="POST" class="row g-3">
+<form action="{{ url_for('login') }}" method="POST" class="row g-3 login-form">
     {{ form.csrf_token }}
     <div class="col-12">
         <label for="username" class="form-label">Nazwa użytkownika:</label>


### PR DESCRIPTION
## Summary
- remove the global form width rule
- add a dedicated `.login-form` style
- update `login.html` to use the login form class

## Testing
- `pip install -r magazyn/requirements.txt`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685c8c7b9f90832aac5a178aa35291ce