### PR TITLE
Fix width of edit item form

### DIFF
--- a/magazyn/static/styles.css
+++ b/magazyn/static/styles.css
@@ -32,6 +32,12 @@ h2, h3 {
     margin: auto;
 }
 
+/* Full-width layout for edit item page */
+.wide-form {
+    width: 100%;
+    margin: auto;
+}
+
 @media (max-width: 768px) {
     .center-form {
         width: 100%;

--- a/magazyn/templates/edit_item.html
+++ b/magazyn/templates/edit_item.html
@@ -3,7 +3,7 @@
 {% block content %}
 <div class="container mt-4">
     <h3 class="text-center">Edytuj przedmiot</h3>
-    <form method="POST" action="{{ url_for('products.edit_item', product_id=product['id']) }}" class="row row-cols-1 row-cols-md-2 g-3 center-form mx-auto">
+    <form method="POST" action="{{ url_for('products.edit_item', product_id=product['id']) }}" class="row row-cols-1 row-cols-md-2 g-3 wide-form mx-auto">
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
         <div class="col-md-6">
             <label for="name" class="form-label">Nazwa:</label>


### PR DESCRIPTION
## Summary
- style the edit item page with a new `.wide-form` class
- apply the new class in the template so the form spans the full width

## Testing
- `pip install -r magazyn/requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ee965d06c832a8930e976d676d8c8