### PR TITLE
Fix CSRF token markup in item forms

### DIFF
--- a/magazyn/templates/items.html
+++ b/magazyn/templates/items.html
@@ -28,7 +28,7 @@
             {% for size in ['XS', 'S', 'M', 'L', 'XL', 'Uniwersalny'] %}
             <td>
                 <form method="POST" action="{{ url_for('products.update_quantity', product_id=product['id'], size=size) }}" class="form-inline quantity-form">
-                    {{ csrf_token() }}
+                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                     <button type="submit" name="action" value="decrease" class="btn btn-danger btn-sm btn-quantity">-</button>
                     <span class="quantity-value">{{ product['sizes'][size] }}</span>
                     <button type="submit" name="action" value="increase" class="btn btn-success btn-sm btn-quantity">+</button>
@@ -38,7 +38,7 @@
             <td>
                 <a href="{{ url_for('products.edit_item', product_id=product['id']) }}" class="btn btn-warning btn-sm">Edytuj</a>
                 <form action="{{ url_for('products.delete_item', item_id=product['id']) }}" method="POST" style="display: inline;" onsubmit="return confirm('Czy na pewno chcesz usunąć ten przedmiot?');">
-                    {{ csrf_token() }}
+                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                     <button type="submit" class="btn btn-danger btn-sm">Usuń</button>
                 </form>
             </td>


### PR DESCRIPTION
## Summary
- sanitize the CSRF token markup in `items.html`

## Testing
- `pip install -r magazyn/requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d39a19414832ab6eae6bff1bef99b