### PR TITLE
UI tweaks for item and delivery forms

### DIFF
--- a/magazyn/templates/add_delivery.html
+++ b/magazyn/templates/add_delivery.html
@@ -2,7 +2,7 @@
 
 {% block content %}
 <h2 class="mb-3 text-center">Dodaj dostawę</h2>
-<form action="{{ url_for('products.add_delivery') }}" method="post" class="row row-cols-1 row-cols-md-2 g-3 center-form mx-auto">
+<form action="{{ url_for('products.add_delivery') }}" method="post" class="row row-cols-1 row-cols-md-2 g-3 wide-form">
     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
     <div id="deliveryRows">
         <div class="delivery-row row row-cols-1 row-cols-md-2 g-3 align-items-end">
@@ -30,31 +30,43 @@
                 <label class="form-label">Cena:</label>
                 <input type="number" step="0.01" name="price" value="0" class="form-control">
             </div>
-            <div class="col-12 text-end">
-                <button type="button" class="btn btn-danger btn-sm remove-row">Usuń</button>
+            <div class="col-md-2 col-12 text-end">
+                <button type="button" class="btn btn-danger btn-sm remove-row" style="display: none;"><i class="bi bi-trash"></i></button>
             </div>
         </div>
     </div>
-    <div class="col-12 text-center">
-        <button type="button" id="addRow" class="btn btn-secondary">Dodaj wiersz</button>
+    <div class="col-12 text-end">
+        <button type="button" id="addRow" class="btn btn-secondary btn-sm"><i class="bi bi-plus-circle"></i></button>
     </div>
     <div class="col-12 form-actions text-center">
         <button type="submit" class="btn btn-primary">Dodaj</button>
     </div>
 </form>
 <script>
+    function updateDeleteVisibility() {
+        const rows = document.querySelectorAll('.delivery-row');
+        const show = rows.length > 1;
+        rows.forEach(r => {
+            const btn = r.querySelector('.remove-row');
+            if (btn) btn.style.display = show ? 'inline-block' : 'none';
+        });
+    }
+
     document.getElementById('addRow').addEventListener('click', () => {
         const container = document.getElementById('deliveryRows');
         const row = container.querySelector('.delivery-row').cloneNode(true);
         row.querySelectorAll('input[name="quantity"]').forEach(i => i.value = 1);
         row.querySelectorAll('input[name="price"]').forEach(i => i.value = 0);
         container.appendChild(row);
+        updateDeleteVisibility();
     });
+
     document.addEventListener('click', e => {
         if (e.target.classList.contains('remove-row')) {
             const rows = document.querySelectorAll('.delivery-row');
             if (rows.length > 1) {
                 e.target.closest('.delivery-row').remove();
+                updateDeleteVisibility();
             }
         }
     });

--- a/magazyn/templates/add_item.html
+++ b/magazyn/templates/add_item.html
@@ -36,7 +36,7 @@
         {% endfor %}
 
         <div class="col-12 form-actions text-center">
-            <button type="submit" class="btn btn-primary">Dodaj produkt</button>
+            <button type="submit" class="btn btn-primary">Dodaj przedmiot</button>
         </div>
     </form>
 

--- a/magazyn/templates/edit_item.html
+++ b/magazyn/templates/edit_item.html
@@ -18,21 +18,21 @@
 
         <div class="col-12">
             <label for="sizes" class="form-label">Ilości dla rozmiarów:</label>
-            {% for size in ALL_SIZES %}
-                {% set info = product_sizes[size] %}
-                <div class="col-12">
-                    <label class="form-label">Rozmiar: {{ size }}</label>
-                    <div class="row g-2">
-                        <div class="col">
-                            <input type="number" name="quantity_{{ size }}" value="{{ info['quantity'] }}" min="0" class="form-control" placeholder="Ilość">
-                        </div>
-                        <div class="col">
-                            <input type="text" name="barcode_{{ size }}" value="{{ info['barcode'] }}" class="form-control" placeholder="Kod kreskowy">
-                        </div>
+        </div>
+        {% for size in ALL_SIZES %}
+            {% set info = product_sizes[size] %}
+            <div class="col-md-6">
+                <label class="form-label">Rozmiar: {{ size }}</label>
+                <div class="row g-2">
+                    <div class="col">
+                        <input type="number" name="quantity_{{ size }}" value="{{ info['quantity'] }}" min="0" class="form-control" placeholder="Ilość">
+                    </div>
+                    <div class="col">
+                        <input type="text" name="barcode_{{ size }}" value="{{ info['barcode'] }}" class="form-control" placeholder="Kod kreskowy">
                     </div>
                 </div>
-            {% endfor %}
-        </div>
+            </div>
+        {% endfor %}
 
         <div class="col-12 form-actions text-center">
             <button type="submit" class="btn btn-primary">Zapisz zmiany</button>

--- a/magazyn/templates/history.html
+++ b/magazyn/templates/history.html
@@ -2,7 +2,7 @@
 {% block content %}
 <h2 class="text-center">Historia drukowania</h2>
 {# .table-responsive ensures horizontal scrolling when needed #}
-<table class="table table-striped table-sm table-responsive mx-auto">
+<table class="table table-striped table-sm table-responsive">
     <thead><tr><th>ID zamówienia</th><th>Nazwa</th><th>Kolor</th><th>Rozmiar</th><th>Czas</th><th>Akcje</th></tr></thead>
     <tbody>
     {% for item in printed %}


### PR DESCRIPTION
## Summary
- align "Dodaj przedmiot" button in add item form
- arrange size fields in two columns on edit item page
- swap delivery row buttons for icons and widen form
- make history table full width

## Testing
- `flake8`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861ca1b9cec832a9060a2b547bb5d4d