### PR TITLE
Increase navbar logo size for desktop

### DIFF
--- a/magazyn/static/styles.css
+++ b/magazyn/static/styles.css
@@ -252,8 +252,8 @@ body {
     }
 
     .mobile-menu a:hover {
-        background-color: rgba(255, 255, 255, 0.1);
-        color: #ddd;
+        background-color: rgba(255, 255, 255, 0.25);
+        color: #fff;
     }
 }
 
@@ -265,9 +265,13 @@ body {
         transition: background-color 0.2s ease, color 0.2s ease;
     }
     .navbar-nav .nav-link:hover {
-        background-color: rgba(255, 255, 255, 0.1);
-        color: #ddd;
+        background-color: rgba(255, 255, 255, 0.25);
+        color: #fff;
         text-decoration: none;
+    }
+
+    .navbar-brand img {
+        height: 70px;
     }
 
     .navbar-nav .dropdown-menu {
@@ -296,7 +300,7 @@ body {
 }
 
 .dropdown-menu .dropdown-item:hover {
-    background-color: #145360;
+    background-color: #1e6a82;
     color: #fff;
 }
 

--- a/magazyn/templates/base.html
+++ b/magazyn/templates/base.html
@@ -17,7 +17,7 @@
         <div class="container">
             <div class="d-flex flex-column flex-md-row align-items-center justify-content-between">
             <span class="navbar-brand d-flex align-items-center mb-2 mb-md-0">
-                <img src="https://retrievershop.pl/wp-content/uploads/2024/08/retriver-2.png" alt="Logo" style="height: 55px;">
+                <img src="https://retrievershop.pl/wp-content/uploads/2024/08/retriver-2.png" alt="Logo" style="height: 70px;">
                 <span class="ms-2">Witaj w aplikacji magazynowej</span>
             </span>
             {% if show_menu %}


### PR DESCRIPTION
## Summary
- enlarge navbar logo on desktop
- brighten hover colors for navigation links and dropdown items

## Testing
- `pip install -r magazyn/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860791deaa4832a80fc0673c6827040