### PR TITLE
Fix history table markup

### DIFF
--- a/magazyn/static/styles.css
+++ b/magazyn/static/styles.css
@@ -142,6 +142,7 @@ td:nth-child(n+3):nth-child(-n+8) {
 .table-responsive {
     width: 100%;
     overflow-x: auto;
+    display: block;
 }
 
 /* Nagłówki tabeli */

--- a/magazyn/templates/history.html
+++ b/magazyn/templates/history.html
@@ -1,9 +1,8 @@
 {% extends "base.html" %}
 {% block content %}
 <h2 class="text-center">Historia drukowania</h2>
-<div class="table-responsive mx-auto">
-    {# .table-responsive ensures horizontal scrolling when needed #}
-<table class="table table-striped table-sm">
+{# .table-responsive ensures horizontal scrolling when needed #}
+<table class="table table-striped table-sm table-responsive mx-auto">
     <thead><tr><th>ID zamówienia</th><th>Nazwa</th><th>Kolor</th><th>Rozmiar</th><th>Czas</th><th>Akcje</th></tr></thead>
     <tbody>
     {% for item in printed %}
@@ -33,5 +32,4 @@
     {% endfor %}
     </tbody>
 </table>
-</div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- inline `.table-responsive` class inside history table
- update CSS so it works when attached directly to the table

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861779fe5b8832a9d002dae5c7b7483