### PR TITLE
Improve layout for new item size rows

### DIFF
--- a/magazyn/templates/add_item.html
+++ b/magazyn/templates/add_item.html
@@ -22,10 +22,16 @@
 
 
         {% for size in ALL_SIZES %}
-            <div class="col-md-6">
+            <div class="col-12">
                 <label class="form-label">Rozmiar: {{ size }}</label>
-                <input type="number" id="quantity_{{ size }}" name="quantity_{{ size }}" min="0" value="0" class="form-control" placeholder="Ilość">
-                <input type="text" id="barcode_{{ size }}" name="barcode_{{ size }}" class="form-control mt-1" placeholder="Kod kreskowy">
+                <div class="row g-2">
+                    <div class="col">
+                        <input type="number" id="quantity_{{ size }}" name="quantity_{{ size }}" min="0" value="0" class="form-control" placeholder="Ilość">
+                    </div>
+                    <div class="col">
+                        <input type="text" id="barcode_{{ size }}" name="barcode_{{ size }}" class="form-control" placeholder="Kod kreskowy">
+                    </div>
+                </div>
             </div>
         {% endfor %}
 


### PR DESCRIPTION
## Summary
- show quantity and barcode on the same line for each size

## Testing
- `pip install -r magazyn/requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68613f9b562c832abccdc51ac9ceef01