### PR TITLE
Handle mobile menu close links

### DIFF
--- a/magazyn/templates/base.html
+++ b/magazyn/templates/base.html
@@ -75,12 +75,23 @@
         const btn = document.getElementById('mobileMenuBtn');
         const menu = document.getElementById('mobileMenu');
         const closeBtn = document.getElementById('mobileMenuClose');
+        const links = document.querySelectorAll('#mobileMenu a');
+
+        function closeMenu() {
+            if (menu) {
+                menu.classList.remove('open');
+            }
+        }
+
         if (btn && menu) {
             btn.addEventListener('click', () => menu.classList.toggle('open'));
         }
-        if (closeBtn && menu) {
-            closeBtn.addEventListener('click', () => menu.classList.remove('open'));
+        if (closeBtn) {
+            closeBtn.addEventListener('click', closeMenu);
         }
+        links.forEach(link => {
+            link.addEventListener('click', closeMenu);
+        });
     </script>
     </div>
 </body>


### PR DESCRIPTION
## Summary
- hide the mobile nav menu when clicking links inside it
- reuse the same close behaviour for the menu's close button

## Testing
- `pip install -r magazyn/requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685eed163bb4832abe7038dc7d2a8508