### PR TITLE
Update size layout in add item form

### DIFF
--- a/magazyn/templates/add_item.html
+++ b/magazyn/templates/add_item.html
@@ -23,10 +23,9 @@
 
         {% for size in ALL_SIZES %}
             <div class="col-md-6">
-                <label for="barcode_{{ size }}" class="form-label">Kod kreskowy ({{ size }}):</label>
-                <input type="text" id="barcode_{{ size }}" name="barcode_{{ size }}" class="form-control">
-                <label for="quantity_{{ size }}" class="form-label mt-1">Ilość ({{ size }}):</label>
-                <input type="number" id="quantity_{{ size }}" name="quantity_{{ size }}" min="0" value="0" class="form-control">
+                <label class="form-label">Rozmiar: {{ size }}</label>
+                <input type="number" id="quantity_{{ size }}" name="quantity_{{ size }}" min="0" value="0" class="form-control" placeholder="Ilość">
+                <input type="text" id="barcode_{{ size }}" name="barcode_{{ size }}" class="form-control mt-1" placeholder="Kod kreskowy">
             </div>
         {% endfor %}
 


### PR DESCRIPTION
## Summary
- reorder size inputs in `add_item.html` to show size label first
- add placeholders for quantity and barcode

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'magazyn')*

------
https://chatgpt.com/codex/tasks/task_e_685fe62619c0832a8597bdce0bb734f5