### PR TITLE
Add product size mapping for invoice import

### DIFF
--- a/magazyn/services.py
+++ b/magazyn/services.py
@@ -158,6 +158,22 @@ def export_rows():
     return rows
 
 
+def get_product_sizes():
+    """Return all product sizes joined with product information."""
+    with get_session() as db:
+        return (
+            db.query(
+                ProductSize.id.label("ps_id"),
+                Product.id.label("product_id"),
+                Product.name,
+                Product.color,
+                ProductSize.size,
+            )
+            .join(Product, ProductSize.product_id == Product.id)
+            .all()
+        )
+
+
 def import_from_dataframe(df: pd.DataFrame):
     """Import products from a pandas DataFrame."""
     with get_session() as db:

--- a/magazyn/templates/review_invoice.html
+++ b/magazyn/templates/review_invoice.html
@@ -17,6 +17,7 @@
                 <th>Ilość</th>
                 <th>Cena</th>
                 <th>Barcode</th>
+                <th>Produkt z bazy</th>
             </tr>
         </thead>
         <tbody>
@@ -29,6 +30,14 @@
                 <td><input type="text" name="quantity_{{ loop.index0 }}" value="{{ row['Ilość'] }}" class="form-control"></td>
                 <td><input type="text" name="price_{{ loop.index0 }}" value="{{ row['Cena'] }}" class="form-control"></td>
                 <td><input type="text" name="barcode_{{ loop.index0 }}" value="{{ row['Barcode'] or '' }}" class="form-control"></td>
+                <td>
+                    <select name="ps_id_{{ loop.index0 }}" class="form-select">
+                        <option value=""></option>
+                        {% for ps in product_sizes %}
+                        <option value="{{ ps['ps_id'] }}">{{ ps['name'] }} ({{ ps['color'] }}) {{ ps['size'] }}</option>
+                        {% endfor %}
+                    </select>
+                </td>
             </tr>
             {% endfor %}
         </tbody>


### PR DESCRIPTION
## Summary
- fetch product-size details for invoice review
- show select list of existing products when reviewing invoice
- update confirm-invoice logic to reuse stock records
- test that linking an invoice row updates stock and avoids duplicates

## Testing
- `pip install -q -r magazyn/requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68603aa6055c832a862dff9f83403a9e