### PR TITLE
Update forms to use center-form layout

### DIFF
--- a/magazyn/static/styles.css
+++ b/magazyn/static/styles.css
@@ -23,6 +23,12 @@ h2, h3 {
     margin: auto;
 }
 
+/* Centered layout shared by item forms */
+.center-form {
+    max-width: 600px;
+    margin: auto;
+}
+
 
 label, input, button {
     margin: 5px 0;

--- a/magazyn/templates/add_delivery.html
+++ b/magazyn/templates/add_delivery.html
@@ -2,7 +2,7 @@
 
 {% block content %}
 <h2 class="mb-3">Dodaj dostawę</h2>
-<form action="{{ url_for('products.add_delivery') }}" method="post" class="row g-3">
+<form action="{{ url_for('products.add_delivery') }}" method="post" class="row row-cols-1 row-cols-md-2 g-3 center-form">
     <div class="col-md-6">
         <label for="product_id" class="form-label">Produkt:</label>
         <select name="product_id" id="product_id" class="form-select">

--- a/magazyn/templates/add_item.html
+++ b/magazyn/templates/add_item.html
@@ -2,7 +2,7 @@
 
 {% block content %}
 <h2 class="mb-3">Dodaj nowy przedmiot</h2>
-    <form action="{{ url_for('products.add_item') }}" method="post" class="row g-3">
+    <form action="{{ url_for('products.add_item') }}" method="post" class="row row-cols-1 row-cols-md-2 g-3 center-form">
         {{ form.csrf_token }}
         <div class="col-md-6">
             <label for="name" class="form-label">Nazwa produktu:</label>

--- a/magazyn/templates/edit_item.html
+++ b/magazyn/templates/edit_item.html
@@ -3,7 +3,7 @@
 {% block content %}
 <div class="container mt-4">
     <h3 class="text-center">Edytuj przedmiot</h3>
-    <form method="POST" action="{{ url_for('products.edit_item', product_id=product['id']) }}" class="row g-3">
+    <form method="POST" action="{{ url_for('products.edit_item', product_id=product['id']) }}" class="row row-cols-1 row-cols-md-2 g-3 center-form">
         <div class="col-md-6">
             <label for="name" class="form-label">Nazwa:</label>
             <input type="text" id="name" name="name" value="{{ product['name'] }}" class="form-control" required>

--- a/magazyn/templates/import_products.html
+++ b/magazyn/templates/import_products.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 
 {% block content %}
-<form action="{{ url_for('products.import_products') }}" method="POST" enctype="multipart/form-data" class="row g-3">
+<form action="{{ url_for('products.import_products') }}" method="POST" enctype="multipart/form-data" class="row row-cols-1 row-cols-md-2 g-3 center-form">
     <div class="col-auto">
         <input type="file" name="file" required class="form-control">
     </div>

--- a/magazyn/templates/settings.html
+++ b/magazyn/templates/settings.html
@@ -2,7 +2,7 @@
 
 {% block content %}
 <h2 class="mb-3">Ustawienia drukarki</h2>
-<form method="post">
+<form method="post" class="center-form">
     <table class="table">
         <tbody>
         {% for key, value in settings.items() %}

--- a/magazyn/templates/test.html
+++ b/magazyn/templates/test.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% block content %}
 <h2 class="mb-3">Test wiadomości</h2>
-<form method="post" class="mb-3">
+<form method="post" class="mb-3 center-form">
     <button type="submit" class="btn btn-primary">Wyślij testową wiadomość</button>
 </form>
 {% if message %}

--- a/magazyn/templates/testprint.html
+++ b/magazyn/templates/testprint.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% block content %}
 <h2 class="mb-3">Test wydruku</h2>
-<form method="post" class="mb-3">
+<form method="post" class="mb-3 center-form">
     <button type="submit" class="btn btn-primary">Wydrukuj stronę testową</button>
 </form>
 {% if message %}


### PR DESCRIPTION
## Summary
- style item forms with new `.center-form` class
- apply responsive form grid using `row-cols-md-2` where applicable
- center test forms and settings form

## Testing
- `pip install -r magazyn/requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d3bb47e68832aa3ab7883fa0008df