### PR TITLE
Fix naming collision in settings route

### DIFF
--- a/magazyn/app.py
+++ b/magazyn/app.py
@@ -191,7 +191,7 @@ def logout():
 
 @app.route("/settings", methods=["GET", "POST"])
 @login_required
-def settings():
+def settings_page():
     values = load_settings()
     if request.method == "POST":
         for key in list(values.keys()):
@@ -201,11 +201,11 @@ def settings():
                 print_agent.parse_time_str(values.get(tkey, ""))
             except ValueError:
                 flash("Niepoprawny format godziny (hh:mm)")
-                return redirect(url_for("settings"))
+                return redirect(url_for("settings_page"))
         write_env(values)
         print_agent.reload_config()
         flash("Zapisano ustawienia.")
-        return redirect(url_for("settings"))
+        return redirect(url_for("settings_page"))
     settings_list = []
     for key, val in values.items():
         label, desc = ENV_INFO.get(key, (key, None))

--- a/magazyn/templates/base.html
+++ b/magazyn/templates/base.html
@@ -29,7 +29,7 @@
                         Ustawienia
                     </a>
                     <ul class="dropdown-menu dropdown-menu-dark">
-                        <li><a class="dropdown-item" href="{{ url_for('settings') }}">Ustawienia</a></li>
+                        <li><a class="dropdown-item" href="{{ url_for('settings_page') }}">Ustawienia</a></li>
                         <li><a class="dropdown-item" href="{{ url_for('agent_logs') }}">Logi</a></li>
                         <li><a class="dropdown-item" href="{{ url_for('test_print') }}">Testuj drukarkę</a></li>
                     </ul>
@@ -58,7 +58,7 @@
             <li class="nav-item dropdown">
                 <a class="nav-link dropdown-toggle text-white" href="#" id="mobileSettingsDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">Ustawienia</a>
                 <ul class="dropdown-menu dropdown-menu-dark">
-                    <li><a class="dropdown-item" href="{{ url_for('settings') }}">Ustawienia</a></li>
+                    <li><a class="dropdown-item" href="{{ url_for('settings_page') }}">Ustawienia</a></li>
                     <li><a class="dropdown-item" href="{{ url_for('agent_logs') }}">Logi</a></li>
                     <li><a class="dropdown-item" href="{{ url_for('test_print') }}">Testuj drukarkę</a></li>
                 </ul>


### PR DESCRIPTION
## Summary
- rename the `/settings` view function to `settings_page` to avoid masking the
  configuration object
- update navigation templates to reference the new endpoint

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'magazyn')*

------
https://chatgpt.com/codex/tasks/task_e_685fdc2f8a20832abe217cd4d195d719