### PR TITLE
Fix syntax error in print_agent

### DIFF
--- a/magazyn/print_agent.py
+++ b/magazyn/print_agent.py
@@ -555,8 +555,7 @@ def _agent_loop():
                     continue
 
                 logger.info(
-                    f"📜 Zamówienie {order_id} ({
-                        last_order_data['name']})"
+                    f"📜 Zamówienie {order_id} ({last_order_data['name']})"
                 )
                 packages = get_order_packages(order_id)
                 labels = []


### PR DESCRIPTION
## Summary
- fix typo in `print_agent` logger f-string

## Testing
- `pip install -r magazyn/requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861ade87534832a910d87f1c4a89b04