### PR TITLE
Update logger on config reload

### DIFF
--- a/magazyn/print_agent.py
+++ b/magazyn/print_agent.py
@@ -81,10 +81,23 @@ def reload_env():
     QUIET_HOURS_END = parse_time_str(settings.QUIET_HOURS_END)
     TIMEZONE = settings.TIMEZONE
     PRINTED_EXPIRY_DAYS = settings.PRINTED_EXPIRY_DAYS
+    old_log_file = LOG_FILE
     LOG_LEVEL = settings.LOG_LEVEL
     LOG_FILE = settings.LOG_FILE
     DB_FILE = settings.DB_PATH
     HEADERS["X-BLToken"] = API_TOKEN
+
+    logger.setLevel(getattr(logging, LOG_LEVEL, logging.INFO))
+    if old_log_file != LOG_FILE:
+        root_logger = logging.getLogger()
+        formatter = logging.Formatter("%(asctime)s [%(levelname)s] %(message)s")
+        for h in list(root_logger.handlers):
+            if isinstance(h, logging.FileHandler):
+                root_logger.removeHandler(h)
+                h.close()
+        file_handler = logging.FileHandler(LOG_FILE)
+        file_handler.setFormatter(formatter)
+        root_logger.addHandler(file_handler)
 
 
 def reload_config():

--- a/magazyn/tests/test_logging.py
+++ b/magazyn/tests/test_logging.py
@@ -1,0 +1,18 @@
+import importlib
+import logging
+from types import SimpleNamespace
+
+import magazyn.print_agent as pa
+
+
+def test_reload_config_updates_logger_level(monkeypatch):
+    new_settings = SimpleNamespace(**vars(pa.settings))
+    new_settings.LOG_LEVEL = "DEBUG"
+    monkeypatch.setattr(pa, "load_config", lambda: new_settings)
+
+    pa.reload_config()
+    assert pa.logger.level == logging.DEBUG
+
+    # restore original configuration
+    monkeypatch.setattr(pa, "load_config", importlib.import_module("magazyn.config").load_config)
+    pa.reload_config()


### PR DESCRIPTION
## Summary
- adjust `reload_env` to update logger level and log file
- test that `reload_config()` applies a new log level

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686067692434832abc750b202c7e870a