### PR TITLE
Centralized configuration

### DIFF
--- a/magazyn/__init__.py
+++ b/magazyn/__init__.py
@@ -1,13 +1,14 @@
 
-import os
+"""Package level helpers and backward compatibility variables."""
+
+from .config import settings
 
 # Path to the SQLite database shared between the application and the
 # printing agent.  It defaults to ``database.db`` located in this
 # package directory but can be overridden with the ``DB_PATH``
-# environment variable.
-DB_PATH = os.getenv(
-    "DB_PATH", os.path.join(os.path.dirname(__file__), "database.db")
-)
+# environment variable.  Other modules historically imported
+# ``DB_PATH`` from ``magazyn`` so expose it here for convenience.
+DB_PATH = settings.DB_PATH
 
 # Allow ``from __init__ import DB_PATH`` when running modules as scripts.
 import sys

--- a/magazyn/app.py
+++ b/magazyn/app.py
@@ -1,9 +1,9 @@
 from flask import Flask, render_template, request, redirect, url_for, session, flash
 from flask_wtf import CSRFProtect
-import os
 from datetime import datetime
+import os
 from werkzeug.security import check_password_hash
-from dotenv import load_dotenv, dotenv_values
+from dotenv import dotenv_values
 from collections import OrderedDict
 from pathlib import Path
 
@@ -34,6 +34,7 @@ from .products import (
 )
 from .history import bp as history_bp, print_history
 from .auth import login_required
+from .config import settings
 from . import print_agent
 from __init__ import DB_PATH
 from .constants import ALL_SIZES
@@ -44,10 +45,8 @@ EXAMPLE_PATH = ROOT_DIR / ".env.example"
 
 
 
-load_dotenv()
-
 app = Flask(__name__)
-app.secret_key = os.environ.get("SECRET_KEY", "default_secret_key")
+app.secret_key = settings.SECRET_KEY
 CSRFProtect(app)
 app.jinja_env.globals['ALL_SIZES'] = ALL_SIZES
 
@@ -219,5 +218,4 @@ def handle_500(error):
 
 if __name__ == "__main__":
     ensure_db_initialized()
-    debug = os.getenv("FLASK_DEBUG") == "1"
-    app.run(host="0.0.0.0", port=80, debug=debug)
+    app.run(host="0.0.0.0", port=80, debug=settings.FLASK_DEBUG)

--- a/magazyn/config.py
+++ b/magazyn/config.py
@@ -1,0 +1,34 @@
+import os
+from types import SimpleNamespace
+from dotenv import load_dotenv
+
+
+def load_config():
+    """Load settings from .env and environment variables."""
+    load_dotenv()
+    return SimpleNamespace(
+        API_TOKEN=os.getenv("API_TOKEN"),
+        PAGE_ACCESS_TOKEN=os.getenv("PAGE_ACCESS_TOKEN"),
+        RECIPIENT_ID=os.getenv("RECIPIENT_ID"),
+        STATUS_ID=int(os.getenv("STATUS_ID", "91618")),
+        PRINTER_NAME=os.getenv("PRINTER_NAME", "Xprinter"),
+        CUPS_SERVER=os.getenv("CUPS_SERVER"),
+        CUPS_PORT=os.getenv("CUPS_PORT"),
+        POLL_INTERVAL=int(os.getenv("POLL_INTERVAL", "60")),
+        QUIET_HOURS_START=int(os.getenv("QUIET_HOURS_START", "10")),
+        QUIET_HOURS_END=int(os.getenv("QUIET_HOURS_END", "22")),
+        TIMEZONE=os.getenv("TIMEZONE", "Europe/Warsaw"),
+        PRINTED_EXPIRY_DAYS=int(os.getenv("PRINTED_EXPIRY_DAYS", "5")),
+        LOG_LEVEL=os.getenv("LOG_LEVEL", "INFO").upper(),
+        LOG_FILE=os.getenv(
+            "LOG_FILE", os.path.join(os.path.dirname(__file__), "agent.log")
+        ),
+        DB_PATH=os.getenv(
+            "DB_PATH", os.path.join(os.path.dirname(__file__), "database.db")
+        ),
+        SECRET_KEY=os.getenv("SECRET_KEY", "default_secret_key"),
+        FLASK_DEBUG=os.getenv("FLASK_DEBUG") == "1",
+    )
+
+
+settings = load_config()

--- a/magazyn/print_agent.py
+++ b/magazyn/print_agent.py
@@ -8,36 +8,34 @@ import sqlite3
 import threading
 from datetime import datetime, timedelta
 from zoneinfo import ZoneInfo
-from dotenv import load_dotenv
 import requests
 
+from .config import settings, load_config
 from __init__ import DB_PATH
 
