### PR TITLE
Fix Quagga barcode config

### DIFF
--- a/magazyn/templates/scan_barcode.html
+++ b/magazyn/templates/scan_barcode.html
@@ -31,11 +31,11 @@
                     "ean_reader",
                     "ean_8_reader",
                     "upc_reader",
-                    "ean_13_reader",
                     "code_39_reader",
                     "codabar_reader"
                 ]
-            }
+            },
+            locate: true
         }, function (err) {
             if (err) {
                 console.log(err);


### PR DESCRIPTION
## Summary
- remove EAN-13 reader from the scanner config
- enable Quagga's locate feature to improve detection

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ebe05180c832a94e9beea9ee0fd98