### PR TITLE
Fix barcode editing and widen forms

### DIFF
--- a/magazyn/static/styles.css
+++ b/magazyn/static/styles.css
@@ -25,7 +25,8 @@ h2, h3 {
 
 /* Centered layout shared by item forms */
 .center-form {
-    max-width: 600px;
+    width: 75%;
+    max-width: none;
     margin: auto;
 }
 
@@ -138,6 +139,7 @@ th {
     height: 30px;
     font-size: 16px;
     padding: 0;
+    margin: 0 2px;
 }
 
 .quantity-value {

--- a/magazyn/templates/items.html
+++ b/magazyn/templates/items.html
@@ -30,10 +30,8 @@
                 <form method="POST" action="{{ url_for('products.update_quantity', product_id=product['id'], size=size) }}" class="form-inline quantity-form">
                     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                     <button type="submit" name="action" value="decrease" class="btn btn-danger btn-sm btn-quantity">-</button>
-                    <span class="quantity-value">{{ product['sizes'][size]['quantity'] }}</span>
+                    <span class="quantity-value">{{ product['sizes'][size] }}</span>
                     <button type="submit" name="action" value="increase" class="btn btn-success btn-sm btn-quantity">+</button>
-                    <br>
-                    <small>{{ product['sizes'][size]['barcode'] }}</small>
                 </form>
             </td>
             {% endfor %}

--- a/magazyn/templates/scan_barcode.html
+++ b/magazyn/templates/scan_barcode.html
@@ -5,6 +5,7 @@
         <h2 class="mb-3">Skanuj kod kreskowy</h2>
         <div id="scanner-container"></div>
         <p id="barcode-result" class="mt-2">Kod kreskowy: </p>
+        <input type="hidden" id="csrf" value="{{ csrf_token() }}">
     </div>
 
     <!-- Element audio do odtworzenia dźwięku -->
@@ -41,10 +42,12 @@
             Quagga.stop();
 
             // Przekierowanie lub wysłanie kodu kreskowego do backendu (np. do Flask)
+            const csrf = document.getElementById('csrf').value;
             fetch('/barcode_scan', {
                 method: 'POST',
                 headers: {
-                    'Content-Type': 'application/json'
+                    'Content-Type': 'application/json',
+                    'X-CSRFToken': csrf
                 },
                 body: JSON.stringify({ barcode: data.codeResult.code })
             })


### PR DESCRIPTION
## Summary
- store `None` when barcode fields are blank
- show quantities only on the products table
- widen all `.center-form` layouts to 75% width
- tweak quantity button spacing
- update tests for new behaviour
- include CSRF token in barcode scan requests

## Testing
- `pip install -r magazyn/requirements.txt`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685d40648dfc832ab78f975268e2a912