### PR TITLE
Remove width limit on main container

### DIFF
--- a/magazyn/static/styles.css
+++ b/magazyn/static/styles.css
@@ -303,7 +303,6 @@ th {
 
 @media (min-width: 768px) {
     main.container-fluid {
-        max-width: 1140px;
         width: 100%;
         margin-left: auto;
         margin-right: auto;


### PR DESCRIPTION
## Summary
- allow `<main>` container to stretch to full width on large screens

## Testing
- `pip install -r magazyn/requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68628eec19d4832a82afbac895581d11