### PR TITLE
Add env mounts for compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,12 @@ Start the stack using the `docker-compose.yml` file in the repository root:
 docker compose up
 ```
 
+The compose configuration mounts the environment files so updates made through
+the application persist on the host:
+
+- `./.env:/app/.env`
+- `./.env.example:/app/.env.example:ro`
+
 The compose configuration mounts the host's `/var/run/cups/cups.sock` so the
 printing agent can communicate with the host CUPS server.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,8 @@ services:
       dockerfile: Dockerfile
     volumes:
       - ./magazyn/database.db:/app/database.db
+      - ./.env:/app/.env
+      - ./.env.example:/app/.env.example:ro
       - /var/run/cups/cups.sock:/var/run/cups/cups.sock
     env_file: .env
     command: ["python", "-m", "magazyn.app"]


### PR DESCRIPTION
## Summary
- mount `.env` and `.env.example` inside the container
- document the env file mounts in README

## Testing
- `pip install -r magazyn/requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685daecd7e24832ab54a7f4dbe3ee2c9