### PR TITLE
Add stoppable agent thread

### DIFF
--- a/magazyn/app.py
+++ b/magazyn/app.py
@@ -12,6 +12,7 @@ from flask_wtf import CSRFProtect
 from datetime import datetime
 import os
 import sys
+import atexit
 from werkzeug.security import check_password_hash
 from dotenv import dotenv_values
 from collections import OrderedDict
@@ -155,6 +156,7 @@ def ensure_db_initialized():
 
 
 start_print_agent()
+atexit.register(print_agent.stop_agent_thread)
 
 ensure_db_initialized()
 

--- a/magazyn/tests/test_agent_thread.py
+++ b/magazyn/tests/test_agent_thread.py
@@ -1,0 +1,20 @@
+import time
+import threading
+import importlib
+import magazyn.print_agent as pa
+
+
+def test_stop_agent_thread_stops(monkeypatch):
+    started = threading.Event()
+
+    def loop():
+        started.set()
+        while not pa._stop_event.is_set():
+            time.sleep(0.01)
+
+    monkeypatch.setattr(pa, "_agent_loop", loop)
+    pa.start_agent_thread()
+    assert started.wait(1)
+    assert pa._agent_thread.is_alive()
+    pa.stop_agent_thread()
+    assert pa._agent_thread is None or not pa._agent_thread.is_alive()


### PR DESCRIPTION
## Summary
- implement a `_stop_event` for the printer agent thread
- make the agent loop exit when the event is set
- expose `stop_agent_thread()` to stop and join the thread
- register thread shutdown via `atexit` in the Flask app
- test that the thread stops on request

## Testing
- `PYTHONPATH=$PWD pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68606d766b34832ab7ff1278878da658