### PR TITLE
Add CSRF tokens and dark theme

### DIFF
--- a/magazyn/static/styles.css
+++ b/magazyn/static/styles.css
@@ -3,6 +3,8 @@ html, body {
 }
 body {
     margin: 0;
+    background-color: #121212;
+    color: #f0f0f0;
 }
 .page-wrapper {
     min-height: 100vh;
@@ -86,7 +88,7 @@ footer {
 }
 
 footer a {
-    color: #17383E;
+    color: #9ecfff;
     text-decoration: none;
 }
 
@@ -99,7 +101,7 @@ table {
     width: 100%; /* Zmniejsz szerokość, aby tabela była bardziej kompaktowa */
     border-collapse: collapse;
     margin-top: 5px;
-    background-color: #fff;
+    background-color: #1e1e1e;
     box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
 }
 
@@ -121,7 +123,7 @@ td:nth-child(n+3):nth-child(-n+8) {
 /* Nagłówki tabeli */
 th {
     padding: 8px 12px; /* Zachowaj odstępy tylko w nagłówkach */
-    background-color: #17383E;
+    background-color: #333;
     color: #fff;
 }
 
@@ -160,8 +162,8 @@ th {
     max-height: 600px;
     overflow-y: auto;
     padding: 10px;
-    border: 1px solid #ccc;
-    background-color: #f8f8f8;
+    border: 1px solid #444;
+    background-color: #1e1e1e;
     margin: 20px auto;
     width: 90%;
 }
@@ -205,6 +207,8 @@ body {
         transform: translateX(100%);
         transition: transform 0.3s ease;
         z-index: 1050;
+        display: flex;
+        flex-direction: column;
     }
     .mobile-menu.open {
         transform: translateX(0);

--- a/magazyn/templates/add_delivery.html
+++ b/magazyn/templates/add_delivery.html
@@ -3,6 +3,7 @@
 {% block content %}
 <h2 class="mb-3">Dodaj dostawę</h2>
 <form action="{{ url_for('products.add_delivery') }}" method="post" class="row g-3">
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
     <div class="col-md-6">
         <label for="product_id" class="form-label">Produkt:</label>
         <select name="product_id" id="product_id" class="form-select">

--- a/magazyn/templates/base.html
+++ b/magazyn/templates/base.html
@@ -11,30 +11,32 @@
     <div class="page-wrapper">
     <nav class="navbar navbar-dark bg-dark fixed-top">
         <div class="container" style="max-width: 75%">
-            <button id="mobileMenuBtn" class="navbar-toggler d-md-none" type="button">
-                <span class="navbar-toggler-icon"></span>
-            </button>
-            <span class="navbar-brand d-flex align-items-center">
-                <img src="https://retrievershop.pl/wp-content/uploads/2024/08/retriver-2.png" alt="Logo" style="height: 40px;">
-                <span class="ms-2">Witaj w aplikacji magazynowej</span>
-            </span>
-            <ul class="navbar-nav flex-row ms-auto gap-3 d-none d-md-flex">
-                <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('home') }}">Strona główna</a></li>
-                <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('products.add_item') }}">Dodaj przedmiot</a></li>
-                <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('products.items') }}">Przedmioty</a></li>
-                <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('products.add_delivery') }}">Dostawy</a></li>
-                <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('history.print_history') }}">Historia drukowania</a></li>
-                <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('agent_logs') }}">Logi</a></li>
-                <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('settings') }}">Ustawienia</a></li>
-                <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('test_print') }}">Testuj drukarkę</a></li>
-            </ul>
-            <a href="{{ url_for('logout') }}" class="btn btn-danger ms-md-3">Wyloguj się</a>
+            <div class="d-flex align-items-center justify-content-between w-100">
+                <span class="d-flex align-items-center">
+                    <img src="https://retrievershop.pl/wp-content/uploads/2024/08/retriver-2.png" alt="Logo" style="height: 40px;">
+                </span>
+                <span class="navbar-brand flex-grow-1 text-center">Witaj w aplikacji magazynowej</span>
+                <button id="mobileMenuBtn" class="navbar-toggler d-md-none" type="button">
+                    <span class="navbar-toggler-icon"></span>
+                </button>
+                <ul class="navbar-nav flex-row ms-md-auto gap-3 d-none d-md-flex">
+                    <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('home') }}">Strona główna</a></li>
+                    <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('products.add_item') }}">Dodaj przedmiot</a></li>
+                    <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('products.items') }}">Przedmioty</a></li>
+                    <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('products.add_delivery') }}">Dostawy</a></li>
+                    <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('history.print_history') }}">Historia drukowania</a></li>
+                    <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('agent_logs') }}">Logi</a></li>
+                    <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('settings') }}">Ustawienia</a></li>
+                    <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('test_print') }}">Testuj drukarkę</a></li>
+                    <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('logout') }}">Wyloguj się</a></li>
+                </ul>
+            </div>
         </div>
     </nav>
 
 
