### PR TITLE
Allow label reprints from print history

### DIFF
--- a/magazyn/history.py
+++ b/magazyn/history.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, render_template
+from flask import Blueprint, render_template, redirect, url_for, flash
 from . import print_agent
 
 from .auth import login_required
@@ -11,4 +11,29 @@ def print_history():
     printed = print_agent.load_printed_orders()
     queue = print_agent.load_queue()
     return render_template('history.html', printed=printed, queue=queue)
+
+
+@bp.route('/history/reprint/<order_id>', methods=['POST'])
+@login_required
+def reprint_label(order_id):
+    """Reprint shipping labels for the given order."""
+    try:
+        queue = [q for q in print_agent.load_queue() if str(q.get('order_id')) == str(order_id)]
+        if queue:
+            for item in queue:
+                print_agent.print_label(item.get('label_data'), item.get('ext', 'pdf'), order_id)
+        else:
+            packages = print_agent.get_order_packages(order_id)
+            for p in packages:
+                pid = p.get('package_id')
+                code = p.get('courier_code')
+                if not pid or not code:
+                    continue
+                label_data, ext = print_agent.get_label(code, pid)
+                if label_data:
+                    print_agent.print_label(label_data, ext, order_id)
+        flash('Etykieta została ponownie wysłana do drukarki.')
+    except Exception as exc:
+        flash(f'Błąd ponownego drukowania: {exc}')
+    return redirect(url_for('.print_history'))
 

--- a/magazyn/templates/history.html
+++ b/magazyn/templates/history.html
@@ -4,13 +4,22 @@
 <div class="table-responsive mx-auto">
     {# .table-responsive ensures horizontal scrolling when needed #}
 <table class="table table-striped table-sm">
-    <thead><tr><th>ID zamówienia</th><th>Czas</th></tr></thead>
+    <thead><tr><th>ID zamówienia</th><th>Czas</th><th>Akcje</th></tr></thead>
     <tbody>
     {% for oid, ts in printed.items() %}
-    <tr><td>{{ oid }}</td><td>{{ ts }}</td></tr>
+    <tr>
+        <td>{{ oid }}</td>
+        <td>{{ ts }}</td>
+        <td>
+            <form method="post" action="{{ url_for('history.reprint_label', order_id=oid) }}">
+                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                <button type="submit" class="btn btn-sm btn-primary">Drukuj ponownie</button>
+            </form>
+        </td>
+    </tr>
     {% endfor %}
     {% for item in queue %}
-    <tr><td>{{ item.order_id }}</td><td>w kolejce</td></tr>
+    <tr><td>{{ item.order_id }}</td><td>w kolejce</td><td></td></tr>
     {% endfor %}
     </tbody>
 </table>

--- a/magazyn/tests/test_history.py
+++ b/magazyn/tests/test_history.py
@@ -1,0 +1,39 @@
+import importlib
+from datetime import datetime
+
+
+def test_history_page_shows_reprint_form(app_mod, client, login, monkeypatch):
+    monkeypatch.setattr(app_mod.print_agent, "load_printed_orders", lambda: {"1": datetime.now()})
+    monkeypatch.setattr(app_mod.print_agent, "load_queue", lambda: [])
+    resp = client.get("/history")
+    assert resp.status_code == 200
+    html = resp.get_data(as_text=True)
+    assert "/history/reprint/1" in html
+    from flask import session as flask_session
+    with client.session_transaction() as sess:
+        with app_mod.app.test_request_context():
+            for k, v in sess.items():
+                flask_session[k] = v
+            token = app_mod.app.jinja_env.globals["csrf_token"]()
+    assert token in html
+
+
+def test_reprint_route_uses_api(app_mod, client, login, monkeypatch):
+    monkeypatch.setattr(app_mod.print_agent, "load_queue", lambda: [])
+    monkeypatch.setattr(app_mod.print_agent, "get_order_packages", lambda oid: [{"package_id": "p1", "courier_code": "c1"}])
+    monkeypatch.setattr(app_mod.print_agent, "get_label", lambda code, pid: ("data", "pdf"))
+    called = {"n": 0}
+    def fake_print(data, ext, oid):
+        called["n"] += 1
+    monkeypatch.setattr(app_mod.print_agent, "print_label", fake_print)
+    resp = client.post("/history/reprint/1")
+    assert resp.status_code == 302
+    assert called["n"] == 1
+
+def test_reprint_route_uses_queue(app_mod, client, login, monkeypatch):
+    monkeypatch.setattr(app_mod.print_agent, "load_queue", lambda: [{"order_id": "2", "label_data": "x", "ext": "pdf"}])
+    called = {"n": 0}
+    monkeypatch.setattr(app_mod.print_agent, "print_label", lambda d, e, o: called.update(n=called["n"] + 1))
+    resp = client.post("/history/reprint/2")
+    assert resp.status_code == 302
+    assert called["n"] == 1


### PR DESCRIPTION
## Summary
- add endpoint for reprinting shipping labels
- show reprint button in print history table
- test reprint form and behaviour

## Testing
- `pip install -q -r magazyn/requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f1af7ba14832a8213443aa1b86cd4