### PR TITLE
Add next parameter to barcode scan

### DIFF
--- a/magazyn/products.py
+++ b/magazyn/products.py
@@ -173,7 +173,8 @@ def barcode_scan():
 @bp.route('/scan_barcode')
 @login_required
 def barcode_scan_page():
-    return render_template('scan_barcode.html')
+    next_url = request.args.get('next', url_for('products.items'))
+    return render_template('scan_barcode.html', next=next_url)
 
 
 @bp.route('/export_products')

--- a/magazyn/templates/home.html
+++ b/magazyn/templates/home.html
@@ -6,7 +6,7 @@
     <div class="d-grid gap-2 col-md-6 mx-auto mt-4">
         <a href="{{ url_for('products.add_item') }}" class="btn btn-primary">Dodaj nowy przedmiot</a>
         <a href="{{ url_for('products.items') }}" class="btn btn-primary">Wyświetl przedmioty</a>
-        <a href="{{ url_for('products.barcode_scan_page') }}" class="btn btn-primary">Skanuj kod kreskowy</a>
+        <a href="{{ url_for('products.barcode_scan_page', next=url_for('home')) }}" class="btn btn-primary">Skanuj kod kreskowy</a>
         <a href="{{ url_for('products.export_products') }}" class="btn btn-primary">Eksportuj produkty do Excel</a>
         <a href="{{ url_for('products.import_products') }}" class="btn btn-primary">Importuj produkty z Excel</a>
     </div>

--- a/magazyn/templates/items.html
+++ b/magazyn/templates/items.html
@@ -46,6 +46,6 @@
 
 </div>
 </div>
-<a href="{{ url_for('products.barcode_scan_page') }}" class="btn btn-primary mt-3">Skanuj kod kreskowy</a>
+<a href="{{ url_for('products.barcode_scan_page', next=url_for('products.items')) }}" class="btn btn-primary mt-3">Skanuj kod kreskowy</a>
 
 {% endblock %}

--- a/magazyn/templates/scan_barcode.html
+++ b/magazyn/templates/scan_barcode.html
@@ -11,6 +11,7 @@
     <!-- Element audio do odtworzenia dźwięku -->
     <audio id="beep-sound" src="{{ url_for('static', filename='beep.mp3') }}" preload="auto"></audio>
     <input type="hidden" id="csrf" value="{{ csrf_token() }}">
+    <input type="hidden" id="next-url" value="{{ next }}">
 
     <script>
         let torchEnabled = false;
@@ -120,7 +121,9 @@
                     const text = `${result.name}, kolor ${result.color}, rozmiar ${result.size}`;
                     speechSynthesis.speak(new SpeechSynthesisUtterance(text));
                 }
-                window.location.href = "/items";
+                const nextUrlInput = document.getElementById('next-url');
+                const nextUrl = nextUrlInput ? nextUrlInput.value : '/items';
+                window.location.href = nextUrl;
             });
         });
     </script>


### PR DESCRIPTION
## Summary
- allow barcode scanner page to accept a `next` URL
- use the `next` URL for post-scan redirection
- update links to include `next` argument

## Testing
- `pip install -r magazyn/requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685eda8e5328832a96528e8668547e4c