### PR TITLE
Add env mounts for compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,12 @@ Start the stack using the `docker-compose.yml` file in the repository root:
 docker compose up
 ```
 
+The compose configuration mounts the environment files so updates made through
+the application persist on the host:
+
+- `./.env:/app/.env`
+- `./.env.example:/app/.env.example:ro`
+
 The compose configuration mounts the host's `/var/run/cups/cups.sock` so the
 printing agent can communicate with the host CUPS server.
 
@@ -81,6 +87,9 @@ file is created automatically on first startup if it does not already exist.
 When running the stack in Docker, this file is mounted inside the container as
 `/app/database.db` and the `DB_PATH` variable in your `.env` file should point
 to that location.
+
+Printed order IDs appear on the **Historia drukowania** page. Each row offers a
+**Drukuj ponownie** button to reprint a label if necessary.
 
 ## Database migration
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,8 @@ services:
       dockerfile: Dockerfile
     volumes:
       - ./magazyn/database.db:/app/database.db
+      - ./.env:/app/.env
+      - ./.env.example:/app/.env.example:ro
       - /var/run/cups/cups.sock:/var/run/cups/cups.sock
     env_file: .env
     command: ["python", "-m", "magazyn.app"]

--- a/magazyn/history.py
+++ b/magazyn/history.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, render_template
+from flask import Blueprint, render_template, flash, redirect, url_for
 from . import print_agent
 
 from .auth import login_required
@@ -11,4 +11,14 @@ def print_history():
     printed = print_agent.load_printed_orders()
     queue = print_agent.load_queue()
     return render_template('history.html', printed=printed, queue=queue)
+
+
+@bp.route('/history/reprint/<order_id>', methods=['POST'])
+@login_required
+def reprint(order_id):
+    success = print_agent.reprint_order(order_id)
+    flash(
+        'Etykieta ponownie wysłana do drukarki.' if success else 'Błąd ponownego wydruku.'
+    )
+    return redirect(url_for('history.print_history'))
 

--- a/magazyn/print_agent.py
+++ b/magazyn/print_agent.py
@@ -321,6 +321,31 @@ def print_test_page():
         return False
 
 
+def reprint_order(order_id):
+    """Fetch and print labels for a previously printed order."""
+    try:
+        packages = get_order_packages(order_id)
+        printed_any = False
+        for pkg in packages:
+            package_id = pkg.get("package_id")
+            courier_code = pkg.get("courier_code")
+            if not package_id or not courier_code:
+                logger.warning(
+                    "Brak danych do ponownego druku: %s", pkg
+                )
+                continue
+            label_data, ext = get_label(courier_code, package_id)
+            if label_data:
+                print_label(label_data, ext, order_id)
+                printed_any = True
+        if printed_any:
+            logger.info("🔁 Ponownie wydrukowano etykietę %s", order_id)
+            return True
+    except Exception as e:
+        logger.error("Błąd ponownego wydruku %s: %s", order_id, e)
+    return False
+
+
 def shorten_product_name(full_name):
     words = full_name.strip().split()
     if len(words) >= 3:

--- a/magazyn/templates/history.html
+++ b/magazyn/templates/history.html
@@ -4,13 +4,22 @@
 <div class="table-responsive mx-auto">
     {# .table-responsive ensures horizontal scrolling when needed #}
 <table class="table table-striped table-sm">
-    <thead><tr><th>ID zamówienia</th><th>Czas</th></tr></thead>
+    <thead><tr><th>ID zamówienia</th><th>Czas</th><th>Akcje</th></tr></thead>
     <tbody>
     {% for oid, ts in printed.items() %}
-    <tr><td>{{ oid }}</td><td>{{ ts }}</td></tr>
+    <tr>
+        <td>{{ oid }}</td>
+        <td>{{ ts }}</td>
+        <td>
+            <form method="POST" action="{{ url_for('history.reprint', order_id=oid) }}">
+                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                <button type="submit" class="btn btn-secondary btn-sm">Drukuj ponownie</button>
+            </form>
+        </td>
+    </tr>
     {% endfor %}
     {% for item in queue %}
-    <tr><td>{{ item.order_id }}</td><td>w kolejce</td></tr>
+    <tr><td>{{ item.order_id }}</td><td>w kolejce</td><td></td></tr>
     {% endfor %}
     </tbody>
 </table>


### PR DESCRIPTION
## Summary
- mount `.env` and `.env.example` inside the container
- document the env file mounts in README
- allow reprinting labels from the print history page

## Testing
- `pip install -r magazyn/requirements.txt`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685daecd7e24832ab54a7f4dbe3ee2c9