### PR TITLE
Handle missing env template

### DIFF
--- a/magazyn/app.py
+++ b/magazyn/app.py
@@ -72,6 +72,11 @@ def start_print_agent():
 
 def load_settings():
     """Return OrderedDict combining keys from the example and current .env."""
+    if not EXAMPLE_PATH.exists():
+        app.logger.error(f"Settings template missing: {EXAMPLE_PATH}")
+        flash("Plik .env.example nie istnieje, brak ustawień do wyświetlenia.")
+        return OrderedDict()
+
     example = dotenv_values(EXAMPLE_PATH)
     current = dotenv_values(ENV_PATH) if ENV_PATH.exists() else {}
     values = OrderedDict()

--- a/magazyn/tests/test_settings.py
+++ b/magazyn/tests/test_settings.py
@@ -1,5 +1,6 @@
 import importlib
 import sys
+from collections import OrderedDict
 from dotenv import load_dotenv
 
 import magazyn.db as db_mod
@@ -103,4 +104,20 @@ def test_extra_keys_display_and_save(tmp_path, monkeypatch):
     env_lines = app_mod.ENV_PATH.read_text().strip().splitlines()
     assert env_lines[-1] == "EXTRA_KEY=bar"
     assert "EXTRA_KEY" in app_mod.load_settings()
+
+
+def test_missing_example_file(tmp_path, monkeypatch):
+    app_mod = setup_app(tmp_path, monkeypatch)
+    app_mod.EXAMPLE_PATH = tmp_path / "no.env.example"
+
+    client = app_mod.app.test_client()
+    login(client)
+
+    resp = client.get("/settings")
+    assert resp.status_code == 200
+    html = resp.get_data(as_text=True)
+    assert "plik .env.example" in html.lower()
+
+    with app_mod.app.test_request_context():
+        assert app_mod.load_settings() == OrderedDict()
 


### PR DESCRIPTION
## Summary
- guard `load_settings()` when `.env.example` is missing
- test settings page behavior without `.env.example`

## Testing
- `pip install -r magazyn/requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685dc596f6e4832ab13c0efbd116e8ba