### PR TITLE
Fix items table button alignment

### DIFF
--- a/magazyn/templates/items.html
+++ b/magazyn/templates/items.html
@@ -35,7 +35,7 @@
                 </form>
             </td>
             {% endfor %}
-            <td>
+            <td class="text-center">
                 <a href="{{ url_for('products.edit_item', product_id=product['id']) }}" class="btn btn-warning btn-sm">Edytuj</a>
                 <form action="{{ url_for('products.delete_item', item_id=product['id']) }}" method="POST" style="display: inline;" onsubmit="return confirm('Czy na pewno chcesz usunąć ten przedmiot?');">
                     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">


### PR DESCRIPTION
## Summary
- center align the edit/delete buttons in `items.html`

## Testing
- `pip install -r magazyn/requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862593f4204832aa2f105515827c747