### PR TITLE
Fix login session expiry issue

### DIFF
--- a/magazyn/app.py
+++ b/magazyn/app.py
@@ -116,10 +116,13 @@ def login():
         username = form.username.data
         password = form.password.data
 
+        valid = False
         with get_session() as db:
             user = db.query(User).filter_by(username=username).first()
+            if user and check_password_hash(user.password, password):
+                valid = True
 
-        if user and check_password_hash(user.password, password):
+        if valid:
             session["username"] = username
             return redirect(url_for("home"))
         else:

--- a/magazyn/tests/test_login.py
+++ b/magazyn/tests/test_login.py
@@ -27,8 +27,43 @@ def setup_app(tmp_path, monkeypatch):
     return app_mod
 
 
+def setup_app_default_session(tmp_path, monkeypatch):
+    monkeypatch.setenv("DB_PATH", ":memory:")
+    import werkzeug
+    monkeypatch.setattr(werkzeug, "__version__", "0", raising=False)
+    init = importlib.import_module("magazyn.__init__")
+    importlib.reload(init)
+    monkeypatch.setitem(sys.modules, "__init__", init)
+    pa = importlib.import_module("magazyn.print_agent")
+    monkeypatch.setitem(sys.modules, "print_agent", pa)
+    monkeypatch.setattr(pa, "start_agent_thread", lambda: None)
+    monkeypatch.setattr(pa, "ensure_db_init", lambda: None)
+    monkeypatch.setattr(pa, "validate_env", lambda: None)
+    import magazyn.app as app_mod
+    importlib.reload(app_mod)
+    import magazyn.db as db_mod
+    from sqlalchemy.orm import sessionmaker
+    db_mod.SessionLocal = sessionmaker(bind=db_mod.engine, autoflush=False)
+    app_mod.app.config["WTF_CSRF_ENABLED"] = False
+    app_mod.init_db()
+    return app_mod
+
+
 def test_login_route_authenticates_user(tmp_path, monkeypatch):
     app_mod = setup_app(tmp_path, monkeypatch)
+    client = app_mod.app.test_client()
+    hashed = generate_password_hash("secret")
+    with app_mod.get_session() as db:
+        db.add(User(username="tester", password=hashed))
+
+    resp = client.post("/login", data={"username": "tester", "password": "secret"})
+    assert resp.status_code == 302
+    with client.session_transaction() as sess:
+        assert sess["username"] == "tester"
+
+
+def test_login_default_session_expiry(tmp_path, monkeypatch):
+    app_mod = setup_app_default_session(tmp_path, monkeypatch)
     client = app_mod.app.test_client()
     hashed = generate_password_hash("secret")
     with app_mod.get_session() as db:


### PR DESCRIPTION
## Summary
- ensure password check happens before the session is committed
- add regression test for login with default session behaviour

## Testing
- `pip install -r magazyn/requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d2308bc40832a9a3846068d2ff6f5