### PR TITLE
Add invoice import feature

### DIFF
--- a/magazyn/app.py
+++ b/magazyn/app.py
@@ -39,6 +39,7 @@ from .products import (
     barcode_scan_page,
     export_products,
     import_products,
+    import_invoice,
     add_delivery,
 )
 from .history import bp as history_bp, print_history

--- a/magazyn/products.py
+++ b/magazyn/products.py
@@ -168,6 +168,21 @@ def import_products():
     return render_template('import_products.html')
 
 
+@bp.route('/import_invoice', methods=['GET', 'POST'])
+@login_required
+def import_invoice():
+    if request.method == 'POST':
+        file = request.files.get('file')
+        if file:
+            try:
+                services.import_invoice_file(file)
+                flash('Zaimportowano fakturę')
+            except Exception as e:
+                flash(f'Błąd podczas importu faktury: {e}')
+        return redirect(url_for('products.items'))
+    return render_template('import_invoice.html')
+
+
 @bp.route('/deliveries', methods=['GET', 'POST'])
 @login_required
 def add_delivery():

--- a/magazyn/requirements.txt
+++ b/magazyn/requirements.txt
@@ -6,3 +6,4 @@ requests
 python-dotenv
 SQLAlchemy
 Flask-WTF
+PyPDF2

--- a/magazyn/services.py
+++ b/magazyn/services.py
@@ -3,8 +3,11 @@ from typing import Dict, Tuple, Optional, List
 import pandas as pd
 
 from .db import get_session, record_purchase, consume_stock
-from .models import Product, ProductSize
+from .models import Product, ProductSize, PurchaseBatch
 from .constants import ALL_SIZES
+from datetime import datetime
+from PyPDF2 import PdfReader
+import io
 
 
 def create_product(name: str, color: str, quantities: Dict[str, int], barcodes: Dict[str, Optional[str]]):
@@ -166,4 +169,79 @@ def import_from_dataframe(df: pd.DataFrame):
                 else:
                     ps.quantity = quantity
                     ps.barcode = size_barcode
+
+
+def _parse_pdf(file) -> pd.DataFrame:
+    """Extract a table from a PDF invoice using a simple heuristic."""
+    reader = PdfReader(file)
+    text = "\n".join(page.extract_text() or "" for page in reader.pages)
+    lines = [l.strip() for l in text.splitlines() if l.strip()]
+    rows = []
+    for line in lines:
+        parts = [p.strip() for p in line.split()]  # naive whitespace split
+        if len(parts) < 4:
+            continue
+        try:
+            qty = int(parts[-2])
+            price = float(parts[-1].replace(",", "."))
+        except ValueError:
+            continue
+        name = " ".join(parts[:-3])
+        size = parts[-3]
+        rows.append({"Nazwa": name, "Kolor": "", "Rozmiar": size, "Ilość": qty, "Cena": price})
+    return pd.DataFrame(rows)
+
+
+def import_invoice_file(file):
+    """Parse uploaded invoice (Excel or PDF) and record purchases."""
+    filename = file.filename or ""
+    ext = filename.rsplit(".", 1)[-1].lower()
+    if ext in {"xlsx", "xls"}:
+        df = pd.read_excel(file)
+    elif ext == "pdf":
+        df = _parse_pdf(file)
+    else:
+        raise ValueError("Nieobsługiwany format pliku")
+
+    for _, row in df.iterrows():
+        name = row.get("Nazwa")
+        color = row.get("Kolor", "")
+        size = row.get("Rozmiar")
+        quantity = int(row.get("Ilość", 0))
+        price = float(row.get("Cena", 0))
+        barcode = row.get("Barcode")
+
+        with get_session() as db:
+            ps = None
+            product = None
+            if barcode:
+                ps = db.query(ProductSize).filter_by(barcode=str(barcode)).first()
+                if ps:
+                    product = ps.product
+                    size = ps.size
+
+            if not product:
+                product = db.query(Product).filter_by(name=name, color=color).first()
+                if not product:
+                    product = Product(name=name, color=color)
+                    db.add(product)
+                    db.flush()
+
+            ps = db.query(ProductSize).filter_by(product_id=product.id, size=size).first()
+            if not ps:
+                ps = ProductSize(product_id=product.id, size=size, quantity=0, barcode=barcode)
+                db.add(ps)
+            elif barcode and not ps.barcode:
+                ps.barcode = barcode
+
+            db.add(
+                PurchaseBatch(
+                    product_id=product.id,
+                    size=size,
+                    quantity=quantity,
+                    price=price,
+                    purchase_date=datetime.now().isoformat(),
+                )
+            )
+            ps.quantity += quantity
 

