### PR TITLE
Fix edit_item product detach issue

### DIFF
--- a/magazyn/products.py
+++ b/magazyn/products.py
@@ -105,9 +105,20 @@ def edit_item(product_id):
             except Exception as e:
                 flash(f'B\u0142\u0105d podczas aktualizacji przedmiotu: {e}')
             return redirect(url_for('products.items'))
-        product = db.query(Product).filter_by(id=product_id).first()
+        row = db.query(Product).filter_by(id=product_id).first()
+        product = None
+        if row:
+            product = {
+                'id': row.id,
+                'name': row.name,
+                'color': row.color,
+                'barcode': row.barcode,
+            }
         sizes = db.query(ProductSize).filter_by(product_id=product_id).all()
-        product_sizes = {s.size: {'quantity': s.quantity, 'barcode': s.barcode} for s in sizes}
+        product_sizes = {
+            s.size: {'quantity': s.quantity, 'barcode': s.barcode}
+            for s in sizes
+        }
     return render_template('edit_item.html', product=product, product_sizes=product_sizes)
 
 

--- a/magazyn/tests/test_products.py
+++ b/magazyn/tests/test_products.py
@@ -107,3 +107,22 @@ def test_items_forms_include_csrf_token(tmp_path, monkeypatch):
                 flask_session[k] = v
             token = app_mod.app.jinja_env.globals["csrf_token"]()
     assert html.count(token) >= 7
+
+
+def test_edit_item_get_shows_product_details(tmp_path, monkeypatch):
+    app_mod = setup_app(tmp_path, monkeypatch)
+    client = app_mod.app.test_client()
+    login(client)
+
+    with app_mod.get_session() as db:
+        prod = Product(name="Prod", color="Blue")
+        db.add(prod)
+        db.flush()
+        db.add(ProductSize(product_id=prod.id, size="M", quantity=4, barcode="123"))
+        pid = prod.id
+
+    resp = client.get(f"/edit_item/{pid}")
+    assert resp.status_code == 200
+    html = resp.get_data(as_text=True)
+    assert "Prod" in html
+    assert "Blue" in html


### PR DESCRIPTION
## Summary
- convert Product and ProductSize rows to plain data in `edit_item`
- test GET `/edit_item/<id>` rendering product details

## Testing
- `pip install -r magazyn/requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c9066efe0832a8624b93660e6a450