### PR TITLE
Fix edit item layout

### DIFF
--- a/magazyn/templates/edit_item.html
+++ b/magazyn/templates/edit_item.html
@@ -3,7 +3,7 @@
 {% block content %}
 <div class="container mt-4">
     <h3 class="text-center">Edytuj przedmiot</h3>
-    <form method="POST" action="{{ url_for('products.edit_item', product_id=product['id']) }}" class="row row-cols-1 row-cols-md-2 g-3 center-form mx-auto">
+    <form method="POST" action="{{ url_for('products.edit_item', product_id=product['id']) }}" class="row row-cols-1 row-cols-md-2 g-3 wide-form mx-auto">
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
         <div class="col-md-6">
             <label for="name" class="form-label">Nazwa:</label>
@@ -16,7 +16,7 @@
         </div>
 
 
-        <div class="col-12">
+        <div class="col-12 text-center">
             <label for="sizes" class="form-label">Ilości dla rozmiarów:</label>
         </div>
         {% for size in ALL_SIZES %}


### PR DESCRIPTION
## Summary
- make the edit item form span the full width
- center the heading for size quantities

## Testing
- `flake8`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68626698ffb4832a86727680ad27a6d1