### PR TITLE
Add sales settings route

### DIFF
--- a/magazyn/templates/base.html
+++ b/magazyn/templates/base.html
@@ -44,6 +44,7 @@
                         </a>
                         <ul class="dropdown-menu dropdown-menu-dark">
                             <li><a class="dropdown-item" href="{{ url_for('settings_page') }}">Ustawienia</a></li>
+                            <li><a class="dropdown-item" href="{{ url_for('sales.sales_settings') }}">Ustawienia sprzedaży</a></li>
                             <li><a class="dropdown-item" href="{{ url_for('agent_logs') }}">Logi</a></li>
                             <li><a class="dropdown-item" href="{{ url_for('test_print') }}">Testuj drukarkę</a></li>
                         </ul>

--- a/magazyn/templates/sales_settings.html
+++ b/magazyn/templates/sales_settings.html
@@ -1,0 +1,27 @@
+{% extends "base.html" %}
+
+{% block content %}
+<h2 class="mb-3 text-center">Ustawienia sprzedaży</h2>
+<form method="post" class="row row-cols-1 row-cols-md-2 g-3 center-form mx-auto">
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+    <table class="table">
+        <tbody>
+        {% for item in settings %}
+        <tr>
+            <th scope="row">
+                {{ item.label }}
+                {% if item.desc %}<br><small class="text-muted">{{ item.desc }}</small>{% endif %}
+                {% if item.label != item.key %}<br><small class="text-muted">{{ item.key }}</small>{% endif %}
+            </th>
+            <td>
+                <input type="number" step="0.01" class="form-control" id="{{ item.key }}" name="{{ item.key }}" value="{{ item.value }}">
+            </td>
+        </tr>
+        {% endfor %}
+        </tbody>
+    </table>
+    <div class="col-12 form-actions text-center">
+        <button type="submit" class="btn btn-primary">Zapisz</button>
+    </div>
+</form>
+{% endblock %}

--- a/magazyn/tests/test_base_template.py
+++ b/magazyn/tests/test_base_template.py
@@ -23,3 +23,12 @@ def test_nav_contains_sales_link(app_mod, client, login):
     resp = client.get("/")
     html = resp.get_data(as_text=True)
     assert f'href="{sales_url}"' in html
+
+
+def test_nav_contains_sales_settings_link(app_mod, client, login):
+    from flask import url_for
+    with app_mod.app.test_request_context():
+        settings_url = url_for('sales.sales_settings')
+    resp = client.get("/")
+    html = resp.get_data(as_text=True)
+    assert f'href="{settings_url}"' in html

--- a/magazyn/tests/test_sales_settings.py
+++ b/magazyn/tests/test_sales_settings.py
@@ -1,0 +1,29 @@
+def _sales_keys():
+    return [
+        "DEFAULT_SHIPPING_ALLEGRO",
+        "DEFAULT_SHIPPING_VINTED",
+        "COMMISSION_ALLEGRO",
+        "COMMISSION_VINTED",
+    ]
+
+
+def test_sales_settings_list_keys(app_mod, client, login, tmp_path):
+    app_mod.ENV_PATH = tmp_path / ".env"
+    resp = client.get('/sales/settings')
+    assert resp.status_code == 200
+    html = resp.get_data(as_text=True)
+    for key in _sales_keys():
+        assert key in html
+
+
+def test_sales_settings_post_saves(app_mod, client, login, tmp_path, monkeypatch):
+    app_mod.ENV_PATH = tmp_path / ".env"
+    reloaded = {"called": False}
+    monkeypatch.setattr(app_mod.print_agent, "reload_config", lambda: reloaded.update(called=True))
+    values = {key: str(1.5 + i) for i, key in enumerate(_sales_keys())}
+    resp = client.post('/sales/settings', data=values)
+    assert resp.status_code == 302
+    env_text = app_mod.ENV_PATH.read_text()
+    for key, val in values.items():
+        assert f"{key}={val}" in env_text
+    assert reloaded["called"] is True


### PR DESCRIPTION
## Summary
- add `/sales/settings` page for shipping/commission options
- create `sales_settings.html` template
- show "Ustawienia sprzedaży" menu item
- test nav and the new settings page

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68617a68b870832a9aba7a670fd49476