### PR TITLE
Ensure CSRF tokens on settings and import forms

### DIFF
--- a/magazyn/templates/edit_item.html
+++ b/magazyn/templates/edit_item.html
@@ -4,6 +4,7 @@
 <div class="container mt-4">
     <h3 class="text-center">Edytuj przedmiot</h3>
     <form method="POST" action="{{ url_for('products.edit_item', product_id=product['id']) }}" class="row row-cols-1 row-cols-md-2 g-3 center-form">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
         <div class="col-md-6">
             <label for="name" class="form-label">Nazwa:</label>
             <input type="text" id="name" name="name" value="{{ product['name'] }}" class="form-control" required>

--- a/magazyn/templates/import_products.html
+++ b/magazyn/templates/import_products.html
@@ -2,6 +2,7 @@
 
 {% block content %}
 <form action="{{ url_for('products.import_products') }}" method="POST" enctype="multipart/form-data" class="row row-cols-1 row-cols-md-2 g-3 center-form">
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
     <div class="col-auto">
         <input type="file" name="file" required class="form-control">
     </div>

--- a/magazyn/templates/settings.html
+++ b/magazyn/templates/settings.html
@@ -3,6 +3,7 @@
 {% block content %}
 <h2 class="mb-3">Ustawienia drukarki</h2>
 <form method="post" class="center-form">
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
     <table class="table">
         <tbody>
         {% for key, value in settings.items() %}


### PR DESCRIPTION
## Summary
- include hidden CSRF token field in settings form
- include hidden CSRF token field in edit item form
- include hidden CSRF token field in import products form

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d635ef8d8832aa6744df93dae037f