### PR TITLE
Add NumberRange validator for product quantity

### DIFF
--- a/magazyn/forms.py
+++ b/magazyn/forms.py
@@ -1,6 +1,6 @@
 from flask_wtf import FlaskForm
 from wtforms import StringField, PasswordField, SelectField, IntegerField
-from wtforms.validators import DataRequired
+from wtforms.validators import DataRequired, NumberRange
 
 from .constants import ALL_SIZES
 
@@ -25,5 +25,13 @@ class AddItemForm(FlaskForm):
 
 # Dynamically add quantity and barcode fields for each size
 for _size in ALL_SIZES:
-    setattr(AddItemForm, f'quantity_{_size}', IntegerField(f'quantity_{_size}', default=0))
-    setattr(AddItemForm, f'barcode_{_size}', StringField(f'barcode_{_size}'))
+    setattr(
+        AddItemForm,
+        f"quantity_{_size}",
+        IntegerField(
+            f"quantity_{_size}",
+            default=0,
+            validators=[NumberRange(min=0)],
+        ),
+    )
+    setattr(AddItemForm, f"barcode_{_size}", StringField(f"barcode_{_size}"))

--- a/magazyn/tests/test_products.py
+++ b/magazyn/tests/test_products.py
@@ -158,3 +158,22 @@ def test_scan_barcode_page_contains_csrf(tmp_path, monkeypatch):
                 flask_session[k] = v
             token = app_mod.app.jinja_env.globals["csrf_token"]()
     assert token in html
+
+
+def test_add_item_rejects_negative_quantity(tmp_path, monkeypatch):
+    app_mod = setup_app(tmp_path, monkeypatch)
+    client = app_mod.app.test_client()
+    login(client)
+
+    data = {
+        "name": "NegProd",
+        "color": "Czerwony",
+        "quantity_M": "-1",
+    }
+    resp = client.post("/add_item", data=data)
+    # Form should re-render when validation fails
+    assert resp.status_code == 200
+
+    with app_mod.get_session() as db:
+        assert db.query(Product).filter_by(name="NegProd").first() is None
+


### PR DESCRIPTION
## Summary
- require non-negative quantities in AddItemForm
- test negative quantity is rejected

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685da30e57ec832a9f0284e0ba24c3ad