-    <div id="mobileMenu" class="mobile-menu d-md-none">
-        <ul class="nav flex-column">
+    <div id="mobileMenu" class="mobile-menu d-md-none d-flex flex-column">
+        <ul class="nav flex-column flex-grow-1">
             <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('home') }}">Strona główna</a></li>
             <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('products.add_item') }}">Dodaj przedmiot</a></li>
             <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('products.items') }}">Przedmioty</a></li>
@@ -44,6 +46,7 @@
             <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('settings') }}">Ustawienia</a></li>
             <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('test_print') }}">Testuj drukarkę</a></li>
         </ul>
+        <a href="{{ url_for('logout') }}" class="btn btn-danger mt-auto">Wyloguj się</a>
     </div>
 
     <main class="container-fluid mt-5 pt-4">

--- a/magazyn/templates/edit_item.html
+++ b/magazyn/templates/edit_item.html
@@ -4,6 +4,7 @@
 <div class="container mt-4">
     <h3 class="text-center">Edytuj przedmiot</h3>
     <form method="POST" action="{{ url_for('products.edit_item', product_id=product['id']) }}" class="row g-3">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
         <div class="col-md-6">
             <label for="name" class="form-label">Nazwa:</label>
             <input type="text" id="name" name="name" value="{{ product['name'] }}" class="form-control" required>

--- a/magazyn/templates/import_products.html
+++ b/magazyn/templates/import_products.html
@@ -2,6 +2,7 @@
 
 {% block content %}
 <form action="{{ url_for('products.import_products') }}" method="POST" enctype="multipart/form-data" class="row g-3">
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
     <div class="col-auto">
         <input type="file" name="file" required class="form-control">
     </div>

--- a/magazyn/templates/settings.html
+++ b/magazyn/templates/settings.html
@@ -3,6 +3,7 @@
 {% block content %}
 <h2 class="mb-3">Ustawienia drukarki</h2>
 <form method="post">
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
     <table class="table">
         <tbody>
         {% for key, value in settings.items() %}

--- a/magazyn/templates/test.html
+++ b/magazyn/templates/test.html
@@ -2,6 +2,7 @@
 {% block content %}
 <h2 class="mb-3">Test wiadomości</h2>
 <form method="post" class="mb-3">
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
     <button type="submit" class="btn btn-primary">Wyślij testową wiadomość</button>
 </form>
 {% if message %}

--- a/magazyn/templates/testprint.html
+++ b/magazyn/templates/testprint.html
@@ -2,6 +2,7 @@
 {% block content %}
 <h2 class="mb-3">Test wydruku</h2>
 <form method="post" class="mb-3">
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
     <button type="submit" class="btn btn-primary">Wydrukuj stronę testową</button>
 </form>
 {% if message %}


### PR DESCRIPTION
## Summary
- add missing CSRF inputs to edit and admin forms
- redesign navbar for better mobile layout and move logout into menus
- enable dark theme styling across the UI

## Testing
- `pip install -r magazyn/requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d3839a49c832a85752c48d803ba32