### PR TITLE
Add error pages

### DIFF
--- a/magazyn/app.py
+++ b/magazyn/app.py
@@ -205,6 +205,18 @@ def test_message():
     return render_template("test.html", message=msg)
 
 
+@app.errorhandler(404)
+def handle_404(error):
+    """Render custom page for 404 errors."""
+    return render_template("404.html"), 404
+
+
+@app.errorhandler(500)
+def handle_500(error):
+    """Render custom page for internal server errors."""
+    return render_template("500.html"), 500
+
+
 if __name__ == "__main__":
     ensure_db_initialized()
     debug = os.getenv("FLASK_DEBUG") == "1"

--- a/magazyn/templates/404.html
+++ b/magazyn/templates/404.html
@@ -1,0 +1,9 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="container text-center mt-5">
+    <h2>Nie znaleziono strony</h2>
+    <p>Przepraszamy, ale żądana strona nie istnieje.</p>
+    <a href="{{ url_for('home') }}" class="btn btn-primary mt-3">Powrót do strony głównej</a>
+</div>
+{% endblock %}

--- a/magazyn/templates/500.html
+++ b/magazyn/templates/500.html
@@ -1,0 +1,9 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="container text-center mt-5">
+    <h2>Błąd serwera</h2>
+    <p>Wystąpił nieoczekiwany błąd. Spróbuj ponownie później.</p>
+    <a href="{{ url_for('home') }}" class="btn btn-primary mt-3">Powrót do strony głównej</a>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add custom templates for 404 and 500 errors
- handle 404 and 500 errors in `app.py`

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685eee563d3c832a9101e11f4fb50f66