### PR TITLE
Track last_order_data and show newest printed first

### DIFF
--- a/magazyn/models.py
+++ b/magazyn/models.py
@@ -29,6 +29,7 @@ class PrintedOrder(Base):
     __tablename__ = 'printed_orders'
     order_id = Column(String, primary_key=True)
     printed_at = Column(String)
+    last_order_data = Column(Text)
 
 class LabelQueue(Base):
     __tablename__ = 'label_queue'

--- a/magazyn/templates/history.html
+++ b/magazyn/templates/history.html
@@ -4,14 +4,17 @@
 <div class="table-responsive mx-auto">
     {# .table-responsive ensures horizontal scrolling when needed #}
 <table class="table table-striped table-sm">
-    <thead><tr><th>ID zamówienia</th><th>Czas</th><th>Akcje</th></tr></thead>
+    <thead><tr><th>ID zamówienia</th><th>Nazwa</th><th>Kolor</th><th>Rozmiar</th><th>Czas</th><th>Akcje</th></tr></thead>
     <tbody>
-    {% for oid, ts in printed.items() %}
+    {% for item in printed %}
     <tr>
-        <td>{{ oid }}</td>
-        <td>{{ ts.strftime('%Y-%m-%d %H:%M') }}</td>
+        <td>{{ item.order_id }}</td>
+        <td>{{ item.last_order_data.name or '' }}</td>
+        <td>{{ item.last_order_data.color or '' }}</td>
+        <td>{{ item.last_order_data.size or '' }}</td>
+        <td>{{ item.printed_at.strftime('%Y-%m-%d %H:%M') }}</td>
         <td>
-            <form class="d-inline" method="post" action="{{ url_for('history.reprint_label', order_id=oid) }}">
+            <form class="d-inline" method="post" action="{{ url_for('history.reprint_label', order_id=item.order_id) }}">
                 <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                 <button type="submit" class="btn btn-sm btn-primary"><i class="bi bi-printer"></i></button>
             </form>
@@ -19,7 +22,14 @@
     </tr>
     {% endfor %}
     {% for item in queue %}
-    <tr><td>{{ item.order_id }}</td><td>w kolejce</td><td></td></tr>
+    <tr>
+        <td>{{ item.order_id }}</td>
+        <td>{{ item.last_order_data.name or '' }}</td>
+        <td>{{ item.last_order_data.color or '' }}</td>
+        <td>{{ item.last_order_data.size or '' }}</td>
+        <td>w kolejce</td>
+        <td></td>
+    </tr>
     {% endfor %}
     </tbody>
 </table>


### PR DESCRIPTION
## Summary
- include `last_order_data` in `PrintedOrder` model
- store extra order info when marking orders as printed
- keep printed history sorted by newest first
- display name, colour and size in printing history
- adjust tests for new behaviour and add ordering test

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685fe9ffc280832aad357898c3f57e91