### PR TITLE
Allow DB engine reconfiguration

### DIFF
--- a/magazyn/db.py
+++ b/magazyn/db.py
@@ -9,8 +9,18 @@ from werkzeug.security import generate_password_hash
 from . import DB_PATH
 from .models import Base, User, ProductSize, PurchaseBatch
 
-engine = create_engine(f"sqlite:///{DB_PATH}", future=True)
-SessionLocal = sessionmaker(bind=engine, autoflush=False)
+engine = None
+SessionLocal = None
+
+
+def configure_engine(db_path):
+    """Create SQLAlchemy engine and session factory for ``db_path``."""
+    global engine, SessionLocal
+    engine = create_engine(f"sqlite:///{db_path}", future=True)
+    SessionLocal = sessionmaker(bind=engine, autoflush=False)
+
+
+configure_engine(DB_PATH)
 logger = logging.getLogger(__name__)
 
 

--- a/magazyn/print_agent.py
+++ b/magazyn/print_agent.py
@@ -87,6 +87,9 @@ def reload_env():
     DB_FILE = settings.DB_PATH
     HEADERS["X-BLToken"] = API_TOKEN
 
+    from . import db
+    db.configure_engine(DB_FILE)
+
     logger.setLevel(getattr(logging, LOG_LEVEL, logging.INFO))
     if old_log_file != LOG_FILE:
         root_logger = logging.getLogger()

--- a/magazyn/tests/conftest.py
+++ b/magazyn/tests/conftest.py
@@ -20,6 +20,7 @@ def app_mod(tmp_path, monkeypatch):
     import magazyn.app as app_mod
     importlib.reload(app_mod)
     import magazyn.db as db_mod
+    db_mod.configure_engine(cfg.settings.DB_PATH)
     from sqlalchemy.orm import sessionmaker
     db_mod.SessionLocal = sessionmaker(bind=db_mod.engine, autoflush=False, expire_on_commit=False)
     app_mod.app.config["WTF_CSRF_ENABLED"] = False

--- a/magazyn/tests/test_db_config.py
+++ b/magazyn/tests/test_db_config.py
@@ -1,0 +1,33 @@
+import sqlite3
+from types import SimpleNamespace
+from werkzeug.security import generate_password_hash
+
+import magazyn.db as db
+import magazyn.print_agent as pa
+from magazyn.models import User
+
+
+def test_reload_env_reconfigures_engine(tmp_path, monkeypatch):
+    first = tmp_path / "first.db"
+    db.configure_engine(str(first))
+    db.init_db()
+    with db.get_session() as session:
+        session.add(User(username="u1", password=generate_password_hash("p")))
+
+    second = tmp_path / "second.db"
+    new_settings = SimpleNamespace(**vars(pa.settings))
+    new_settings.DB_PATH = str(second)
+    monkeypatch.setattr(pa, "load_config", lambda: new_settings)
+
+    pa.reload_config()
+
+    db.init_db()
+    with db.get_session() as session:
+        session.add(User(username="u2", password=generate_password_hash("p")))
+
+    conn1 = sqlite3.connect(first)
+    conn2 = sqlite3.connect(second)
+    assert conn1.execute("SELECT username FROM users").fetchall() == [("u1",)]
+    assert conn2.execute("SELECT username FROM users").fetchall() == [("u2",)]
+    conn1.close()
+    conn2.close()


### PR DESCRIPTION
## Summary
- refactor DB engine creation into `configure_engine`
- reload SQLAlchemy engine when print agent env changes
- update tests to call `configure_engine`
- test reconfiguration of DB_PATH at runtime

## Testing
- `pip install -r magazyn/requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68606ef446ec832abd1cd4032406b1ed