-load_dotenv()
-
-API_TOKEN = os.getenv("API_TOKEN")
-PAGE_ACCESS_TOKEN = os.getenv("PAGE_ACCESS_TOKEN")
-RECIPIENT_ID = os.getenv("RECIPIENT_ID")
-STATUS_ID = int(os.getenv("STATUS_ID", "91618"))
-PRINTER_NAME = os.getenv("PRINTER_NAME", "Xprinter")
-CUPS_SERVER = os.getenv("CUPS_SERVER")
-CUPS_PORT = os.getenv("CUPS_PORT")
-POLL_INTERVAL = int(os.getenv("POLL_INTERVAL", "60"))
-QUIET_HOURS_START = int(os.getenv("QUIET_HOURS_START", "10"))
-QUIET_HOURS_END = int(os.getenv("QUIET_HOURS_END", "22"))
-TIMEZONE = os.getenv("TIMEZONE", "Europe/Warsaw")
+API_TOKEN = settings.API_TOKEN
+PAGE_ACCESS_TOKEN = settings.PAGE_ACCESS_TOKEN
+RECIPIENT_ID = settings.RECIPIENT_ID
+STATUS_ID = settings.STATUS_ID
+PRINTER_NAME = settings.PRINTER_NAME
+CUPS_SERVER = settings.CUPS_SERVER
+CUPS_PORT = settings.CUPS_PORT
+POLL_INTERVAL = settings.POLL_INTERVAL
+QUIET_HOURS_START = settings.QUIET_HOURS_START
+QUIET_HOURS_END = settings.QUIET_HOURS_END
+TIMEZONE = settings.TIMEZONE
 BASE_URL = "https://api.baselinker.com/connector.php"
 PRINTED_FILE = os.path.join(os.path.dirname(__file__), "printed_orders.txt")
-PRINTED_EXPIRY_DAYS = int(os.getenv("PRINTED_EXPIRY_DAYS", "5"))
+PRINTED_EXPIRY_DAYS = settings.PRINTED_EXPIRY_DAYS
 LABEL_QUEUE = os.path.join(os.path.dirname(__file__), "queued_labels.jsonl")
-LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO").upper()
+LOG_LEVEL = settings.LOG_LEVEL
 # Use the same database file as the web application
 DB_FILE = DB_PATH
 # Location of the legacy database used by the standalone printer agent
 OLD_DB_FILE = os.path.abspath(
     os.path.join(os.path.dirname(__file__), os.pardir, "printer", "data.db")
 )
