### PR TITLE
Fix CSS class clashes

### DIFF
--- a/magazyn/static/styles.css
+++ b/magazyn/static/styles.css
@@ -3,6 +3,7 @@ html, body {
 }
 body {
     margin: 0;
+    padding-top: 70px;
     background-color: #121212;
     color: #f0f0f0;
 }
@@ -51,19 +52,19 @@ label, input, button {
     padding: 8px;
 }
 
-.container {
+.custom-container {
     text-align: center;
     margin: 30px auto;
     width: 100%;
 }
 
-.navbar .container {
+.navbar .custom-container {
     margin: 0 auto;
     max-width: 1140px;
     width: 100%;
 }
 @media (max-width: 768px) {
-    .navbar .container { max-width: 100%; padding: 0 1rem; }
+    .navbar .custom-container { max-width: 100%; padding: 0 1rem; }
 }
 
 .actions {
@@ -75,7 +76,7 @@ label, input, button {
     text-align: center;
 }
 
-.btn {
+.custom-btn {
     display: inline-block;
     margin: 10px;
     padding: 12px 24px;
@@ -86,7 +87,7 @@ label, input, button {
     font-weight: bold;
 }
 
-.btn:hover {
+.custom-btn:hover {
     background-color: #145360;
 }
 
@@ -213,11 +214,6 @@ th {
 }
 
 /* Adjust layout for fixed navbar */
-body {
-    padding-top: 70px;
-    background-color: #121212;
-    color: #f0f0f0;
-}
 
 /* Mobile slide-in menu */
 @media (max-width: 768px) {
@@ -331,7 +327,7 @@ body {
 }
 
 @media (max-width: 768px) {
-    #mobileMenu .btn {
+    #mobileMenu .custom-btn {
         margin-left: auto;
         margin-right: auto;
         display: block;

--- a/magazyn/templates/base.html
+++ b/magazyn/templates/base.html
@@ -14,7 +14,7 @@
     {% endif %}
     <div class="page-wrapper">
     <nav class="navbar navbar-dark bg-dark fixed-top">
-        <div class="container">
+        <div class="custom-container">
             <div class="d-flex flex-column">
                 <div class="d-flex align-items-center justify-content-between">
                     <span class="navbar-brand d-flex align-items-center mb-2 mb-md-0">
@@ -59,7 +59,7 @@
 
     {% if show_menu %}
     <div id="mobileMenu" class="mobile-menu d-md-none">
-        <button id="mobileMenuClose" class="mobile-close btn btn-link text-white" type="button" aria-label="Close">&times;</button>
+        <button id="mobileMenuClose" class="mobile-close btn btn-link text-white custom-btn" type="button" aria-label="Close">&times;</button>
         <img src="https://retrievershop.pl/wp-content/uploads/2024/08/retriver-2.png" alt="Logo" class="mobile-logo mx-auto mb-3">
         <ul class="nav flex-column h-100">
             <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('home') }}">Strona główna</a></li>
@@ -73,7 +73,7 @@
             <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('agent_logs') }}">Logi</a></li>
             <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('test_print') }}">Testuj drukarkę</a></li>
             <li class="nav-item mt-auto text-center">
-                <a class="btn btn-danger w-100" href="{{ url_for('logout') }}">Wyloguj się</a>
+                <a class="btn btn-danger w-100 custom-btn" href="{{ url_for('logout') }}">Wyloguj się</a>
             </li>
         </ul>
     </div>

--- a/magazyn/tests/test_base_template.py
+++ b/magazyn/tests/test_base_template.py
@@ -14,7 +14,7 @@ def test_nav_container_class(app_mod, client, login):
     assert nav_match, "nav section missing"
     nav_html = nav_match.group(1)
     assert "container-fluid" not in nav_html
-    assert 'class="container"' in nav_html
+    assert 'class="custom-container"' in nav_html
 
 
 def test_nav_contains_sales_link(app_mod, client, login):


### PR DESCRIPTION
## Summary
- avoid overriding Bootstrap by renaming custom classes
- adjust templates for new custom class names
- deduplicate `body` styles
- update tests for new container class

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861cdf36780832a942a412dad9439c0