### PR TITLE
Enable full width layout for history page

### DIFF
--- a/magazyn/static/styles.css
+++ b/magazyn/static/styles.css
@@ -308,6 +308,9 @@ th {
         margin-left: auto;
         margin-right: auto;
     }
+    .container-fluid.full-width {
+        max-width: none;
+    }
 }
 
 

--- a/magazyn/templates/base.html
+++ b/magazyn/templates/base.html
@@ -12,6 +12,10 @@
     {% if show_menu is not defined %}
         {% set show_menu = True %}
     {% endif %}
+    {% if full_width is not defined %}
+        {% set full_width = False %}
+    {% endif %}
+    {% block page_vars %}{% endblock %}
     <div class="page-wrapper">
     <nav class="navbar navbar-dark bg-dark fixed-top">
         <div class="custom-container">
@@ -77,7 +81,7 @@
     </div>
     {% endif %}
 
-    <main class="container-fluid mt-4 pt-4">
+    <main class="container-fluid mt-4 pt-4{% if full_width %} full-width{% endif %}">
 	{% with messages = get_flashed_messages() %}
   {% if messages %}
     <div class="alert alert-info" role="alert">

--- a/magazyn/templates/history.html
+++ b/magazyn/templates/history.html
@@ -1,4 +1,7 @@
 {% extends "base.html" %}
+{% block page_vars %}
+{% set full_width = True %}
+{% endblock %}
 {% block content %}
 <h2 class="text-center">Historia drukowania</h2>
 {# .table-responsive ensures horizontal scrolling when needed #}


### PR DESCRIPTION
## Summary
- let templates set `full_width` via a `page_vars` block
- allow `.container-fluid.full-width` elements to expand
- mark `history.html` as `full_width`

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686269b70518832aa13da2951d6f1caf