### PR TITLE
Add sales list link to navigation

### DIFF
--- a/magazyn/sales.py
+++ b/magazyn/sales.py
@@ -15,7 +15,14 @@ PLATFORMS = {
     },
 }
 
-@bp.route('/sales', methods=['GET', 'POST'])
+
+@bp.route('/sales')
+@login_required
+def list_sales():
+    """Placeholder page listing sales."""
+    return 'Sales list'
+
+@bp.route('/sales/profit', methods=['GET', 'POST'])
 @login_required
 def sales_page():
     platform = request.form.get('platform', 'allegro')

--- a/magazyn/templates/base.html
+++ b/magazyn/templates/base.html
@@ -27,6 +27,7 @@
                 <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('products.add_item') }}">Dodaj przedmiot</a></li>
                 <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('products.items') }}">Przedmioty</a></li>
                 <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('products.add_delivery') }}">Dostawy</a></li>
+                <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('sales.list_sales') }}">Sprzedaż</a></li>
                 <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('sales.sales_page') }}">Sprzedaż</a></li>
                 <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('history.print_history') }}">Historia drukowania</a></li>
                 <li class="nav-item dropdown">
@@ -61,6 +62,7 @@
             <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('products.add_item') }}">Dodaj przedmiot</a></li>
             <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('products.items') }}">Przedmioty</a></li>
             <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('products.add_delivery') }}">Dostawy</a></li>
+            <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('sales.list_sales') }}">Sprzedaż</a></li>
             <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('sales.sales_page') }}">Sprzedaż</a></li>
             <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('history.print_history') }}">Historia drukowania</a></li>
             <li class="nav-item dropdown">

--- a/magazyn/tests/test_base_template.py
+++ b/magazyn/tests/test_base_template.py
@@ -14,3 +14,12 @@ def test_nav_container_class(app_mod, client, login):
     nav_html = nav_match.group(1)
     assert "container-fluid" not in nav_html
     assert "class=\"container\"" in nav_html
+
+
+def test_nav_contains_sales_link(app_mod, client, login):
+    from flask import url_for
+    with app_mod.app.test_request_context():
+        sales_url = url_for('sales.list_sales')
+    resp = client.get("/")
+    html = resp.get_data(as_text=True)
+    assert f'href="{sales_url}"' in html

--- a/magazyn/tests/test_sales.py
+++ b/magazyn/tests/test_sales.py
@@ -2,14 +2,14 @@ from magazyn.app import app
 
 
 def test_sales_get(app_mod, client, login):
-    resp = client.get('/sales')
+    resp = client.get('/sales/profit')
     assert resp.status_code == 200
     html = resp.get_data(as_text=True)
     assert 'Sprzedaż' in html
 
 
 def test_sales_profit_calculation(app_mod, client, login):
-    resp = client.post('/sales', data={'platform': 'allegro', 'price': '100'})
+    resp = client.post('/sales/profit', data={'platform': 'allegro', 'price': '100'})
     assert resp.status_code == 200
     html = resp.get_data(as_text=True)
     assert '82.0' in html


### PR DESCRIPTION
## Summary
- add a new route `sales.list_sales`
- link `/sales` from both desktop and mobile navbars
- rename profit route to `/sales/profit`
- ensure tests cover the new link

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861233048f8832ab61f3b0e2f03ee5a