### PR TITLE
Remove table max-width

### DIFF
--- a/magazyn/static/styles.css
+++ b/magazyn/static/styles.css
@@ -88,17 +88,9 @@ footer a:hover {
     text-decoration: underline;
 }
 
-/* Wyśrodkowanie kontenera tabeli */
-.table-container {
-    display: flex;
-    justify-content: center;
-    width: 100%;
-}
-
 /* Ustawienie szerokości tabeli */
 table {
     width: 100%; /* Zmniejsz szerokość, aby tabela była bardziej kompaktowa */
-    max-width: 1200px;
     border-collapse: collapse;
     margin-top: 5px;
     background-color: #fff;

--- a/magazyn/tests/test_styles.py
+++ b/magazyn/tests/test_styles.py
@@ -1,0 +1,8 @@
+from pathlib import Path
+
+
+def test_table_style_has_no_max_width():
+    css_path = Path(__file__).resolve().parent.parent / "static" / "styles.css"
+    css = css_path.read_text()
+    assert "max-width: 1200px" not in css
+    assert "overflow-x: auto" in css


### PR DESCRIPTION
## Summary
- drop unused `.table-container` styles
- stop capping table width at 1200px
- add test to ensure style has no hardcoded table width

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d17a10504832ab0f3fdcc5051e9d4