### PR TITLE
Update layout to use container-fluid and adjust column width

### DIFF
--- a/magazyn/static/styles.css
+++ b/magazyn/static/styles.css
@@ -100,8 +100,8 @@ table {
 /* Ustawienie węższej szerokości dla kolumn rozmiarów */
 th:nth-child(n+3):nth-child(-n+8),
 td:nth-child(n+3):nth-child(-n+8) {
-    width: 100px; /* Stała szerokość umożliwia przewijanie na małych ekranach */
-    max-width: 100px;
+    width: 80px; /* Stała szerokość umożliwia przewijanie na małych ekranach */
+    max-width: 80px;
     text-align: center;
     padding: 0; /* Usuń nadmiarowe odstępy */
 }

--- a/magazyn/templates/base.html
+++ b/magazyn/templates/base.html
@@ -46,7 +46,7 @@
         </ul>
     </div>
 
-    <main class="container mt-5 pt-4">
+    <main class="container-fluid mt-5 pt-4">
 	{% with messages = get_flashed_messages() %}
   {% if messages %}
     <div class="alert alert-info" role="alert">

--- a/magazyn/tests/test_styles.py
+++ b/magazyn/tests/test_styles.py
@@ -5,4 +5,5 @@ def test_table_style_has_no_max_width():
     css_path = Path(__file__).resolve().parent.parent / "static" / "styles.css"
     css = css_path.read_text()
     assert "max-width: 1200px" not in css
+    assert "width: 80px" in css
     assert "overflow-x: auto" in css


### PR DESCRIPTION
## Summary
- shrink size column width to 80px
- use `container-fluid` in base template for wider layout
- check for updated width in tests

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d2b578fb4832ab4311341dea1cde8