### PR TITLE
Remove drop_all from init_db

### DIFF
--- a/magazyn/app.py
+++ b/magazyn/app.py
@@ -13,6 +13,7 @@ from .forms import LoginForm
 from .db import (
     get_session,
     init_db,
+    reset_db,
     ensure_schema,
     register_default_user,
     record_purchase,

--- a/magazyn/db.py
+++ b/magazyn/db.py
@@ -31,6 +31,15 @@ get_db_connection = get_session
 
 def init_db():
     """Initialize the SQLite database and create required tables."""
+    Base.metadata.create_all(engine)
+
+
+def reset_db():
+    """Drop all tables and recreate them.
+
+    This is useful for testing scenarios that require a completely clean
+    database state without losing the ability of :func:`init_db` to preserve
+    existing data."""
     Base.metadata.drop_all(engine)
     Base.metadata.create_all(engine)
 

--- a/magazyn/tests/test_base_template.py
+++ b/magazyn/tests/test_base_template.py
@@ -22,7 +22,7 @@ def setup_app(tmp_path, monkeypatch):
     from sqlalchemy.orm import sessionmaker
     db_mod.SessionLocal = sessionmaker(bind=db_mod.engine, autoflush=False, expire_on_commit=False)
     app_mod.app.config["WTF_CSRF_ENABLED"] = False
-    app_mod.init_db()
+    app_mod.reset_db()
     return app_mod
 
 

--- a/magazyn/tests/test_deliveries.py
+++ b/magazyn/tests/test_deliveries.py
@@ -16,7 +16,7 @@ def setup_app(tmp_path, monkeypatch):
     monkeypatch.setattr(pa, "validate_env", lambda: None)
     import magazyn.app as app_mod
     importlib.reload(app_mod)
-    app_mod.init_db()
+    app_mod.reset_db()
     return app_mod
 
 

--- a/magazyn/tests/test_excel.py
+++ b/magazyn/tests/test_excel.py
@@ -20,7 +20,7 @@ def setup_app(tmp_path, monkeypatch):
     monkeypatch.setattr(pa, "validate_env", lambda: None)
     import magazyn.app as app_mod
     importlib.reload(app_mod)
-    app_mod.init_db()
+    app_mod.reset_db()
     return app_mod
 
 

--- a/magazyn/tests/test_login.py
+++ b/magazyn/tests/test_login.py
@@ -23,7 +23,7 @@ def setup_app(tmp_path, monkeypatch):
     from sqlalchemy.orm import sessionmaker
     db_mod.SessionLocal = sessionmaker(bind=db_mod.engine, autoflush=False, expire_on_commit=False)
     app_mod.app.config["WTF_CSRF_ENABLED"] = False
-    app_mod.init_db()
+    app_mod.reset_db()
     return app_mod
 
 
@@ -45,7 +45,7 @@ def setup_app_default_session(tmp_path, monkeypatch):
     from sqlalchemy.orm import sessionmaker
     db_mod.SessionLocal = sessionmaker(bind=db_mod.engine, autoflush=False)
     app_mod.app.config["WTF_CSRF_ENABLED"] = False
-    app_mod.init_db()
+    app_mod.reset_db()
     return app_mod
 
 

--- a/magazyn/tests/test_products.py
+++ b/magazyn/tests/test_products.py
@@ -23,7 +23,7 @@ def setup_app(tmp_path, monkeypatch):
         bind=db_mod.engine, autoflush=False, expire_on_commit=False
     )
     app_mod.app.config["WTF_CSRF_ENABLED"] = False
-    app_mod.init_db()
+    app_mod.reset_db()
     return app_mod
 
 


### PR DESCRIPTION
## Summary
- avoid wiping data in `init_db`
- add new `reset_db` helper for tests
- import and use `reset_db` in tests

## Testing
- `python -m pip install -r magazyn/requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685dc21e5a8c832aaeac788b40738b5c