### PR TITLE
Refactor tests to use shared fixtures

### DIFF
--- a/magazyn/tests/conftest.py
+++ b/magazyn/tests/conftest.py
@@ -1,0 +1,39 @@
+import importlib
+import sys
+import pytest
+
+import magazyn.config as cfg
+
+@pytest.fixture
+def app_mod(tmp_path, monkeypatch):
+    monkeypatch.setattr(cfg.settings, "DB_PATH", ":memory:")
+    import werkzeug
+    monkeypatch.setattr(werkzeug, "__version__", "0", raising=False)
+    init = importlib.import_module("magazyn.__init__")
+    importlib.reload(init)
+    monkeypatch.setitem(sys.modules, "__init__", init)
+    pa = importlib.import_module("magazyn.print_agent")
+    monkeypatch.setitem(sys.modules, "print_agent", pa)
+    monkeypatch.setattr(pa, "start_agent_thread", lambda: None)
+    monkeypatch.setattr(pa, "ensure_db_init", lambda: None)
+    monkeypatch.setattr(pa, "validate_env", lambda: None)
+    import magazyn.app as app_mod
+    importlib.reload(app_mod)
+    import magazyn.db as db_mod
+    from sqlalchemy.orm import sessionmaker
+    db_mod.SessionLocal = sessionmaker(bind=db_mod.engine, autoflush=False, expire_on_commit=False)
+    app_mod.app.config["WTF_CSRF_ENABLED"] = False
+    app_mod.reset_db()
+    return app_mod
+
+
+@pytest.fixture
+def client(app_mod):
+    return app_mod.app.test_client()
+
+
+@pytest.fixture
+def login(client):
+    with client.session_transaction() as sess:
+        sess["username"] = "tester"
+    yield

--- a/magazyn/tests/test_base_template.py
+++ b/magazyn/tests/test_base_template.py
@@ -1,44 +1,11 @@
-import importlib
-import sys
 from magazyn.models import User
 from werkzeug.security import generate_password_hash
-import magazyn.config as cfg
 
 
-def setup_app(tmp_path, monkeypatch):
-    monkeypatch.setattr(cfg.settings, "DB_PATH", ":memory:")
-    import werkzeug
-    monkeypatch.setattr(werkzeug, "__version__", "0", raising=False)
-    init = importlib.import_module("magazyn.__init__")
-    importlib.reload(init)
-    monkeypatch.setitem(sys.modules, "__init__", init)
-    pa = importlib.import_module("magazyn.print_agent")
-    monkeypatch.setitem(sys.modules, "print_agent", pa)
-    monkeypatch.setattr(pa, "start_agent_thread", lambda: None)
-    monkeypatch.setattr(pa, "ensure_db_init", lambda: None)
-    monkeypatch.setattr(pa, "validate_env", lambda: None)
-    import magazyn.app as app_mod
-    importlib.reload(app_mod)
-    import magazyn.db as db_mod
-    from sqlalchemy.orm import sessionmaker
-    db_mod.SessionLocal = sessionmaker(bind=db_mod.engine, autoflush=False, expire_on_commit=False)
-    app_mod.app.config["WTF_CSRF_ENABLED"] = False
-    app_mod.reset_db()
-    return app_mod
-
-
-def login(client):
-    with client.session_transaction() as sess:
-        sess["username"] = "tester"
-
-
-def test_nav_container_class(tmp_path, monkeypatch):
-    app_mod = setup_app(tmp_path, monkeypatch)
-    client = app_mod.app.test_client()
+def test_nav_container_class(app_mod, client, login):
     hashed = generate_password_hash("secret")
     with app_mod.get_session() as db:
         db.add(User(username="tester", password=hashed))
-    login(client)
     resp = client.get("/")
     html = resp.get_data(as_text=True)
     import re

--- a/magazyn/tests/test_login.py
+++ b/magazyn/tests/test_login.py
@@ -6,28 +6,6 @@ from magazyn.models import User
 import magazyn.config as cfg
 
 
-def setup_app(tmp_path, monkeypatch):
-    monkeypatch.setattr(cfg.settings, "DB_PATH", ":memory:")
-    import werkzeug
-    monkeypatch.setattr(werkzeug, "__version__", "0", raising=False)
-    init = importlib.import_module("magazyn.__init__")
-    importlib.reload(init)
-    monkeypatch.setitem(sys.modules, "__init__", init)
-    pa = importlib.import_module("magazyn.print_agent")
-    monkeypatch.setitem(sys.modules, "print_agent", pa)
-    monkeypatch.setattr(pa, "start_agent_thread", lambda: None)
-    monkeypatch.setattr(pa, "ensure_db_init", lambda: None)
-    monkeypatch.setattr(pa, "validate_env", lambda: None)
-    import magazyn.app as app_mod
-    importlib.reload(app_mod)
-    import magazyn.db as db_mod
-    from sqlalchemy.orm import sessionmaker
-    db_mod.SessionLocal = sessionmaker(bind=db_mod.engine, autoflush=False, expire_on_commit=False)
-    app_mod.app.config["WTF_CSRF_ENABLED"] = False
-    app_mod.reset_db()
-    return app_mod
-
-
 def setup_app_default_session(tmp_path, monkeypatch):
     monkeypatch.setattr(cfg.settings, "DB_PATH", ":memory:")
     import werkzeug
