### PR TITLE
Set container widths

### DIFF
--- a/magazyn/static/styles.css
+++ b/magazyn/static/styles.css
@@ -52,9 +52,9 @@ label, input, button {
 
 .navbar .container {
     margin: 0 auto;
+    max-width: 1140px;
+    width: 100%;
 }
-
-.navbar .container { max-width: 75%; }
 @media (max-width: 768px) {
     .navbar .container { max-width: 100%; padding: 0 1rem; }
 }
@@ -252,7 +252,8 @@ body {
 
 @media (min-width: 768px) {
     main.container-fluid {
-        width: 75%;
+        max-width: 1140px;
+        width: 100%;
         margin-left: auto;
         margin-right: auto;
     }


### PR DESCRIPTION
## Summary
- keep main layout centered with new 1140px width limit
- match navbar container width to the same limit

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685eb0bb28a0832aae6c5a62b1be68e1