### PR TITLE
Revise sales page with profit table

### DIFF
--- a/magazyn/models.py
+++ b/magazyn/models.py
@@ -64,3 +64,7 @@ class Sale(Base):
     size = Column(String, nullable=False)
     quantity = Column(Integer, nullable=False)
     sale_date = Column(String, nullable=False)
+    purchase_cost = Column(Float, nullable=False, default=0.0)
+    sale_price = Column(Float, nullable=False, default=0.0)
+    shipping_cost = Column(Float, nullable=False, default=0.0)
+    commission_fee = Column(Float, nullable=False, default=0.0)

--- a/magazyn/templates/base.html
+++ b/magazyn/templates/base.html
@@ -37,7 +37,6 @@
                     <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('products.items') }}">Przedmioty</a></li>
                     <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('products.add_delivery') }}">Dostawy</a></li>
                     <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('sales.list_sales') }}">Lista sprzedaży</a></li>
-                    <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('sales.sales_page') }}">Kalkulator zysku</a></li>
                     <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('history.print_history') }}">Historia drukowania</a></li>
                     <li class="nav-item dropdown">
                         <a class="nav-link dropdown-toggle text-white" href="#" id="navbarSettings" role="button" aria-expanded="false">
@@ -67,7 +66,6 @@
             <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('products.items') }}">Przedmioty</a></li>
             <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('products.add_delivery') }}">Dostawy</a></li>
             <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('sales.list_sales') }}">Lista sprzedaży</a></li>
-            <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('sales.sales_page') }}">Kalkulator zysku</a></li>
             <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('history.print_history') }}">Historia drukowania</a></li>
             <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('settings_page') }}">Ustawienia</a></li>
             <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('agent_logs') }}">Logi</a></li>

--- a/magazyn/templates/sales.html
+++ b/magazyn/templates/sales.html
@@ -1,39 +1,32 @@
 {% extends "base.html" %}
 {% block content %}
-<h2 class="mb-3 text-center">Sprzedaż</h2>
-<form method="post" class="row row-cols-1 row-cols-md-2 g-3 center-form mx-auto">
-    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-    <div class="col">
-        <label for="platform" class="form-label">Platforma</label>
-        <select id="platform" name="platform" class="form-select">
-            {% for p in platforms %}
-            <option value="{{ p }}" {% if p == platform %}selected{% endif %}>{{ p|capitalize }}</option>
-            {% endfor %}
-        </select>
-    </div>
-    <div class="col">
-        <label for="price" class="form-label">Cena sprzedaży</label>
-        <input type="number" step="0.01" class="form-control" id="price" name="price" value="{{ price }}">
-    </div>
-    <div class="col">
-        <label for="shipping" class="form-label">Koszt wysyłki</label>
-        <input type="number" step="0.01" class="form-control" id="shipping" name="shipping" value="{{ shipping }}" {% if auto_shipping %}disabled{% endif %}>
-    </div>
-    <div class="col">
-        <div class="form-check mt-4">
-            <input class="form-check-input" type="checkbox" id="auto_shipping" name="auto_shipping" {% if auto_shipping %}checked{% endif %}>
-            <label class="form-check-label" for="auto_shipping">Automatyczna wysyłka</label>
-        </div>
-    </div>
-    <div class="col">
-        <label for="commission" class="form-label">Prowizja (%)</label>
-        <input type="number" step="0.01" class="form-control" id="commission" name="commission" value="{{ commission }}">
-    </div>
-    <div class="col-12 form-actions text-center">
-        <button type="submit" class="btn btn-primary">Oblicz</button>
-    </div>
-</form>
-{% if result is not none %}
-<div class="alert alert-info mt-4 text-center">Zysk: {{ result }}</div>
-{% endif %}
+<h2 class="text-center mb-3">Sprzedaż</h2>
+<div class="table-responsive">
+<table class="table table-striped table-sm mx-auto">
+    <thead>
+    <tr>
+        <th>Data</th>
+        <th>Produkt</th>
+        <th>Koszt zakupu</th>
+        <th>Prowizja</th>
+        <th>Wysyłka</th>
+        <th>Cena sprzedaży</th>
+        <th>Zysk</th>
+    </tr>
+    </thead>
+    <tbody>
+    {% for s in sales %}
+    <tr>
+        <td>{{ s.date[:16] }}</td>
+        <td>{{ s.product }}</td>
+        <td>{{ '%.2f'|format(s.purchase_cost) }}</td>
+        <td>{{ '%.2f'|format(s.commission) }}</td>
+        <td>{{ '%.2f'|format(s.shipping) }}</td>
+        <td>{{ '%.2f'|format(s.sale_price) }}</td>
+        <td>{{ '%.2f'|format(s.profit) }}</td>
+    </tr>
+    {% endfor %}
+    </tbody>
+</table>
+</div>
 {% endblock %}

--- a/magazyn/tests/test_sales.py
+++ b/magazyn/tests/test_sales.py
@@ -1,27 +1,30 @@
 from magazyn.app import app
+from magazyn.models import Product, ProductSize, Sale
 
 
-def test_sales_get(app_mod, client, login):
-    resp = client.get("/sales/profit")
+def test_sales_page_get(app_mod, client, login):
+    resp = client.get("/sales")
     assert resp.status_code == 200
     html = resp.get_data(as_text=True)
     assert "Sprzedaż" in html
 
 
-def test_sales_profit_calculation(app_mod, client, login):
-    resp = client.post(
-        "/sales/profit", data={"platform": "allegro", "price": "100"}
-    )
-    assert resp.status_code == 200
+def test_sales_profit_calculated(app_mod, client, login):
+    # create product and sale
+    with app_mod.get_session() as db:
+        prod = Product(name="Prod", color="Blue")
+        db.add(prod)
+        db.flush()
+        db.add(ProductSize(product_id=prod.id, size="M", quantity=0))
+        pid = prod.id
+    app_mod.record_purchase(pid, "M", 1, 10.0)
+    app_mod.consume_stock(pid, "M", 1)
+    with app_mod.get_session() as db:
+        sale = db.query(Sale).first()
+        sale.sale_price = 20.0
+        sale.shipping_cost = 5.0
+        sale.commission_fee = 2.0
+    resp = client.get("/sales")
     html = resp.get_data(as_text=True)
-    assert "82.0" in html
+    assert "3.00" in html
 
-
-def test_auto_shipping_free(app_mod, client, login):
-    resp = client.post(
-        "/sales/profit",
-        data={"platform": "allegro", "price": "160", "auto_shipping": "on"},
-    )
-    assert resp.status_code == 200
-    html = resp.get_data(as_text=True)
-    assert "144.0" in html


### PR DESCRIPTION
## Summary
- store cost and pricing details on each `Sale`
- ensure schema upgrades existing DBs
- compute purchase cost during stock consumption
- remove profit calculator and list sales with profit table
- adjust navigation
- update tests for the new sales view

## Testing
- `pip install -q -r magazyn/requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861d1345388832a8b21f7413aacac03