### PR TITLE
Handle print-agent config errors

### DIFF
--- a/magazyn/app.py
+++ b/magazyn/app.py
@@ -77,6 +77,8 @@ def start_print_agent():
         print_agent.validate_env()
         print_agent.ensure_db_init()
         print_agent.start_agent_thread()
+    except print_agent.ConfigError as e:
+        app.logger.error(f"Failed to start print agent: {e}")
     except Exception as e:
         app.logger.error(f"Failed to start print agent: {e}")
 

--- a/magazyn/print_agent.py
+++ b/magazyn/print_agent.py
@@ -11,6 +11,11 @@ from zoneinfo import ZoneInfo
 import requests
 
 
+class ConfigError(Exception):
+    """Raised when required configuration is missing."""
+
+
+
 def parse_time_str(value: str) -> dt_time:
     """Return a ``datetime.time`` from ``HH:MM`` string or raise ``ValueError``."""
     try:
@@ -122,8 +127,12 @@ def validate_env():
     }
     missing = [name for name, value in required.items() if not value]
     if missing:
-        logger.error("Brak wymaganych zmiennych środowiskowych: %s", ", ".join(missing))
-        raise SystemExit(1)
+        logger.error(
+            "Brak wymaganych zmiennych środowiskowych: %s", ", ".join(missing)
+        )
+        raise ConfigError(
+            "Missing environment variables: " + ", ".join(missing)
+        )
 
 
 def ensure_db():

--- a/magazyn/tests/test_app_no_agent.py
+++ b/magazyn/tests/test_app_no_agent.py
@@ -1,0 +1,40 @@
+import importlib
+import sys
+import magazyn.config as cfg
+
+
+def setup_app_missing_agent(tmp_path, monkeypatch):
+    monkeypatch.setattr(cfg.settings, "DB_PATH", ":memory:")
+    monkeypatch.setattr(cfg.settings, "API_TOKEN", "")
+    monkeypatch.setattr(cfg.settings, "PAGE_ACCESS_TOKEN", "")
+    monkeypatch.setattr(cfg.settings, "RECIPIENT_ID", "")
+
+    import werkzeug
+    monkeypatch.setattr(werkzeug, "__version__", "0", raising=False)
+
+    init = importlib.import_module("magazyn.__init__")
+    importlib.reload(init)
+    monkeypatch.setitem(sys.modules, "__init__", init)
+
+    pa = importlib.import_module("magazyn.print_agent")
+    pa = importlib.reload(pa)
+    monkeypatch.setitem(sys.modules, "print_agent", pa)
+    monkeypatch.setattr(pa, "start_agent_thread", lambda: None)
+    monkeypatch.setattr(pa, "ensure_db_init", lambda: None)
+
+    import magazyn.app as app_mod
+    importlib.reload(app_mod)
+    import magazyn.db as db_mod
+    db_mod.configure_engine(cfg.settings.DB_PATH)
+    from sqlalchemy.orm import sessionmaker
+    db_mod.SessionLocal = sessionmaker(bind=db_mod.engine, autoflush=False, expire_on_commit=False)
+    app_mod.app.config["WTF_CSRF_ENABLED"] = False
+    app_mod.reset_db()
+    return app_mod
+
+
+def test_app_response_without_agent(tmp_path, monkeypatch):
+    app_mod = setup_app_missing_agent(tmp_path, monkeypatch)
+    client = app_mod.app.test_client()
+    resp = client.get("/login")
+    assert resp.status_code == 200

--- a/magazyn/tests/test_utils.py
+++ b/magazyn/tests/test_utils.py
@@ -132,7 +132,7 @@ def test_validate_env_missing_api_token(monkeypatch):
     monkeypatch.setattr(bl, "API_TOKEN", "")
     monkeypatch.setattr(bl, "PAGE_ACCESS_TOKEN", "x")
     monkeypatch.setattr(bl, "RECIPIENT_ID", "x")
-    with pytest.raises(SystemExit):
+    with pytest.raises(bl.ConfigError):
         bl.validate_env()
 
 


### PR DESCRIPTION
## Summary
- add `ConfigError` and raise it from `validate_env`
- catch `ConfigError` when starting the print agent so Flask can start
- add regression test ensuring the app works without agent settings
- update util test for the new exception

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686072ae6bec832ab6bc335907562753