### PR TITLE
Format timestamps in history page

### DIFF
--- a/magazyn/templates/history.html
+++ b/magazyn/templates/history.html
@@ -9,7 +9,7 @@
     {% for oid, ts in printed.items() %}
     <tr>
         <td>{{ oid }}</td>
-        <td>{{ ts }}</td>
+        <td>{{ ts.strftime('%Y-%m-%d %H:%M') }}</td>
         <td>
             <form class="d-inline" method="post" action="{{ url_for('history.reprint_label', order_id=oid) }}">
                 <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">

--- a/magazyn/tests/test_history.py
+++ b/magazyn/tests/test_history.py
@@ -2,7 +2,8 @@ from datetime import datetime
 
 
 def test_history_page_shows_reprint_form(app_mod, client, login, monkeypatch):
-    monkeypatch.setattr(app_mod.print_agent, "load_printed_orders", lambda: {"1": datetime.now()})
+    ts = datetime(2023, 1, 2, 3, 4)
+    monkeypatch.setattr(app_mod.print_agent, "load_printed_orders", lambda: {"1": ts})
     monkeypatch.setattr(app_mod.print_agent, "load_queue", lambda: [])
     resp = client.get("/history")
     assert resp.status_code == 200
@@ -15,6 +16,7 @@ def test_history_page_shows_reprint_form(app_mod, client, login, monkeypatch):
                 flask_session[k] = v
             token = app_mod.app.jinja_env.globals["csrf_token"]()
     assert token in html
+    assert ts.strftime('%Y-%m-%d %H:%M') in html
 
 
 def test_reprint_route_uses_api(app_mod, client, login, monkeypatch):


### PR DESCRIPTION
## Summary
- format timestamps on the history page
- expect formatted timestamps in the history page test

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685fd92cec2c832a8915cd2578dd2f83