### PR TITLE
Improve PDF invoice parsing with column detection

### DIFF
--- a/magazyn/tests/data/sample_invalid.pdf
+++ b/magazyn/tests/data/sample_invalid.pdf
@@ -1,0 +1,68 @@
+%PDF-1.3
+% ReportLab Generated PDF document http://www.reportlab.com
+1 0 obj
+<<
+/F1 2 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/Contents 7 0 R /MediaBox [ 0 0 612 792 ] /Parent 6 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+4 0 obj
+<<
+/PageMode /UseNone /Pages 6 0 R /Type /Catalog
+>>
+endobj
+5 0 obj
+<<
+/Author (anonymous) /CreationDate (D:20250628144424+00'00') /Creator (ReportLab PDF Library - www.reportlab.com) /Keywords () /ModDate (D:20250628144424+00'00') /Producer (ReportLab PDF Library - www.reportlab.com) 
+  /Subject (unspecified) /Title (untitled) /Trapped /False
+>>
+endobj
+6 0 obj
+<<
+/Count 1 /Kids [ 3 0 R ] /Type /Pages
+>>
+endobj
+7 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 206
+>>
+stream
+Gas3-0akiP&;K/W^Z$3_U#ogBZ[tqP.c/NPC;^Ia:ue4`hIpi+@R@R5a2@E[P^i?$CC;[2dku\5p]Saf$s[2ZM;OND>[d&U/OnKI2.Q+Z4S_9hT_?VdTOn;6F-$>L)kaKPlG0O2d_0+2F""ZoGctBu:NTSOOZGchdO'WHW`6K&okJJ`h:Zn4/:j9]PRr^?$-BrOOLtQM=_e!~>endstream
+endobj
+xref
+0 8
+0000000000 65535 f 
+0000000073 00000 n 
+0000000104 00000 n 
+0000000211 00000 n 
+0000000404 00000 n 
+0000000472 00000 n 
+0000000768 00000 n 
+0000000827 00000 n 
+trailer
+<<
+/ID 
+[<f954e577eeccb632a4811de5ec72b6ea><f954e577eeccb632a4811de5ec72b6ea>]
+% ReportLab generated PDF document -- digest (http://www.reportlab.com)
+
+/Info 5 0 R
+/Root 4 0 R
+/Size 8
+>>
+startxref
+1123
+%%EOF

--- a/magazyn/tests/data/sample_invoice.pdf
+++ b/magazyn/tests/data/sample_invoice.pdf
@@ -1,0 +1,68 @@
+%PDF-1.3
+% ReportLab Generated PDF document http://www.reportlab.com
+1 0 obj
+<<
+/F1 2 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/Contents 7 0 R /MediaBox [ 0 0 612 792 ] /Parent 6 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+4 0 obj
+<<
+/PageMode /UseNone /Pages 6 0 R /Type /Catalog
+>>
+endobj
+5 0 obj
+<<
+/Author (anonymous) /CreationDate (D:20250628144222+00'00') /Creator (ReportLab PDF Library - www.reportlab.com) /Keywords () /ModDate (D:20250628144222+00'00') /Producer (ReportLab PDF Library - www.reportlab.com) 
+  /Subject (unspecified) /Title (untitled) /Trapped /False
+>>
+endobj
+6 0 obj
+<<
+/Count 1 /Kids [ 3 0 R ] /Type /Pages
+>>
+endobj
+7 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 246
+>>
+stream
+Gas309acP,*67T]YMsc-%^sW;gsmJ0+Ao[:f3p!1.]A\[oiY$.dDjfKIm/fE)[.)prL@!o_ue+&"_A6(:uCph&o<7Xbc.<;_.qVs_X&DGHk(.O=Ss;=WO.$kPc(KZs7hY&%3=1Y1YhY(CfG%MelXl:\$RT18M"Gq0M@`V+a5q*GEGa>RK@ihep5kMaqRT&@>[lSQm.L!KG_VDkSk<#=!Y('/0?omgS7K_1Ug((ibkEu_0H'\nr,[~>endstream
+endobj
+xref
+0 8
+0000000000 65535 f 
+0000000073 00000 n 
+0000000104 00000 n 
+0000000211 00000 n 
+0000000404 00000 n 
+0000000472 00000 n 
+0000000768 00000 n 
+0000000827 00000 n 
+trailer
+<<
+/ID 
+[<f6c89cdc9e1fef1b3794fe2e6f068276><f6c89cdc9e1fef1b3794fe2e6f068276>]
+% ReportLab generated PDF document -- digest (http://www.reportlab.com)
+
+/Info 5 0 R
+/Root 4 0 R
+/Size 8
+>>
+startxref
+1163
+%%EOF


### PR DESCRIPTION
## Summary
- enhance `_parse_pdf` to group text by coordinates and detect column boundaries
- validate sizes against `ALL_SIZES` and log when skipping invalid rows
- add regression tests that parse real PDF invoices

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ffe90b458832a91f13498d0847cee