### PR TITLE
Add mobile menu logo and logout style

### DIFF
--- a/magazyn/static/styles.css
+++ b/magazyn/static/styles.css
@@ -261,3 +261,17 @@ body {
     color: #f0f0f0;
     border-color: #555;
 }
+
+/* Additional mobile menu styling */
+.mobile-logo {
+    height: 40px;
+    display: block;
+}
+
+@media (max-width: 768px) {
+    #mobileMenu .btn {
+        margin-left: auto;
+        margin-right: auto;
+        display: block;
+    }
+}

--- a/magazyn/templates/base.html
+++ b/magazyn/templates/base.html
@@ -37,6 +37,7 @@
 
 
     <div id="mobileMenu" class="mobile-menu d-md-none">
+        <img src="https://retrievershop.pl/wp-content/uploads/2024/08/retriver-2.png" alt="Logo" class="mobile-logo mx-auto mb-3">
         <ul class="nav flex-column h-100">
             <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('home') }}">Strona główna</a></li>
             <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('products.add_item') }}">Dodaj przedmiot</a></li>
@@ -46,7 +47,9 @@
             <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('agent_logs') }}">Logi</a></li>
             <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('settings') }}">Ustawienia</a></li>
             <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('test_print') }}">Testuj drukarkę</a></li>
-            <li class="nav-item mt-auto"><a class="nav-link text-white" href="{{ url_for('logout') }}">Wyloguj się</a></li>
+            <li class="nav-item mt-auto text-center">
+                <a class="btn btn-danger w-100" href="{{ url_for('logout') }}">Wyloguj się</a>
+            </li>
         </ul>
     </div>
 


### PR DESCRIPTION
## Summary
- add logo to mobile menu and style logout button
- tweak CSS for `.mobile-logo` and centering of logout button

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685dc4a088c4832aafcc4d064f295dc2