### PR TITLE
Handle scanner init errors

### DIFF
--- a/magazyn/templates/scan_barcode.html
+++ b/magazyn/templates/scan_barcode.html
@@ -39,6 +39,10 @@
         }, function (err) {
             if (err) {
                 console.log(err);
+                const el = document.getElementById('barcode-result');
+                if (el) {
+                    el.innerText = 'B\u0142\u0105d uruchomienia skanera. Sprawd\u017a, czy przegl\u0105darka ma dost\u0119p do kamery.';
+                }
                 return;
             }
             console.log("Inicjalizacja zakończona");


### PR DESCRIPTION
## Summary
- display a user-friendly message when Quagga initialization fails

## Testing
- `pip install -r magazyn/requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685dc0ecc294832a99d7617a0352d67e