### PR TITLE
Remove unused HTTP server config

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,6 @@ This repository contains the code for the RetrieverShop warehouse application an
 | `SECRET_KEY` | Secret key for Flask sessions |
 | `FLASK_DEBUG` | Set to `1` to enable Flask debug mode |
 | `FLASK_ENV` | Flask configuration environment |
-| `ENABLE_HTTP_SERVER` | Set to `1` to start the HTTP server |
-| `HTTP_PORT` | Port used by the HTTP server |
 
 ## Modifying settings via the web interface
 

--- a/magazyn/app.py
+++ b/magazyn/app.py
@@ -104,6 +104,10 @@ def load_settings():
         if key not in values:
             values[key] = val
 
+    # remove deprecated/unused keys
+    for hidden in ("ENABLE_HTTP_SERVER", "HTTP_PORT"):
+        values.pop(hidden, None)
+
     return values
 
 

--- a/magazyn/env_info.py
+++ b/magazyn/env_info.py
@@ -44,9 +44,4 @@ ENV_INFO = {
         "Ustaw 1 aby włączyć tryb debugowania Flask",
     ),
     "FLASK_ENV": ("Środowisko Flask", "Konfiguracja środowiska Flask"),
-    "ENABLE_HTTP_SERVER": (
-        "Włącz serwer HTTP",
-        "Ustaw 1 aby uruchomić serwer HTTP",
-    ),
-    "HTTP_PORT": ("Port HTTP", "Port używany przez serwer HTTP"),
 }


### PR DESCRIPTION
## Summary
- drop `ENABLE_HTTP_SERVER` and `HTTP_PORT` from environment info
- remove HTTP server variables from docs
- hide deprecated variables when loading settings

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68603302fbb4832abdc0feb23b92df93