### PR TITLE
Enhance PDF invoice parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,14 @@ Running a newer version of the application on an older database file will
 automatically add missing columns (for example the `barcode` column in the
 `product_sizes` table) during startup.
 
+## Importing invoices
+
+The **Import faktury** page accepts Excel or PDF invoices. PDF files produced
+by the Tip-Top accounting software are recognised automatically. The parser
+handles values written with spaces as thousand separators and extracts product
+barcodes from lines containing "Kod kreskowy". When a barcode is found, it is
+used to match existing items during import.
+
 ## Responsive tables
 
 Product lists are displayed inside Bootstrap's `.table-responsive` wrapper.

--- a/magazyn/tests/test_pdf_tiptop.py
+++ b/magazyn/tests/test_pdf_tiptop.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+from magazyn.services import _parse_pdf
+
+
+def test_parse_tiptop_invoice():
+    pdf_path = Path('magazyn/samples/sample_invoice.pdf')
+    with pdf_path.open('rb') as fh:
+        df = _parse_pdf(fh)
+
+    assert len(df) == 10
+    first = df.iloc[0]
+    assert first['Nazwa'].startswith('Szelki dla psa Truelove Front Line Premium')
+    assert first['Rozmiar'] == 'XL'
+    assert first['Ilość'] == 5
+    assert first['Barcode'] == '6971818794853'
+    assert abs(first['Cena'] - 134.33) < 0.01
+
+    other = df[df['Nazwa'].str.contains('Pas samochodowy')].iloc[0]
+    assert other['Rozmiar'] == ''
+    assert other['Ilość'] == 10
+    assert other['Barcode'] == '6976128181720'
+    assert abs(other['Cena'] - 53.33) < 0.01


### PR DESCRIPTION
## Summary
- support Tip-Top PDF invoices
- recognise barcodes during PDF import
- document invoice import behaviour
- test the new parser

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686006f37f50832a9e182b8699848237