### PR TITLE
Add profit calculator link

### DIFF
--- a/magazyn/templates/base.html
+++ b/magazyn/templates/base.html
@@ -36,7 +36,8 @@
                     <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('products.add_item') }}">Dodaj przedmiot</a></li>
                     <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('products.items') }}">Przedmioty</a></li>
                     <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('products.add_delivery') }}">Dostawy</a></li>
-                    <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('sales.list_sales') }}">Sprzedaż</a></li>
+                    <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('sales.list_sales') }}">Lista sprzedaży</a></li>
+                    <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('sales.sales_page') }}">Kalkulator zysku</a></li>
                     <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('history.print_history') }}">Historia drukowania</a></li>
                     <li class="nav-item dropdown">
                         <a class="nav-link dropdown-toggle text-white" href="#" id="navbarSettings" role="button" aria-expanded="false">
@@ -65,7 +66,8 @@
             <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('products.add_item') }}">Dodaj przedmiot</a></li>
             <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('products.items') }}">Przedmioty</a></li>
             <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('products.add_delivery') }}">Dostawy</a></li>
-            <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('sales.list_sales') }}">Sprzedaż</a></li>
+            <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('sales.list_sales') }}">Lista sprzedaży</a></li>
+            <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('sales.sales_page') }}">Kalkulator zysku</a></li>
             <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('history.print_history') }}">Historia drukowania</a></li>
             <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('settings_page') }}">Ustawienia</a></li>
             <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('agent_logs') }}">Logi</a></li>


### PR DESCRIPTION
## Summary
- add link to `sales.sales_page` labeled "Kalkulator zysku"
- rename existing sales link to "Lista sprzedaży"

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861a9de1648832a8fde737e917ef21c