### PR TITLE
Fix mobile header layout and barcode scan session

### DIFF
--- a/magazyn/products.py
+++ b/magazyn/products.py
@@ -141,18 +141,17 @@ def barcode_scan():
     if barcode:
         with get_session() as db:
             row = (
-                db.query(Product, ProductSize)
+                db.query(Product.name, Product.color, ProductSize.size)
                 .join(ProductSize)
                 .filter(ProductSize.barcode == barcode)
                 .first()
             )
-        if row:
-            product, ps = row
-            result = {
-                "name": product.name,
-                "color": product.color,
-                "size": ps.size,
-            }
+            if row:
+                name, color, size = row
+                result = {"name": name, "color": color, "size": size}
+            else:
+                result = None
+        if result:
             flash(f'Znaleziono produkt: {result["name"]}')
             return jsonify(result)
         else:

--- a/magazyn/static/styles.css
+++ b/magazyn/static/styles.css
@@ -212,6 +212,11 @@ body {
         transform: translateX(100%);
         transition: transform 0.3s ease;
         z-index: 1050;
+        display: flex;
+        flex-direction: column;
+    }
+    .mobile-menu ul {
+        flex-grow: 1;
     }
     .mobile-menu.open {
         transform: translateX(0);

--- a/magazyn/templates/base.html
+++ b/magazyn/templates/base.html
@@ -11,14 +11,13 @@
     <div class="page-wrapper">
     <nav class="navbar navbar-dark bg-dark fixed-top">
         <div class="container">
-            <button id="mobileMenuBtn" class="navbar-toggler d-md-none" type="button">
-                <span class="navbar-toggler-icon"></span>
-            </button>
-            <span class="navbar-brand d-flex align-items-center">
+            <div class="d-flex align-items-center justify-content-between">
+            <span class="navbar-brand d-flex align-items-center mb-0">
                 <img src="https://retrievershop.pl/wp-content/uploads/2024/08/retriver-2.png" alt="Logo" style="height: 40px;">
                 <span class="ms-2">Witaj w aplikacji magazynowej</span>
             </span>
-            <ul class="navbar-nav flex-row ms-auto gap-3 d-none d-md-flex">
+            <div class="d-flex align-items-center">
+                <ul class="navbar-nav flex-row gap-3 d-none d-md-flex">
                 <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('home') }}">Strona główna</a></li>
                 <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('products.add_item') }}">Dodaj przedmiot</a></li>
                 <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('products.items') }}">Przedmioty</a></li>
@@ -27,14 +26,18 @@
                 <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('agent_logs') }}">Logi</a></li>
                 <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('settings') }}">Ustawienia</a></li>
                 <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('test_print') }}">Testuj drukarkę</a></li>
-            </ul>
-            <a href="{{ url_for('logout') }}" class="btn btn-danger ms-md-3">Wyloguj się</a>
+                </ul>
+                <a href="{{ url_for('logout') }}" class="btn btn-danger ms-md-3 d-none d-md-inline-block">Wyloguj się</a>
+                <button id="mobileMenuBtn" class="navbar-toggler d-md-none ms-2" type="button">
+                    <span class="navbar-toggler-icon"></span>
+                </button>
+            </div>
         </div>
     </nav>
 
 
     <div id="mobileMenu" class="mobile-menu d-md-none">
-        <ul class="nav flex-column">
+        <ul class="nav flex-column h-100">
             <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('home') }}">Strona główna</a></li>
             <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('products.add_item') }}">Dodaj przedmiot</a></li>
             <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('products.items') }}">Przedmioty</a></li>
@@ -43,6 +46,7 @@
             <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('agent_logs') }}">Logi</a></li>
             <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('settings') }}">Ustawienia</a></li>
             <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('test_print') }}">Testuj drukarkę</a></li>
+            <li class="nav-item mt-auto"><a class="nav-link text-white" href="{{ url_for('logout') }}">Wyloguj się</a></li>
         </ul>
     </div>
 


### PR DESCRIPTION
## Summary
- adjust navbar structure so brand appears before hamburger menu
- hide desktop logout button on mobile and add logout link to slide-out menu
- ensure slide-out menu can place logout link at bottom
- fix barcode scanning by querying plain columns within session

## Testing
- `pip install -q -r magazyn/requirements.txt`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d89983210832aa80e7538983bbe74