### PR TITLE
Update database init behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,9 @@ before using the same database file.
 
 Running a newer version of the application on an older database file will
 automatically add missing columns (for example the `barcode` column in the
-`product_sizes` table) during startup.
+`product_sizes` table) during startup. Any tables introduced in new versions
+are created on each launch because `init_db()` now runs every time the
+application starts.
 
 ## Importing invoices
 

--- a/magazyn/app.py
+++ b/magazyn/app.py
@@ -141,8 +141,14 @@ def ensure_db_initialized():
             if has_request_context():
                 flash("Błąd konfiguracji bazy danych.")
             raise SystemExit(1)
-        if not os.path.isfile(DB_PATH):
-            init_db()
+        if os.path.exists(DB_PATH) and not os.path.isfile(DB_PATH):
+            app.logger.error(f"Database path {DB_PATH} is not a file.")
+            if has_request_context():
+                flash("Błąd konfiguracji bazy danych.")
+            raise SystemExit(1)
+
+        # Always run table creation so new tables appear automatically.
+        init_db()
         ensure_schema()
         register_default_user()
     except Exception as e:


### PR DESCRIPTION
## Summary
- always run `init_db()` on startup after checking `DB_PATH`
- document that new tables are automatically created

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68625cc48a04832a84e7e5cf9e50350f