### PR TITLE
Add mobile menu close button

### DIFF
--- a/magazyn/static/styles.css
+++ b/magazyn/static/styles.css
@@ -281,4 +281,9 @@ body {
         margin-right: auto;
         display: block;
     }
+    .mobile-close {
+        position: absolute;
+        top: 0;
+        right: 0;
+    }
 }

--- a/magazyn/templates/base.html
+++ b/magazyn/templates/base.html
@@ -37,6 +37,7 @@
 
 
     <div id="mobileMenu" class="mobile-menu d-md-none">
+        <button id="mobileMenuClose" class="mobile-close btn btn-link text-white" type="button" aria-label="Close">&times;</button>
         <img src="https://retrievershop.pl/wp-content/uploads/2024/08/retriver-2.png" alt="Logo" class="mobile-logo mx-auto mb-3">
         <ul class="nav flex-column h-100">
             <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('home') }}">Strona główna</a></li>
@@ -73,8 +74,12 @@
     <script>
         const btn = document.getElementById('mobileMenuBtn');
         const menu = document.getElementById('mobileMenu');
+        const closeBtn = document.getElementById('mobileMenuClose');
         if (btn && menu) {
             btn.addEventListener('click', () => menu.classList.toggle('open'));
+        }
+        if (closeBtn && menu) {
+            closeBtn.addEventListener('click', () => menu.classList.remove('open'));
         }
     </script>
     </div>


### PR DESCRIPTION
## Summary
- add a close button inside the mobile menu
- style the button for mobile view
- hide the menu when the close button is clicked

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ed789ba50832aa834c036e41f9954