### PR TITLE
Add bootstrap icons and tweak history button

### DIFF
--- a/magazyn/templates/base.html
+++ b/magazyn/templates/base.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Retriever Shop - Magazyn</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
     <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
 </head>
 <body>

--- a/magazyn/templates/history.html
+++ b/magazyn/templates/history.html
@@ -11,9 +11,9 @@
         <td>{{ oid }}</td>
         <td>{{ ts }}</td>
         <td>
-            <form method="post" action="{{ url_for('history.reprint_label', order_id=oid) }}">
+            <form class="d-inline" method="post" action="{{ url_for('history.reprint_label', order_id=oid) }}">
                 <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-                <button type="submit" class="btn btn-sm btn-primary">Drukuj ponownie</button>
+                <button type="submit" class="btn btn-sm btn-primary"><i class="bi bi-printer"></i></button>
             </form>
         </td>
     </tr>


### PR DESCRIPTION
## Summary
- add Bootstrap Icons to base layout for consistent icon use
- update reprint button in history view to use a printer icon and inline form

## Testing
- `pip install -r magazyn/requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f2a922164832a8e4599e31e7dbcb4