--- a/magazyn/templates/home.html
+++ b/magazyn/templates/home.html
@@ -9,6 +9,7 @@
         <a href="{{ url_for('products.barcode_scan_page', next=url_for('home')) }}" class="btn btn-primary">Skanuj kod kreskowy</a>
         <a href="{{ url_for('products.export_products') }}" class="btn btn-primary">Eksportuj produkty do Excel</a>
         <a href="{{ url_for('products.import_products') }}" class="btn btn-primary">Importuj produkty z Excel</a>
+        <a href="{{ url_for('products.import_invoice') }}" class="btn btn-primary">Importuj fakturę</a>
     </div>
 </div>
 {% endblock %}

--- a/magazyn/templates/import_invoice.html
+++ b/magazyn/templates/import_invoice.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+{% block content %}
+<form action="{{ url_for('products.import_invoice') }}" method="POST" enctype="multipart/form-data" class="row row-cols-1 row-cols-md-2 g-3 center-form mx-auto">
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+    <div class="col-auto">
+        <input type="file" name="file" required class="form-control">
+    </div>
+    <div class="col-12 form-actions text-center">
+        <button type="submit" class="btn btn-primary">Zaimportuj</button>
+    </div>
+</form>
+{% endblock %}

--- a/magazyn/tests/test_invoice_import.py
+++ b/magazyn/tests/test_invoice_import.py
@@ -1,0 +1,47 @@
+import pandas as pd
+from io import BytesIO
+from sqlalchemy.sql import text
+from magazyn.models import Product, ProductSize
+
+
+def test_import_invoice_creates_products(app_mod, tmp_path):
+    df = pd.DataFrame([
+        {
+            "Nazwa": "ProdInv",
+            "Kolor": "Blue",
+            "Rozmiar": "M",
+            "Ilość": 2,
+            "Cena": 5.5,
+            "Barcode": "inv-123",
+        }
+    ])
+    file_path = tmp_path / "inv.xlsx"
+    df.to_excel(file_path, index=False)
+
+    with open(file_path, "rb") as f:
+        data = {"file": (f, "inv.xlsx")}
+        with app_mod.app.test_request_context(
+            "/import_invoice",
+            method="POST",
+            data=data,
+            content_type="multipart/form-data",
+        ):
+            from flask import session
+
+            session["username"] = "x"
+            app_mod.import_invoice.__wrapped__()
+
+    with app_mod.get_session() as db:
+        prod = db.query(Product).filter_by(name="ProdInv", color="Blue").first()
+        assert prod is not None
+        ps = db.query(ProductSize).filter_by(product_id=prod.id, size="M").first()
+        assert ps.quantity == 2
+        assert ps.barcode == "inv-123"
+        batch = db.execute(
+            text(
+                "SELECT quantity, price FROM purchase_batches WHERE product_id=:pid AND size='M'"
+            ),
+            {"pid": prod.id},
+        ).fetchone()
+        assert batch[0] == 2
+        assert abs(batch[1] - 5.5) < 0.001


### PR DESCRIPTION
## Summary
- add PyPDF2 dependency
- parse uploaded invoices via new `import_invoice` endpoint
- create products on-the-fly when importing invoices
- record purchase batches for imported items
- expose invoice importer in home menu
- cover invoice import with tests

## Testing
- `pip install -r magazyn/requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685fe887fe7c832aac748b783daddd4b