### PR TITLE
Handle init_db flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,15 +92,16 @@ to that location.
 
 The project now uses SQLAlchemy for all database interactions. Existing
 SQLite databases remain compatible with the new ORM models. When upgrading,
-install the updated requirements and run `init_db` once to create any missing
-tables:
+install the updated requirements and initialise the database once using the
+new command:
 
 ```bash
 pip install -r magazyn/requirements.txt
 python -m magazyn.app init_db
 ```
 
-No data is removed during this step. The application can then be started as
+The `init_db` argument runs the database initialisation and exits without
+starting the server. No data is removed during this step. The application can then be started as
 before using the same database file.
 
 Running a newer version of the application on an older database file will

--- a/magazyn/app.py
+++ b/magazyn/app.py
@@ -11,6 +11,7 @@ from flask import (
 from flask_wtf import CSRFProtect
 from datetime import datetime
 import os
+import sys
 from werkzeug.security import check_password_hash
 from dotenv import dotenv_values
 from collections import OrderedDict
@@ -261,5 +262,8 @@ def handle_500(error):
 
 
 if __name__ == "__main__":
-    ensure_db_initialized()
-    app.run(host="0.0.0.0", port=80, debug=settings.FLASK_DEBUG)
+    if len(sys.argv) > 1 and sys.argv[1] == "init_db":
+        init_db()
+    else:
+        ensure_db_initialized()
+        app.run(host="0.0.0.0", port=80, debug=settings.FLASK_DEBUG)


### PR DESCRIPTION
## Summary
- parse `sys.argv` for `init_db` flag in `magazyn/app.py`
- document the command behaviour in the README

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686030dc5ba0832a8fc324f3bd9503f9