### PR TITLE
Update README with test instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,9 @@ not appear on this page.
 
 ## Running Tests
 
-Before running the tests you must install the required dependencies:
+Before running the tests you must install the required dependencies.
+Execute the following command from the repository root before running
+`pytest`:
 
 ```bash
 pip install -r magazyn/requirements.txt
@@ -73,6 +75,8 @@ repository root on `PYTHONPATH`:
 ```bash
 PYTHONPATH=. pytest -q
 ```
+
+The project is developed and tested using **Python 3.9**.
 
 ## Running with Docker Compose
 


### PR DESCRIPTION
## Summary
- clarify that requirements must be installed before running tests
- mention Python version used for running the suite

## Testing
- `pip install -r magazyn/requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861c38186c0832a8637aa5ca49111b7