### PR TITLE
Implement sales profit page

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,3 +33,11 @@ DB_PATH=/app/database.db
 # Web app settings
 SECRET_KEY=changeme
 FLASK_DEBUG=1
+
+# Default shipping costs
+DEFAULT_SHIPPING_ALLEGRO=10.0
+DEFAULT_SHIPPING_VINTED=8.0
+
+# Platform commission percentages
+COMMISSION_ALLEGRO=10.0
+COMMISSION_VINTED=5.0

--- a/magazyn/app.py
+++ b/magazyn/app.py
@@ -45,6 +45,7 @@ from .products import (
     add_delivery,
 )
 from .history import bp as history_bp, print_history
+from .sales import bp as sales_bp
 from .auth import login_required
 from .config import settings
 from . import print_agent
@@ -64,6 +65,7 @@ app.jinja_env.globals["ALL_SIZES"] = ALL_SIZES
 
 app.register_blueprint(products_bp)
 app.register_blueprint(history_bp)
+app.register_blueprint(sales_bp)
 
 
 @app.context_processor

--- a/magazyn/config.py
+++ b/magazyn/config.py
@@ -28,6 +28,10 @@ def load_config():
         ),
         SECRET_KEY=os.getenv("SECRET_KEY", "default_secret_key"),
         FLASK_DEBUG=os.getenv("FLASK_DEBUG") == "1",
+        DEFAULT_SHIPPING_ALLEGRO=float(os.getenv("DEFAULT_SHIPPING_ALLEGRO", "0")),
+        DEFAULT_SHIPPING_VINTED=float(os.getenv("DEFAULT_SHIPPING_VINTED", "0")),
+        COMMISSION_ALLEGRO=float(os.getenv("COMMISSION_ALLEGRO", "0")),
+        COMMISSION_VINTED=float(os.getenv("COMMISSION_VINTED", "0")),
     )
 
 

--- a/magazyn/env_info.py
+++ b/magazyn/env_info.py
@@ -43,4 +43,20 @@ ENV_INFO = {
         "Ustaw 1 aby włączyć tryb debugowania Flask",
     ),
     "FLASK_ENV": ("Środowisko Flask", "Konfiguracja środowiska Flask"),
+    "DEFAULT_SHIPPING_ALLEGRO": (
+        "Wysyłka Allegro",
+        "Domyślny koszt wysyłki dla platformy Allegro",
+    ),
+    "DEFAULT_SHIPPING_VINTED": (
+        "Wysyłka Vinted",
+        "Domyślny koszt wysyłki dla platformy Vinted",
+    ),
+    "COMMISSION_ALLEGRO": (
+        "Prowizja Allegro (%)",
+        "Procent prowizji pobieranej przez Allegro",
+    ),
+    "COMMISSION_VINTED": (
+        "Prowizja Vinted (%)",
+        "Procent prowizji pobieranej przez Vinted",
+    ),
 }

--- a/magazyn/sales.py
+++ b/magazyn/sales.py
@@ -1,0 +1,41 @@
+from flask import Blueprint, render_template, request
+from .auth import login_required
+from .config import settings
+
+bp = Blueprint('sales', __name__)
+
+PLATFORMS = {
+    'allegro': {
+        'shipping': settings.DEFAULT_SHIPPING_ALLEGRO,
+        'commission': settings.COMMISSION_ALLEGRO,
+    },
+    'vinted': {
+        'shipping': settings.DEFAULT_SHIPPING_VINTED,
+        'commission': settings.COMMISSION_VINTED,
+    },
+}
+
+@bp.route('/sales', methods=['GET', 'POST'])
+@login_required
+def sales_page():
+    platform = request.form.get('platform', 'allegro')
+    config = PLATFORMS.get(platform, {'shipping': 0.0, 'commission': 0.0})
+    price = request.form.get('price', '')
+    shipping = float(request.form.get('shipping', config['shipping'] or 0))
+    commission = float(request.form.get('commission', config['commission'] or 0))
+    result = None
+    if request.method == 'POST':
+        try:
+            price_val = float(price)
+            result = round(price_val - shipping - price_val * commission / 100, 2)
+        except ValueError:
+            result = None
+    return render_template(
+        'sales.html',
+        platforms=PLATFORMS.keys(),
+        platform=platform,
+        price=price,
+        shipping=shipping,
+        commission=commission,
+        result=result,
+    )

--- a/magazyn/templates/base.html
+++ b/magazyn/templates/base.html
@@ -27,6 +27,7 @@
                 <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('products.add_item') }}">Dodaj przedmiot</a></li>
                 <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('products.items') }}">Przedmioty</a></li>
                 <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('products.add_delivery') }}">Dostawy</a></li>
+                <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('sales.sales_page') }}">Sprzedaż</a></li>
                 <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('history.print_history') }}">Historia drukowania</a></li>
                 <li class="nav-item dropdown">
                     <a class="nav-link dropdown-toggle text-white" href="#" id="navbarSettings" role="button" aria-expanded="false">