-LOG_FILE = os.getenv("LOG_FILE", os.path.join(os.path.dirname(__file__), "agent.log"))
+LOG_FILE = settings.LOG_FILE
 
 logging.basicConfig(
     level=getattr(logging, LOG_LEVEL, logging.INFO),
@@ -57,25 +55,26 @@ HEADERS = {
 
 def reload_env():
     """Reload environment variables and update globals."""
-    load_dotenv(override=True)
+    global settings
+    settings = load_config()
     global API_TOKEN, PAGE_ACCESS_TOKEN, RECIPIENT_ID, STATUS_ID, PRINTER_NAME
     global CUPS_SERVER, CUPS_PORT, POLL_INTERVAL, QUIET_HOURS_START, QUIET_HOURS_END
     global TIMEZONE, PRINTED_EXPIRY_DAYS, LOG_LEVEL, LOG_FILE, DB_FILE, HEADERS
-    API_TOKEN = os.getenv("API_TOKEN")
-    PAGE_ACCESS_TOKEN = os.getenv("PAGE_ACCESS_TOKEN")
-    RECIPIENT_ID = os.getenv("RECIPIENT_ID")
-    STATUS_ID = int(os.getenv("STATUS_ID", "91618"))
-    PRINTER_NAME = os.getenv("PRINTER_NAME", "Xprinter")
-    CUPS_SERVER = os.getenv("CUPS_SERVER")
-    CUPS_PORT = os.getenv("CUPS_PORT")
-    POLL_INTERVAL = int(os.getenv("POLL_INTERVAL", "60"))
-    QUIET_HOURS_START = int(os.getenv("QUIET_HOURS_START", "10"))
-    QUIET_HOURS_END = int(os.getenv("QUIET_HOURS_END", "22"))
-    TIMEZONE = os.getenv("TIMEZONE", "Europe/Warsaw")
-    PRINTED_EXPIRY_DAYS = int(os.getenv("PRINTED_EXPIRY_DAYS", "5"))
-    LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO").upper()
-    LOG_FILE = os.getenv("LOG_FILE", os.path.join(os.path.dirname(__file__), "agent.log"))
-    DB_FILE = DB_PATH
+    API_TOKEN = settings.API_TOKEN
+    PAGE_ACCESS_TOKEN = settings.PAGE_ACCESS_TOKEN
+    RECIPIENT_ID = settings.RECIPIENT_ID
+    STATUS_ID = settings.STATUS_ID
+    PRINTER_NAME = settings.PRINTER_NAME
+    CUPS_SERVER = settings.CUPS_SERVER
+    CUPS_PORT = settings.CUPS_PORT
+    POLL_INTERVAL = settings.POLL_INTERVAL
+    QUIET_HOURS_START = settings.QUIET_HOURS_START
+    QUIET_HOURS_END = settings.QUIET_HOURS_END
+    TIMEZONE = settings.TIMEZONE
+    PRINTED_EXPIRY_DAYS = settings.PRINTED_EXPIRY_DAYS
+    LOG_LEVEL = settings.LOG_LEVEL
+    LOG_FILE = settings.LOG_FILE
+    DB_FILE = settings.DB_PATH
     HEADERS["X-BLToken"] = API_TOKEN
 
 

--- a/magazyn/tests/test_base_template.py
+++ b/magazyn/tests/test_base_template.py
@@ -2,10 +2,11 @@ import importlib
 import sys
 from magazyn.models import User
 from werkzeug.security import generate_password_hash
+import magazyn.config as cfg
 
 
 def setup_app(tmp_path, monkeypatch):
-    monkeypatch.setenv("DB_PATH", ":memory:")
+    monkeypatch.setattr(cfg.settings, "DB_PATH", ":memory:")
     import werkzeug
     monkeypatch.setattr(werkzeug, "__version__", "0", raising=False)
     init = importlib.import_module("magazyn.__init__")

--- a/magazyn/tests/test_deliveries.py
+++ b/magazyn/tests/test_deliveries.py
@@ -2,10 +2,11 @@ import importlib
 import sys
 from sqlalchemy import text
 from magazyn.models import Product, ProductSize
+import magazyn.config as cfg
 
 
 def setup_app(tmp_path, monkeypatch):
-    monkeypatch.setenv("DB_PATH", ":memory:")
+    monkeypatch.setattr(cfg.settings, "DB_PATH", ":memory:")
     init = importlib.import_module("magazyn.__init__")
     importlib.reload(init)
     monkeypatch.setitem(sys.modules, "__init__", init)

--- a/magazyn/tests/test_excel.py
+++ b/magazyn/tests/test_excel.py
@@ -4,10 +4,11 @@ import sys
 from io import BytesIO
 from sqlalchemy import text
 from magazyn.models import Product, ProductSize
+import magazyn.config as cfg
 
 
 def setup_app(tmp_path, monkeypatch):
-    monkeypatch.setenv("DB_PATH", ":memory:")
+    monkeypatch.setattr(cfg.settings, "DB_PATH", ":memory:")
     import werkzeug
     monkeypatch.setattr(werkzeug, "__version__", "0", raising=False)
     init = importlib.import_module("magazyn.__init__")

--- a/magazyn/tests/test_login.py
+++ b/magazyn/tests/test_login.py
@@ -3,10 +3,11 @@ import sys
 
 from werkzeug.security import generate_password_hash
 from magazyn.models import User
+import magazyn.config as cfg
 
 
 def setup_app(tmp_path, monkeypatch):
-    monkeypatch.setenv("DB_PATH", ":memory:")
+    monkeypatch.setattr(cfg.settings, "DB_PATH", ":memory:")
     import werkzeug
     monkeypatch.setattr(werkzeug, "__version__", "0", raising=False)
     init = importlib.import_module("magazyn.__init__")
@@ -28,7 +29,7 @@ def setup_app(tmp_path, monkeypatch):
 
 
 def setup_app_default_session(tmp_path, monkeypatch):
-    monkeypatch.setenv("DB_PATH", ":memory:")
+    monkeypatch.setattr(cfg.settings, "DB_PATH", ":memory:")
     import werkzeug
     monkeypatch.setattr(werkzeug, "__version__", "0", raising=False)
     init = importlib.import_module("magazyn.__init__")

--- a/magazyn/tests/test_products.py
+++ b/magazyn/tests/test_products.py
@@ -1,10 +1,11 @@
 import importlib
 import sys
 from magazyn.models import Product, ProductSize
+import magazyn.config as cfg
 
 
 def setup_app(tmp_path, monkeypatch):
-    monkeypatch.setenv("DB_PATH", ":memory:")
+    monkeypatch.setattr(cfg.settings, "DB_PATH", ":memory:")
     import werkzeug
     monkeypatch.setattr(werkzeug, "__version__", "0", raising=False)
     init = importlib.import_module("magazyn.__init__")


### PR DESCRIPTION
## Summary
- add `magazyn/config.py` with `load_config()` and module-level `settings`
- make modules use the new configuration object
- update tests to patch `settings` instead of environment variables

## Testing
- `pip install -r magazyn/requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ef3deb860832a9579e6f995c8b656