### PR TITLE
Move email settings to sales config

### DIFF
--- a/magazyn/sales.py
+++ b/magazyn/sales.py
@@ -57,7 +57,8 @@ def list_sales():
 
 
 def _sales_keys(values):
-    return [k for k in values.keys() if "SHIPPING" in k or "COMMISSION" in k]
+    keywords = ("SHIPPING", "COMMISSION", "EMAIL", "SMTP")
+    return [k for k in values.keys() if any(word in k for word in keywords)]
 
 
 @bp.route("/sales/settings", methods=["GET", "POST"])

--- a/magazyn/tests/test_sales_settings.py
+++ b/magazyn/tests/test_sales_settings.py
@@ -3,6 +3,11 @@ def _sales_keys():
         "DEFAULT_SHIPPING_ALLEGRO",
         "FREE_SHIPPING_THRESHOLD_ALLEGRO",
         "COMMISSION_ALLEGRO",
+        "ALERT_EMAIL",
+        "SMTP_SERVER",
+        "SMTP_PORT",
+        "SMTP_USERNAME",
+        "SMTP_PASSWORD",
     ]
 
 


### PR DESCRIPTION
## Summary
- include ALERT_EMAIL and SMTP keys in `_sales_keys`
- verify new keys in sales settings tests

## Testing
- `pip install -r magazyn/requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862bd0a0b0c832aa2bfd08e872deafa