### PR TITLE
Adjust page-wrapper height

### DIFF
--- a/magazyn/static/styles.css
+++ b/magazyn/static/styles.css
@@ -7,7 +7,8 @@ body {
     color: #f0f0f0;
 }
 .page-wrapper {
-    min-height: 100vh;
+    /* Subtract navbar height so short pages avoid unnecessary scrolling */
+    min-height: calc(100vh - 70px);
     display: flex;
     flex-direction: column;
 }


### PR DESCRIPTION
## Summary
- adjust page-wrapper min-height to avoid unwanted vertical scrolling

## Testing
- `pip install -r magazyn/requirements.txt`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685f2c7bf520832ab019942a1aadcc4f