### PR TITLE
Add invoice review step

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,10 @@ handles values written with spaces as thousand separators and extracts product
 barcodes from lines containing "Kod kreskowy". When a barcode is found, it is
 used to match existing items during import.
 
+After uploading a file the application shows a preview of the parsed rows.
+You can adjust quantities or other fields and deselect unwanted entries
+before confirming the import.
+
 ## Responsive tables
 
 Product lists are displayed inside Bootstrap's `.table-responsive` wrapper.

--- a/magazyn/services.py
+++ b/magazyn/services.py
@@ -351,17 +351,8 @@ def _parse_pdf(file) -> pd.DataFrame:
     return _parse_simple_pdf(file_obj)
 
 
-def import_invoice_file(file):
-    """Parse uploaded invoice (Excel or PDF) and record purchases."""
-    filename = file.filename or ""
-    ext = filename.rsplit(".", 1)[-1].lower()
-    if ext in {"xlsx", "xls"}:
-        df = pd.read_excel(file)
-    elif ext == "pdf":
-        df = _parse_pdf(file)
-    else:
-        raise ValueError("Nieobsługiwany format pliku")
-
+def _import_invoice_df(df: pd.DataFrame):
+    """Record purchases using rows from a DataFrame."""
     for _, row in df.iterrows():
         name = row.get("Nazwa")
         color = row.get("Kolor", "")
@@ -405,4 +396,24 @@ def import_invoice_file(file):
                 )
             )
             ps.quantity += quantity
+
+
+def import_invoice_rows(rows: List[Dict]):
+    """Record purchases from a list of row dictionaries."""
+    df = pd.DataFrame(rows)
+    _import_invoice_df(df)
+
+
+def import_invoice_file(file):
+    """Parse uploaded invoice (Excel or PDF) and record purchases."""
+    filename = file.filename or ""
+    ext = filename.rsplit(".", 1)[-1].lower()
+    if ext in {"xlsx", "xls"}:
+        df = pd.read_excel(file)
+    elif ext == "pdf":
+        df = _parse_pdf(file)
+    else:
+        raise ValueError("Nieobsługiwany format pliku")
+
+    _import_invoice_df(df)
 

--- a/magazyn/templates/review_invoice.html
+++ b/magazyn/templates/review_invoice.html
@@ -1,0 +1,41 @@
+{% extends "base.html" %}
+{% block content %}
+<h2 class="mb-3 text-center">Potwierdź pozycje faktury</h2>
+{% if pdf_url %}
+<embed src="{{ pdf_url }}" type="application/pdf" width="100%" height="600">
+{% endif %}
+<form action="{{ url_for('products.confirm_invoice') }}" method="post" class="mt-3">
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+    <div class="table-responsive">
+    <table class="table table-sm table-dark align-middle">
+        <thead>
+            <tr>
+                <th>Akceptuj</th>
+                <th>Nazwa</th>
+                <th>Kolor</th>
+                <th>Rozmiar</th>
+                <th>Ilość</th>
+                <th>Cena</th>
+                <th>Barcode</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for row in rows %}
+            <tr>
+                <td><input type="checkbox" name="accept_{{ loop.index0 }}" checked></td>
+                <td><input type="text" name="name_{{ loop.index0 }}" value="{{ row['Nazwa'] }}" class="form-control"></td>
+                <td><input type="text" name="color_{{ loop.index0 }}" value="{{ row['Kolor'] }}" class="form-control"></td>
+                <td><input type="text" name="size_{{ loop.index0 }}" value="{{ row['Rozmiar'] }}" class="form-control"></td>
+                <td><input type="text" name="quantity_{{ loop.index0 }}" value="{{ row['Ilość'] }}" class="form-control"></td>
+                <td><input type="text" name="price_{{ loop.index0 }}" value="{{ row['Cena'] }}" class="form-control"></td>
+                <td><input type="text" name="barcode_{{ loop.index0 }}" value="{{ row['Barcode'] or '' }}" class="form-control"></td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+    </div>
+    <div class="form-actions text-center">
+        <button type="submit" class="btn btn-primary">Potwierdź</button>
+    </div>
+</form>
+{% endblock %}


### PR DESCRIPTION
## Summary
- allow reviewing parsed invoice rows before confirming
- parse invoice uploads without importing immediately
- add `/confirm_invoice` route and HTML form
- implement helper functions for importing invoice rows
- document new invoice confirmation step
- update tests for new workflow

## Testing
- `pip install -r magazyn/requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68602b4b775c832a98f5d0a33964195b