### PR TITLE
Limit main content to 75% width

### DIFF
--- a/magazyn/static/styles.css
+++ b/magazyn/static/styles.css
@@ -244,6 +244,14 @@ body {
     }
 }
 
+@media (min-width: 768px) {
+    main.container-fluid {
+        width: 75%;
+        margin-left: auto;
+        margin-right: auto;
+    }
+}
+
 
 
 


### PR DESCRIPTION
## Summary
- keep content centered on desktop by restricting `main` width to 75%

## Testing
- `pip install -r magazyn/requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d95b98bb8832a8e8b6dea403e3056