### PR TITLE
Add speech feedback for unknown barcode

### DIFF
--- a/magazyn/templates/scan_barcode.html
+++ b/magazyn/templates/scan_barcode.html
@@ -50,7 +50,13 @@
                 },
                 body: JSON.stringify({ barcode: data.codeResult.code })
             })
-            .then(res => res.json().catch(() => null))
+            .then(res => {
+                if (res.status === 204) {
+                    speechSynthesis.speak(new SpeechSynthesisUtterance('Nie znaleziono produktu o podanym kodzie kreskowym'));
+                    return null;
+                }
+                return res.json().catch(() => null);
+            })
             .then(result => {
                 if (result) {
                     const text = `${result.name}, kolor ${result.color}, rozmiar ${result.size}`;


### PR DESCRIPTION
## Summary
- improve scan page to notify when barcode lookup fails

## Testing
- `pip install -r magazyn/requirements.txt`
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d83275788832ab1d1cc35a0efa454