### PR TITLE
Fix navbar overlap

### DIFF
--- a/magazyn/static/styles.css
+++ b/magazyn/static/styles.css
@@ -3,13 +3,13 @@ html, body {
 }
 body {
     margin: 0;
-    padding-top: 70px;
+    padding-top: 110px;
     background-color: #121212;
     color: #f0f0f0;
 }
 .page-wrapper {
     /* Subtract navbar height so short pages avoid unnecessary scrolling */
-    min-height: calc(100vh - 70px);
+    min-height: calc(100vh - 110px);
     display: flex;
     flex-direction: column;
 }

--- a/magazyn/templates/base.html
+++ b/magazyn/templates/base.html
@@ -77,7 +77,7 @@
     </div>
     {% endif %}
 
-    <main class="container-fluid mt-5 pt-4">
+    <main class="container-fluid mt-4 pt-4">
 	{% with messages = get_flashed_messages() %}
   {% if messages %}
     <div class="alert alert-info" role="alert">


### PR DESCRIPTION
## Summary
- increase body padding-top so headers do not sit under fixed navbar
- adjust page-wrapper min-height
- tweak `<main>` margin

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68625a092d24832a96944cd99c506fe0