### PR TITLE
Show size barcodes in items list

### DIFF
--- a/magazyn/products.py
+++ b/magazyn/products.py
@@ -125,8 +125,16 @@ def items():
         products = db.query(Product).all()
         result = []
         for p in products:
-            sizes = {s.size: s.quantity for s in p.sizes}
-            result.append({'id': p.id, 'name': p.name, 'color': p.color, 'sizes': sizes})
+            all_sizes = ['XS', 'S', 'M', 'L', 'XL', 'Uniwersalny']
+            sizes = {size: {'quantity': 0, 'barcode': ''} for size in all_sizes}
+            for s in p.sizes:
+                sizes[s.size] = {'quantity': s.quantity, 'barcode': s.barcode}
+            result.append({
+                'id': p.id,
+                'name': p.name,
+                'color': p.color,
+                'sizes': sizes,
+            })
     return render_template('items.html', products=result)
 
 

--- a/magazyn/templates/items.html
+++ b/magazyn/templates/items.html
@@ -30,8 +30,10 @@
                 <form method="POST" action="{{ url_for('products.update_quantity', product_id=product['id'], size=size) }}" class="form-inline quantity-form">
                     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                     <button type="submit" name="action" value="decrease" class="btn btn-danger btn-sm btn-quantity">-</button>
-                    <span class="quantity-value">{{ product['sizes'][size] }}</span>
+                    <span class="quantity-value">{{ product['sizes'][size]['quantity'] }}</span>
                     <button type="submit" name="action" value="increase" class="btn btn-success btn-sm btn-quantity">+</button>
+                    <br>
+                    <small>{{ product['sizes'][size]['barcode'] }}</small>
                 </form>
             </td>
             {% endfor %}

--- a/magazyn/tests/test_products.py
+++ b/magazyn/tests/test_products.py
@@ -124,3 +124,20 @@ def test_edit_item_get_shows_product_details(tmp_path, monkeypatch):
     html = resp.get_data(as_text=True)
     assert "Prod" in html
     assert "Blue" in html
+
+
+def test_items_page_displays_barcodes(tmp_path, monkeypatch):
+    app_mod = setup_app(tmp_path, monkeypatch)
+    client = app_mod.app.test_client()
+    login(client)
+
+    with app_mod.get_session() as db:
+        prod = Product(name="P", color="C")
+        db.add(prod)
+        db.flush()
+        db.add(ProductSize(product_id=prod.id, size="M", quantity=2, barcode="321"))
+
+    resp = client.get("/items")
+    assert resp.status_code == 200
+    html = resp.get_data(as_text=True)
+    assert "321" in html


### PR DESCRIPTION
## Summary
- expose barcode data in `items()` view
- render barcodes under quantity in the items table
- test that barcodes appear on the page

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d67db2410832abd2e878064005281