### PR TITLE
Add settings dropdown to navigation

### DIFF
--- a/magazyn/templates/base.html
+++ b/magazyn/templates/base.html
@@ -24,9 +24,16 @@
                 <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('products.items') }}">Przedmioty</a></li>
                 <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('products.add_delivery') }}">Dostawy</a></li>
                 <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('history.print_history') }}">Historia drukowania</a></li>
-                <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('agent_logs') }}">Logi</a></li>
-                <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('settings') }}">Ustawienia</a></li>
-                <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('test_print') }}">Testuj drukarkę</a></li>
+                <li class="nav-item dropdown">
+                    <a class="nav-link dropdown-toggle text-white" href="#" id="navbarSettings" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+                        Ustawienia
+                    </a>
+                    <ul class="dropdown-menu dropdown-menu-dark">
+                        <li><a class="dropdown-item" href="{{ url_for('settings') }}">Ustawienia</a></li>
+                        <li><a class="dropdown-item" href="{{ url_for('agent_logs') }}">Logi</a></li>
+                        <li><a class="dropdown-item" href="{{ url_for('test_print') }}">Testuj drukarkę</a></li>
+                    </ul>
+                </li>
                 </ul>
                 <a href="{{ url_for('logout') }}" class="btn btn-danger ms-md-3 d-none d-md-inline-block">Wyloguj się</a>
                 <button id="mobileMenuBtn" class="navbar-toggler d-md-none ms-2" type="button">
@@ -46,9 +53,14 @@
             <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('products.items') }}">Przedmioty</a></li>
             <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('products.add_delivery') }}">Dostawy</a></li>
             <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('history.print_history') }}">Historia drukowania</a></li>
-            <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('agent_logs') }}">Logi</a></li>
-            <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('settings') }}">Ustawienia</a></li>
-            <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('test_print') }}">Testuj drukarkę</a></li>
+            <li class="nav-item dropdown">
+                <a class="nav-link dropdown-toggle text-white" href="#" id="mobileSettingsDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">Ustawienia</a>
+                <ul class="dropdown-menu dropdown-menu-dark">
+                    <li><a class="dropdown-item" href="{{ url_for('settings') }}">Ustawienia</a></li>
+                    <li><a class="dropdown-item" href="{{ url_for('agent_logs') }}">Logi</a></li>
+                    <li><a class="dropdown-item" href="{{ url_for('test_print') }}">Testuj drukarkę</a></li>
+                </ul>
+            </li>
             <li class="nav-item mt-auto text-center">
                 <a class="btn btn-danger w-100" href="{{ url_for('logout') }}">Wyloguj się</a>
             </li>


### PR DESCRIPTION
## Summary
- group Logi and printing options under a unified **Ustawienia** dropdown in the navbar
- mirror the dropdown in the mobile slide‑in menu
- keep Bootstrap dropdown script so menus work

## Testing
- `pip install -r magazyn/requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685fe153aed8832aa35c83b87df8b61d