### PR TITLE
Fix DB_PATH imports

### DIFF
--- a/magazyn/app.py
+++ b/magazyn/app.py
@@ -50,7 +50,7 @@ from .auth import login_required
 from .config import settings
 from . import print_agent
 from .env_info import ENV_INFO
-from __init__ import DB_PATH
+from magazyn import DB_PATH
 from .constants import ALL_SIZES
 
 ROOT_DIR = Path(__file__).resolve().parents[1]

--- a/magazyn/migrations/add_barcode_to_product_sizes.py
+++ b/magazyn/migrations/add_barcode_to_product_sizes.py
@@ -1,5 +1,5 @@
 import sqlite3
-from __init__ import DB_PATH
+from magazyn import DB_PATH
 
 def migrate():
     with sqlite3.connect(DB_PATH) as conn:

--- a/magazyn/migrations/remove_barcode_from_products.py
+++ b/magazyn/migrations/remove_barcode_from_products.py
@@ -1,5 +1,5 @@
 import sqlite3
-from __init__ import DB_PATH
+from magazyn import DB_PATH
 
 def migrate():
     with sqlite3.connect(DB_PATH) as conn:

--- a/magazyn/print_agent.py
+++ b/magazyn/print_agent.py
@@ -25,7 +25,7 @@ def parse_time_str(value: str) -> dt_time:
 
 
 from .config import settings, load_config
-from __init__ import DB_PATH
+from magazyn import DB_PATH
 from .services import consume_order_stock, get_sales_summary
 from .notifications import send_report
 


### PR DESCRIPTION
## Summary
- simplify DB_PATH imports
- update migration scripts

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861b921aa98832aabab0aa986a3aa2e