@@ -60,6 +61,7 @@
             <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('products.add_item') }}">Dodaj przedmiot</a></li>
             <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('products.items') }}">Przedmioty</a></li>
             <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('products.add_delivery') }}">Dostawy</a></li>
+            <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('sales.sales_page') }}">Sprzedaż</a></li>
             <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('history.print_history') }}">Historia drukowania</a></li>
             <li class="nav-item dropdown">
                 <a class="nav-link dropdown-toggle text-white" href="#" id="mobileSettingsDropdown" role="button" aria-expanded="false">Ustawienia</a>

--- a/magazyn/templates/sales.html
+++ b/magazyn/templates/sales.html
@@ -1,0 +1,33 @@
+{% extends "base.html" %}
+{% block content %}
+<h2 class="mb-3 text-center">Sprzedaż</h2>
+<form method="post" class="row row-cols-1 row-cols-md-2 g-3 center-form mx-auto">
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+    <div class="col">
+        <label for="platform" class="form-label">Platforma</label>
+        <select id="platform" name="platform" class="form-select">
+            {% for p in platforms %}
+            <option value="{{ p }}" {% if p == platform %}selected{% endif %}>{{ p|capitalize }}</option>
+            {% endfor %}
+        </select>
+    </div>
+    <div class="col">
+        <label for="price" class="form-label">Cena sprzedaży</label>
+        <input type="number" step="0.01" class="form-control" id="price" name="price" value="{{ price }}">
+    </div>
+    <div class="col">
+        <label for="shipping" class="form-label">Koszt wysyłki</label>
+        <input type="number" step="0.01" class="form-control" id="shipping" name="shipping" value="{{ shipping }}">
+    </div>
+    <div class="col">
+        <label for="commission" class="form-label">Prowizja (%)</label>
+        <input type="number" step="0.01" class="form-control" id="commission" name="commission" value="{{ commission }}">
+    </div>
+    <div class="col-12 form-actions text-center">
+        <button type="submit" class="btn btn-primary">Oblicz</button>
+    </div>
+</form>
+{% if result is not none %}
+<div class="alert alert-info mt-4 text-center">Zysk: {{ result }}</div>
+{% endif %}
+{% endblock %}

--- a/magazyn/templates/settings.html
+++ b/magazyn/templates/settings.html
@@ -20,7 +20,12 @@
                 {% if item.label != item.key %}<br><small class="text-muted">{{ item.key }}</small>{% endif %}
             </th>
             <td>
+                {% set lower = item.key.lower() %}
+                {% if 'shipping' in lower or 'commission' in lower %}
+                <input type="number" step="0.01" class="form-control" id="{{ item.key }}" name="{{ item.key }}" value="{{ item.value }}">
+                {% else %}
                 <input type="text" class="form-control" id="{{ item.key }}" name="{{ item.key }}" value="{{ item.value }}">
+                {% endif %}
             </td>
         </tr>
         {% endfor %}

--- a/magazyn/tests/conftest.py
+++ b/magazyn/tests/conftest.py
@@ -7,6 +7,12 @@ import magazyn.config as cfg
 @pytest.fixture
 def app_mod(tmp_path, monkeypatch):
     monkeypatch.setattr(cfg.settings, "DB_PATH", ":memory:")
+    monkeypatch.setattr(cfg.settings, "DEFAULT_SHIPPING_ALLEGRO", 8.0)
+    monkeypatch.setattr(cfg.settings, "DEFAULT_SHIPPING_VINTED", 7.0)
+    monkeypatch.setattr(cfg.settings, "COMMISSION_ALLEGRO", 10.0)
+    monkeypatch.setattr(cfg.settings, "COMMISSION_VINTED", 5.0)
+    import magazyn.sales as sales_mod
+    importlib.reload(sales_mod)
     import werkzeug
     monkeypatch.setattr(werkzeug, "__version__", "0", raising=False)
     init = importlib.import_module("magazyn.__init__")

--- a/magazyn/tests/test_sales.py
+++ b/magazyn/tests/test_sales.py
@@ -1,0 +1,15 @@
+from magazyn.app import app
+
+
+def test_sales_get(app_mod, client, login):
+    resp = client.get('/sales')
+    assert resp.status_code == 200
+    html = resp.get_data(as_text=True)
+    assert 'Sprzedaż' in html
+
+
+def test_sales_profit_calculation(app_mod, client, login):
+    resp = client.post('/sales', data={'platform': 'allegro', 'price': '100'})
+    assert resp.status_code == 200
+    html = resp.get_data(as_text=True)
+    assert '82.0' in html


### PR DESCRIPTION
## Summary
- add shipping/commission env info and defaults
- allow editing numeric shipping/commission in settings
- implement `/sales` page calculating profit
- link new page in navigation
- tests for sales profit page

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68611d046604832a91f2eedab867e5ea