### PR TITLE
Add CSRF header for barcode scan

### DIFF
--- a/magazyn/templates/scan_barcode.html
+++ b/magazyn/templates/scan_barcode.html
@@ -9,6 +9,7 @@
 
     <!-- Element audio do odtworzenia dźwięku -->
     <audio id="beep-sound" src="{{ url_for('static', filename='beep.mp3') }}" preload="auto"></audio>
+    <input type="hidden" id="csrf" value="{{ csrf_token() }}">
 
     <script>
         Quagga.init({
@@ -44,7 +45,8 @@
             fetch('/barcode_scan', {
                 method: 'POST',
                 headers: {
-                    'Content-Type': 'application/json'
+                    'Content-Type': 'application/json',
+                    'X-CSRFToken': document.getElementById('csrf').value
                 },
                 body: JSON.stringify({ barcode: data.codeResult.code })
             })

--- a/magazyn/tests/test_products.py
+++ b/magazyn/tests/test_products.py
@@ -141,3 +141,20 @@ def test_items_page_displays_barcodes(tmp_path, monkeypatch):
     assert resp.status_code == 200
     html = resp.get_data(as_text=True)
     assert "321" not in html
+
+
+def test_scan_barcode_page_contains_csrf(tmp_path, monkeypatch):
+    app_mod = setup_app(tmp_path, monkeypatch)
+    client = app_mod.app.test_client()
+    login(client)
+
+    resp = client.get("/scan_barcode")
+    assert resp.status_code == 200
+    html = resp.get_data(as_text=True)
+    from flask import session as flask_session
+    with client.session_transaction() as sess:
+        with app_mod.app.test_request_context():
+            for k, v in sess.items():
+                flask_session[k] = v
+            token = app_mod.app.jinja_env.globals["csrf_token"]()
+    assert token in html


### PR DESCRIPTION
## Summary
- render CSRF token in `scan_barcode.html`
- send token as `X-CSRFToken` header from JavaScript
- test presence of CSRF token on barcode scanning page

## Testing
- `pip install -r magazyn/requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d7712b2f0832aba7fc7fa7985dc5e