### PR TITLE
Remove product barcode field

### DIFF
--- a/magazyn/forms.py
+++ b/magazyn/forms.py
@@ -15,7 +15,6 @@ class AddItemForm(FlaskForm):
         ('Czarny', 'Czarny'),
         ('Biały', 'Biały'),
     ], validators=[DataRequired()])
-    barcode = StringField('barcode')
     # Fields for each size
     quantity_XS = IntegerField('quantity_XS', default=0)
     barcode_XS = StringField('barcode_XS')

--- a/magazyn/migrations/remove_barcode_from_products.py
+++ b/magazyn/migrations/remove_barcode_from_products.py
@@ -1,0 +1,20 @@
+import sqlite3
+from __init__ import DB_PATH
+
+def migrate():
+    with sqlite3.connect(DB_PATH) as conn:
+        cur = conn.cursor()
+        cur.execute("PRAGMA table_info(products)")
+        cols = [row[1] for row in cur.fetchall()]
+        if 'barcode' in cols:
+            cur.execute("CREATE TABLE products_new (id INTEGER PRIMARY KEY, name TEXT NOT NULL, color TEXT)")
+            cur.execute("INSERT INTO products_new (id, name, color) SELECT id, name, color FROM products")
+            cur.execute("DROP TABLE products")
+            cur.execute("ALTER TABLE products_new RENAME TO products")
+            conn.commit()
+            print('Removed barcode column from products')
+        else:
+            print('barcode column already removed')
+
+if __name__ == '__main__':
+    migrate()

--- a/magazyn/models.py
+++ b/magazyn/models.py
@@ -14,7 +14,6 @@ class Product(Base):
     id = Column(Integer, primary_key=True)
     name = Column(String, nullable=False)
     color = Column(String)
-    barcode = Column(String, unique=True)
     sizes = relationship('ProductSize', back_populates='product', cascade='all, delete-orphan')
 
 class ProductSize(Base):

--- a/magazyn/templates/add_item.html
+++ b/magazyn/templates/add_item.html
@@ -20,11 +20,6 @@
             </select>
         </div>
 
-        <div class="col-md-6">
-            <label for="barcode" class="form-label">Kod kreskowy:</label>
-            <input type="text" id="barcode" name="barcode" class="form-control">
-            <button type="button" class="btn btn-secondary mt-2" onclick="startBarcodeScan()">Skanuj kod kreskowy</button>
-        </div>
 
         {% for size in ['XS', 'S', 'M', 'L', 'XL', 'Uniwersalny'] %}
             <div class="col-md-6">
@@ -40,38 +35,5 @@
         </div>
     </form>
 
-    <!-- Kontener skanera kodów kreskowych -->
-    <div id="scanner-container" style="display: none;"></div>
 
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/quagga/0.12.1/quagga.min.js"></script>
-    <script>
-        function startBarcodeScan() {
-            document.getElementById("scanner-container").style.display = "block"; // Pokazuje kontener skanera
-
-            Quagga.init({
-                inputStream: {
-                    type: "LiveStream",
-                    target: document.querySelector('#scanner-container'),
-                    constraints: {
-                        facingMode: "environment"
-                    }
-                },
-                decoder: {
-                    readers: ["code_128_reader", "ean_reader", "ean_8_reader", "upc_reader"]
-                }
-            }, function(err) {
-                if (err) {
-                    console.log(err);
-                    return;
-                }
-                Quagga.start();
-            });
-
-            Quagga.onDetected(function(data) {
-                document.getElementById("barcode").value = data.codeResult.code;
-                document.getElementById("scanner-container").style.display = "none"; // Ukrywa kontener po zeskanowaniu
-                Quagga.stop();
-            });
-        }
-    </script>
 {% endblock %}

--- a/magazyn/templates/edit_item.html
+++ b/magazyn/templates/edit_item.html
@@ -14,11 +14,6 @@
             <input type="text" id="color" name="color" value="{{ product['color'] }}" class="form-control" required>
         </div>
 
-        <div class="col-md-6">
-            <label for="barcode" class="form-label">Kod kreskowy:</label>
-            <input type="text" id="barcode" name="barcode" value="{{ product['barcode'] }}" class="form-control">
-            <button type="button" class="btn btn-secondary mt-2" onclick="startBarcodeScan()">Skanuj kod kreskowy</button>
-        </div>
 
         <div class="col-12">
             <label for="sizes" class="form-label">Ilości dla rozmiarów:</label>
@@ -39,38 +34,5 @@
     </form>
 </div>
 
-<!-- Kontener skanera kodów kreskowych -->
-<div id="scanner-container" style="display: none;"></div>
 
-<script src="https://cdnjs.cloudflare.com/ajax/libs/quagga/0.12.1/quagga.min.js"></script>
-<script>
-    function startBarcodeScan() {
-        document.getElementById("scanner-container").style.display = "block";
-
-        Quagga.init({
-            inputStream: {
-                type: "LiveStream",
-                target: document.querySelector('#scanner-container'),
-                constraints: {
-                    facingMode: "environment"
-                }
-            },
-            decoder: {
-                readers: ["code_128_reader", "ean_reader", "ean_8_reader", "upc_reader"]
-            }
-        }, function(err) {
-            if (err) {
-                console.log(err);
-                return;
-            }
-            Quagga.start();
-        });
-
-        Quagga.onDetected(function(data) {
-            document.getElementById("barcode").value = data.codeResult.code;
-            document.getElementById("scanner-container").style.display = "none";
-            Quagga.stop();
-        });
-    }
-</script>
 {% endblock %}

--- a/magazyn/tests/test_products.py
+++ b/magazyn/tests/test_products.py
@@ -41,7 +41,6 @@ def test_product_crud_and_barcode_scan(tmp_path, monkeypatch):
     data_add = {
         "name": "Prod",
         "color": "Czerwony",
-        "barcode": "",
         "quantity_M": "2",
         "barcode_M": "111",
     }
@@ -60,7 +59,6 @@ def test_product_crud_and_barcode_scan(tmp_path, monkeypatch):
     data_edit = {
         "name": "Prod2",
         "color": "Zielony",
-        "barcode": "",
         "quantity_M": "5",
         "barcode_M": "111",
     }


### PR DESCRIPTION
## Summary
- drop `Product.barcode` column
- remove product-level barcode from forms and templates
- adjust product views for barcode removal
- add migration to drop the column
- update tests

## Testing
- `pip install -r magazyn/requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d5e3a5fac832a93dca683d6cc20cf