### PR TITLE
Add sales list template

### DIFF
--- a/magazyn/sales.py
+++ b/magazyn/sales.py
@@ -39,7 +39,7 @@ def list_sales():
                     "profit": profit,
                 }
             )
-    return render_template("sales.html", sales=sales)
+    return render_template("sales_list.html", sales=sales)
 
 
 

--- a/magazyn/templates/sales_list.html
+++ b/magazyn/templates/sales_list.html
@@ -1,0 +1,32 @@
+{% extends "base.html" %}
+{% block content %}
+<h2 class="text-center mb-3">Sprzedaż</h2>
+<div class="table-responsive">
+<table class="table table-striped table-sm mx-auto">
+    <thead>
+    <tr>
+        <th>Data</th>
+        <th>Produkt</th>
+        <th>Koszt zakupu</th>
+        <th>Prowizja</th>
+        <th>Wysyłka</th>
+        <th>Cena sprzedaży</th>
+        <th>Zysk</th>
+    </tr>
+    </thead>
+    <tbody>
+    {% for s in sales %}
+    <tr>
+        <td>{{ s.date[:16] }}</td>
+        <td>{{ s.product }}</td>
+        <td>{{ '%.2f'|format(s.purchase_cost) }}</td>
+        <td>{{ '%.2f'|format(s.commission) }}</td>
+        <td>{{ '%.2f'|format(s.shipping) }}</td>
+        <td>{{ '%.2f'|format(s.sale_price) }}</td>
+        <td>{{ '%.2f'|format(s.profit) }}</td>
+    </tr>
+    {% endfor %}
+    </tbody>
+</table>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add new template to display sales history
- use new template in `list_sales` route

## Testing
- `pip install -r magazyn/requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861d2c6c110832a8dfc753722d4fdd4