### PR TITLE
Remove unused import from test_history

### DIFF
--- a/magazyn/tests/test_history.py
+++ b/magazyn/tests/test_history.py
@@ -1,4 +1,3 @@
-import importlib
 from datetime import datetime
 
 
@@ -61,6 +60,7 @@ def test_reprint_logs_exception(app_mod, client, login, monkeypatch):
             logged["msg"] = msg
             logged["order_id"] = order_id
 
+    import importlib
     hist_mod = importlib.import_module("magazyn.history")
     monkeypatch.setattr(hist_mod, "logger", DummyLogger())
 


### PR DESCRIPTION
## Summary
- delete the global `import importlib` in `test_history`
- import `importlib` only when needed in the test

## Testing
- `pytest -k test_history -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685fd1baaa84832aaa5ba0c5b49b717b