### PR TITLE
Remove unused product handlers from app imports

### DIFF
--- a/magazyn/app.py
+++ b/magazyn/app.py
@@ -30,21 +30,8 @@ from .db import (
     record_purchase,
     consume_stock,
 )
-from .products import (
-    bp as products_bp,
-    add_item,
-    update_quantity,
-    delete_item,
-    edit_item,
-    items,
-    barcode_scan,
-    barcode_scan_page,
-    export_products,
-    import_products,
-    import_invoice,
-    add_delivery,
-)
-from .history import bp as history_bp, print_history
+from .products import bp as products_bp
+from .history import bp as history_bp
 from .sales import bp as sales_bp
 from .auth import login_required
 from .config import settings

--- a/magazyn/tests/test_deliveries.py
+++ b/magazyn/tests/test_deliveries.py
@@ -20,7 +20,8 @@ def test_record_delivery(app_mod):
     with app_mod.app.test_request_context("/deliveries", method="POST", data=data):
         from flask import session
         session["username"] = "x"
-        app_mod.add_delivery.__wrapped__()
+        from magazyn import products
+        products.add_delivery.__wrapped__()
 
     with app_mod.get_session() as db:
         batch = db.execute(
@@ -60,7 +61,8 @@ def test_record_multiple_deliveries(app_mod):
     with app_mod.app.test_request_context("/deliveries", method="POST", data=data):
         from flask import session
         session["username"] = "x"
-        app_mod.add_delivery.__wrapped__()
+        from magazyn import products
+        products.add_delivery.__wrapped__()
 
     with app_mod.get_session() as db:
         m = db.execute(
@@ -131,5 +133,6 @@ def test_deliveries_page_shows_color(app_mod):
     with app_mod.app.test_request_context("/deliveries"):
         from flask import session
         session["username"] = "tester"
-        html = app_mod.add_delivery.__wrapped__()
+        from magazyn import products
+        html = products.add_delivery.__wrapped__()
     assert "Prod (Blue)" in html

--- a/magazyn/tests/test_excel.py
+++ b/magazyn/tests/test_excel.py
@@ -45,7 +45,8 @@ def test_import_products_reads_barcode(app_mod, tmp_path):
         ):
             from flask import session
             session["username"] = "x"
-            app_mod.import_products.__wrapped__()
+            from magazyn import products
+            products.import_products.__wrapped__()
 
     with app_mod.get_session() as db:
         row = db.execute(


### PR DESCRIPTION
## Summary
- streamline `magazyn/app.py` imports
- update tests to use product handlers directly

## Testing
- `flake8 > /tmp/flake8.log`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861be262b10832a9c9078214c064a2d