### PR TITLE
Insert csrf tokens in forms

### DIFF
--- a/magazyn/templates/add_delivery.html
+++ b/magazyn/templates/add_delivery.html
@@ -3,6 +3,7 @@
 {% block content %}
 <h2 class="mb-3 text-center">Dodaj dostawę</h2>
 <form action="{{ url_for('products.add_delivery') }}" method="post" class="row row-cols-1 row-cols-md-2 g-3 center-form mx-auto">
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
     <div class="col-md-6">
         <label for="product_id" class="form-label">Produkt:</label>
         <select name="product_id" id="product_id" class="form-select">

--- a/magazyn/templates/test.html
+++ b/magazyn/templates/test.html
@@ -2,6 +2,7 @@
 {% block content %}
 <h2 class="mb-3 text-center">Test wiadomości</h2>
 <form method="post" class="mb-3 row row-cols-1 row-cols-md-2 g-3 center-form mx-auto">
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
     <button type="submit" class="btn btn-primary">Wyślij testową wiadomość</button>
 </form>
 {% if message %}

--- a/magazyn/templates/testprint.html
+++ b/magazyn/templates/testprint.html
@@ -2,6 +2,7 @@
 {% block content %}
 <h2 class="mb-3 text-center">Test wydruku</h2>
 <form method="post" class="mb-3 row row-cols-1 row-cols-md-2 g-3 center-form mx-auto">
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
     <button type="submit" class="btn btn-primary">Wydrukuj stronę testową</button>
 </form>
 {% if message %}


### PR DESCRIPTION
## Summary
- add CSRF hidden inputs to `testprint.html` and `test.html`
- include CSRF token in the `add_delivery.html` form

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f19495608832aaf60c1d8aa2e625a