### PR TITLE
Move scanner link to top of items page

### DIFF
--- a/magazyn/templates/items.html
+++ b/magazyn/templates/items.html
@@ -3,6 +3,9 @@
 {% block content %}
 
 <div class="container text-center mt-5">
+    <div class="mb-3 text-center">
+        <a href="{{ url_for('products.barcode_scan_page', next=url_for('products.items')) }}" class="btn btn-primary">Skanuj kod kreskowy</a>
+    </div>
 <div class="table-responsive">
     {# wrapper adds overflow-x:auto so columns never get cut off #}
 
@@ -46,6 +49,4 @@
 
 </div>
 </div>
-<a href="{{ url_for('products.barcode_scan_page', next=url_for('products.items')) }}" class="btn btn-primary mt-3">Skanuj kod kreskowy</a>
-
 {% endblock %}


### PR DESCRIPTION
## Summary
- move the barcode scanner link above the items table in `items.html`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for `magazyn`)*

------
https://chatgpt.com/codex/tasks/task_e_685ee10cbf78832a9192967e7992c1c9