### PR TITLE
Improve call_api error handling

### DIFF
--- a/magazyn/print_agent.py
+++ b/magazyn/print_agent.py
@@ -294,8 +294,11 @@ def call_api(method, parameters=None):
     try:
         payload = {"method": method, "parameters": json.dumps(parameters)}
         response = requests.post(BASE_URL, headers=HEADERS, data=payload, timeout=10)
+        response.raise_for_status()
         logger.info(f"[{method}] {response.status_code}")
         return response.json()
+    except requests.exceptions.HTTPError as e:
+        logger.error(f"HTTP error in call_api({method}): {e}")
     except requests.exceptions.RequestException as e:
         logger.error(f"Request error in call_api({method}): {e}")
     except Exception as e:

--- a/magazyn/tests/test_utils.py
+++ b/magazyn/tests/test_utils.py
@@ -150,3 +150,19 @@ def test_load_queue_handles_corrupted_json(tmp_path, monkeypatch):
     conn.close()
     items = bl.load_queue()
     assert items[0]["last_order_data"] == {}
+
+
+def test_call_api_handles_http_error(monkeypatch):
+    class DummyResp:
+        status_code = 500
+
+        def json(self):
+            return {"error": "x"}
+
+        def raise_for_status(self):
+            raise bl.requests.HTTPError("500")
+
+    monkeypatch.setattr(bl.requests, "post", lambda *a, **k: DummyResp())
+
+    result = bl.call_api("dummy")
+    assert result == {}


### PR DESCRIPTION
## Summary
- raise for HTTP errors when calling the Baselinker API
- log HTTP errors specifically
- test call_api handling of non-200 responses

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860366f2934832aaae0b901c72ec0d9