### PR TITLE
Add center-form and responsive login form

### DIFF
--- a/magazyn/static/styles.css
+++ b/magazyn/static/styles.css
@@ -23,6 +23,12 @@ h2, h3 {
     margin: auto;
 }
 
+.center-form {
+    max-width: 600px;
+    margin-left: auto;
+    margin-right: auto;
+}
+
 
 label, input, button {
     margin: 5px 0;

--- a/magazyn/templates/login.html
+++ b/magazyn/templates/login.html
@@ -2,7 +2,7 @@
 
 {% block content %}
 <h2 class="mb-3">Logowanie</h2>
-<form action="{{ url_for('login') }}" method="POST" class="row g-3 login-form">
+<form action="{{ url_for('login') }}" method="POST" class="row row-cols-1 row-cols-md-2 g-3 login-form center-form">
     {{ form.csrf_token }}
     <div class="col-12">
         <label for="username" class="form-label">Nazwa użytkownika:</label>


### PR DESCRIPTION
## Summary
- add `.center-form` CSS rule for wider form styling
- implement responsive classes in `login.html`

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d3ac4cd64832a830031bdf63ebc45