### PR TITLE
Fix add item form width

### DIFF
--- a/magazyn/templates/add_item.html
+++ b/magazyn/templates/add_item.html
@@ -2,7 +2,7 @@
 
 {% block content %}
 <h2 class="mb-3 text-center">Dodaj nowy przedmiot</h2>
-    <form action="{{ url_for('products.add_item') }}" method="post" class="row row-cols-1 row-cols-md-2 g-3 center-form mx-auto">
+    <form action="{{ url_for('products.add_item') }}" method="post" class="row row-cols-1 row-cols-md-2 g-3 wide-form mx-auto">
         {{ form.csrf_token }}
         <div class="col-md-6">
             <label for="name" class="form-label">Nazwa produktu:</label>


### PR DESCRIPTION
## Summary
- replace `center-form` with `wide-form` in add_item.html
- confirm `.wide-form` CSS class provides `width: 100%`

## Testing
- `flake8`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686265abf8bc832a93b1ccca60f0efe7