### PR TITLE
Refactor navbar structure

### DIFF
--- a/magazyn/templates/base.html
+++ b/magazyn/templates/base.html
@@ -15,40 +15,42 @@
     <div class="page-wrapper">
     <nav class="navbar navbar-dark bg-dark fixed-top">
         <div class="container">
-            <div class="d-flex flex-column flex-md-row align-items-center justify-content-between">
-            <span class="navbar-brand d-flex align-items-center mb-2 mb-md-0">
-                <img src="https://retrievershop.pl/wp-content/uploads/2024/08/retriver-2.png" alt="Logo" style="height: 70px;">
-                <span class="ms-2">Witaj w aplikacji magazynowej</span>
-            </span>
-            {% if show_menu %}
-            <div class="d-flex align-items-center">
-                <ul class="navbar-nav flex-row flex-nowrap gap-3 d-none d-md-flex align-items-center">
-                <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('home') }}">Strona główna</a></li>
-                <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('products.add_item') }}">Dodaj przedmiot</a></li>
-                <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('products.items') }}">Przedmioty</a></li>
-                <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('products.add_delivery') }}">Dostawy</a></li>
-                <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('sales.list_sales') }}">Sprzedaż</a></li>
-                <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('sales.sales_page') }}">Sprzedaż</a></li>
-                <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('history.print_history') }}">Historia drukowania</a></li>
-                <li class="nav-item dropdown">
-                    <a class="nav-link dropdown-toggle text-white" href="#" id="navbarSettings" role="button" aria-expanded="false">
-                        Ustawienia
-                    </a>
-                    <ul class="dropdown-menu dropdown-menu-dark">
-                        <li><a class="dropdown-item" href="{{ url_for('settings_page') }}">Ustawienia</a></li>
-                        <li><a class="dropdown-item" href="{{ url_for('agent_logs') }}">Logi</a></li>
-                        <li><a class="dropdown-item" href="{{ url_for('test_print') }}">Testuj drukarkę</a></li>
-                    </ul>
-                </li>
-                    <li class="nav-item">
+            <div class="d-flex flex-column">
+                <div class="d-flex align-items-center justify-content-between">
+                    <span class="navbar-brand d-flex align-items-center mb-2 mb-md-0">
+                        <img src="https://retrievershop.pl/wp-content/uploads/2024/08/retriver-2.png" alt="Logo" style="height: 70px;">
+                        <span class="ms-2">Witaj w aplikacji magazynowej</span>
+                    </span>
+                    {% if show_menu %}
+                    <div class="d-flex align-items-center">
                         <a href="{{ url_for('logout') }}" class="btn btn-danger ms-md-3 d-none d-md-inline-block">Wyloguj się</a>
+                        <button id="mobileMenuBtn" class="navbar-toggler d-md-none ms-2" type="button">
+                            <span class="navbar-toggler-icon"></span>
+                        </button>
+                    </div>
+                    {% endif %}
+                </div>
+                {% if show_menu %}
+                <ul class="navbar-nav flex-row flex-nowrap gap-3 d-none d-md-flex align-items-center mt-2">
+                    <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('home') }}">Strona główna</a></li>
+                    <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('products.add_item') }}">Dodaj przedmiot</a></li>
+                    <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('products.items') }}">Przedmioty</a></li>
+                    <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('products.add_delivery') }}">Dostawy</a></li>
+                    <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('sales.list_sales') }}">Sprzedaż</a></li>
+                    <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('history.print_history') }}">Historia drukowania</a></li>
+                    <li class="nav-item dropdown">
+                        <a class="nav-link dropdown-toggle text-white" href="#" id="navbarSettings" role="button" aria-expanded="false">
+                            Ustawienia
+                        </a>
+                        <ul class="dropdown-menu dropdown-menu-dark">
+                            <li><a class="dropdown-item" href="{{ url_for('settings_page') }}">Ustawienia</a></li>
+                            <li><a class="dropdown-item" href="{{ url_for('agent_logs') }}">Logi</a></li>
+                            <li><a class="dropdown-item" href="{{ url_for('test_print') }}">Testuj drukarkę</a></li>
+                        </ul>
                     </li>
                 </ul>
-                <button id="mobileMenuBtn" class="navbar-toggler d-md-none ms-2" type="button">
-                    <span class="navbar-toggler-icon"></span>
-                </button>
+                {% endif %}
             </div>
-            {% endif %}
         </div>
     </nav>
 
@@ -63,7 +65,6 @@
             <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('products.items') }}">Przedmioty</a></li>
             <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('products.add_delivery') }}">Dostawy</a></li>
             <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('sales.list_sales') }}">Sprzedaż</a></li>
-            <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('sales.sales_page') }}">Sprzedaż</a></li>
             <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('history.print_history') }}">Historia drukowania</a></li>
             <li class="nav-item dropdown">
                 <a class="nav-link dropdown-toggle text-white" href="#" id="mobileSettingsDropdown" role="button" aria-expanded="false">Ustawienia</a>


### PR DESCRIPTION
## Summary
- restructure navbar using a vertical flex layout
- keep hover styles
- remove duplicate "Sprzedaż" link

## Testing
- `pip install -r magazyn/requirements.txt`
- `PYTHONPATH=. pytest -q`
- `curl -I http://127.0.0.1`

------
https://chatgpt.com/codex/tasks/task_e_68613850969c832aa8bd5f86765357d2