### PR TITLE
Fix conflict markers in styles.css

### DIFF
--- a/magazyn/static/styles.css
+++ b/magazyn/static/styles.css
@@ -23,17 +23,10 @@ h2, h3 {
     margin: auto;
 }
 
-<<<<<<< codex/update-templates-with-new-styling-and-grid
 /* Centered layout shared by item forms */
 .center-form {
     max-width: 600px;
     margin: auto;
-=======
-.center-form {
-    max-width: 600px;
-    margin-left: auto;
-    margin-right: auto;
->>>>>>> main
 }
 
 


### PR DESCRIPTION
## Summary
- remove merge conflict markers from `styles.css`
- consolidate `.center-form` styling

## Testing
- `pip install -q -r magazyn/requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d46051788832a84250f93903cee96