@@ -50,9 +28,7 @@ def setup_app_default_session(tmp_path, monkeypatch):
     return app_mod
 
 
-def test_login_route_authenticates_user(tmp_path, monkeypatch):
-    app_mod = setup_app(tmp_path, monkeypatch)
-    client = app_mod.app.test_client()
+def test_login_route_authenticates_user(app_mod, client):
     hashed = generate_password_hash("secret")
     with app_mod.get_session() as db:
         db.add(User(username="tester", password=hashed))

--- a/magazyn/tests/test_settings.py
+++ b/magazyn/tests/test_settings.py
@@ -1,43 +1,12 @@
 import importlib
-import sys
 from collections import OrderedDict
 from dotenv import load_dotenv
 
-import magazyn.db as db_mod
 import magazyn.config as cfg
 
 
-def setup_app(tmp_path, monkeypatch):
-    monkeypatch.setattr(cfg.settings, "DB_PATH", str(tmp_path / "settings.db"))
-    import werkzeug
-    monkeypatch.setattr(werkzeug, "__version__", "0", raising=False)
-    init = importlib.import_module("magazyn.__init__")
-    importlib.reload(init)
-    monkeypatch.setitem(sys.modules, "__init__", init)
-    pa = importlib.import_module("magazyn.print_agent")
-    monkeypatch.setitem(sys.modules, "print_agent", pa)
-    monkeypatch.setattr(pa, "start_agent_thread", lambda: None)
-    monkeypatch.setattr(pa, "ensure_db_init", lambda: None)
-    monkeypatch.setattr(pa, "validate_env", lambda: None)
-    import magazyn.app as app_mod
-    importlib.reload(app_mod)
-    from sqlalchemy.orm import sessionmaker
-    db_mod.SessionLocal = sessionmaker(bind=db_mod.engine, autoflush=False, expire_on_commit=False)
-    app_mod.app.config["WTF_CSRF_ENABLED"] = False
-    # use temp env file
+def test_settings_list_all_keys(app_mod, client, login, tmp_path):
     app_mod.ENV_PATH = tmp_path / ".env"
-    return app_mod
-
-
-def login(client):
-    with client.session_transaction() as sess:
-        sess["username"] = "tester"
-
-
-def test_settings_list_all_keys(tmp_path, monkeypatch):
-    app_mod = setup_app(tmp_path, monkeypatch)
-    client = app_mod.app.test_client()
-    login(client)
     resp = client.get("/settings")
     assert resp.status_code == 200
     text = resp.get_data(as_text=True)
@@ -45,12 +14,10 @@ def test_settings_list_all_keys(tmp_path, monkeypatch):
         assert key in text
 
 
-def test_settings_post_saves_and_reloads(tmp_path, monkeypatch):
-    app_mod = setup_app(tmp_path, monkeypatch)
+def test_settings_post_saves_and_reloads(app_mod, client, login, tmp_path, monkeypatch):
+    app_mod.ENV_PATH = tmp_path / ".env"
     reloaded = {"called": False}
     monkeypatch.setattr(app_mod.print_agent, "reload_config", lambda: reloaded.update(called=True))
-    client = app_mod.app.test_client()
-    login(client)
     values = {k: f"val{i}" for i, k in enumerate(app_mod.load_settings().keys())}
     resp = client.post("/settings", data=values)
     assert resp.status_code == 302
@@ -59,10 +26,8 @@ def test_settings_post_saves_and_reloads(tmp_path, monkeypatch):
     assert reloaded["called"] is True
 
 
-def test_env_updates_persist_and_reload(tmp_path, monkeypatch):
-    app_mod = setup_app(tmp_path, monkeypatch)
-    client = app_mod.app.test_client()
-    login(client)
+def test_env_updates_persist_and_reload(app_mod, client, login, tmp_path, monkeypatch):
+    app_mod.ENV_PATH = tmp_path / ".env"
 
     original_load = cfg.load_config
 
@@ -89,13 +54,11 @@ def test_env_updates_persist_and_reload(tmp_path, monkeypatch):
     assert pa.API_TOKEN == "new0"
 
 
-def test_extra_keys_display_and_save(tmp_path, monkeypatch):
-    app_mod = setup_app(tmp_path, monkeypatch)
+def test_extra_keys_display_and_save(app_mod, client, login, tmp_path, monkeypatch):
+    app_mod.ENV_PATH = tmp_path / ".env"
     # create env file with an additional key
     app_mod.ENV_PATH.write_text("EXTRA_KEY=foo\n")
 
-    client = app_mod.app.test_client()
-    login(client)
 
     resp = client.get("/settings")
     assert resp.status_code == 200
@@ -111,12 +74,9 @@ def test_extra_keys_display_and_save(tmp_path, monkeypatch):
     assert "EXTRA_KEY" in app_mod.load_settings()
 
 
-def test_missing_example_file(tmp_path, monkeypatch):
-    app_mod = setup_app(tmp_path, monkeypatch)
+def test_missing_example_file(app_mod, client, login, tmp_path, monkeypatch):
+    app_mod.ENV_PATH = tmp_path / ".env"
     app_mod.EXAMPLE_PATH = tmp_path / "no.env.example"
-
-    client = app_mod.app.test_client()
-    login(client)
 
     resp = client.get("/settings")
     assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- add shared fixtures in `magazyn/tests/conftest.py`
- update all tests to use the new fixtures

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685efeb92534832a8adf47a437158d2b