### PR TITLE
Move save buttons outside center form

### DIFF
--- a/magazyn/static/styles.css
+++ b/magazyn/static/styles.css
@@ -74,6 +74,8 @@ label, input, button {
 /* Optional wrapper for centering form buttons */
 .form-actions {
     text-align: center;
+    width: 100%;
+    margin-top: 1rem;
 }
 
 .custom-btn {

--- a/magazyn/templates/sales_settings.html
+++ b/magazyn/templates/sales_settings.html
@@ -2,7 +2,7 @@
 
 {% block content %}
 <h2 class="mb-3 text-center">Ustawienia sprzedaży</h2>
-<form method="post" class="row row-cols-1 row-cols-md-2 g-3 center-form mx-auto">
+<form method="post" id="salesSettingsForm" class="row row-cols-1 row-cols-md-2 g-3 center-form mx-auto">
     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
     <table class="table">
         <tbody>
@@ -52,10 +52,10 @@
     <div class="col-12 text-center mb-3">
         <button type="button" id="addThresholdRow" class="btn btn-secondary">Dodaj próg</button>
     </div>
-    <div class="col-12 form-actions text-center">
-        <button type="submit" class="btn btn-primary">Zapisz</button>
-    </div>
 </form>
+<div class="form-actions text-center mt-3">
+    <button type="submit" form="salesSettingsForm" class="btn btn-primary">Zapisz</button>
+</div>
 <script>
     function updateDeleteVisibility() {
         const rows = document.querySelectorAll('.threshold-row');

--- a/magazyn/templates/settings.html
+++ b/magazyn/templates/settings.html
@@ -8,7 +8,7 @@
   Aby zmienić lokalizację, edytuj plik <code>.env</code> i zrestartuj serwer.
 </div>
 {% endif %}
-<form method="post" class="row row-cols-1 row-cols-md-2 g-3 center-form mx-auto">
+<form method="post" id="settingsForm" class="row row-cols-1 row-cols-md-2 g-3 center-form mx-auto">
     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
     <table class="table">
         <tbody>
@@ -31,8 +31,8 @@
         {% endfor %}
         </tbody>
     </table>
-    <div class="col-12 form-actions text-center">
-        <button type="submit" class="btn btn-primary">Zapisz</button>
-    </div>
 </form>
+<div class="form-actions text-center mt-3">
+    <button type="submit" form="settingsForm" class="btn btn-primary">Zapisz</button>
+</div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- ensure form action buttons are outside of the `.center-form` container
- update form markup for settings and sales settings
- tweak `.form-actions` styling so buttons span the full width

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'magazyn')*

------
https://chatgpt.com/codex/tasks/task_e_686458b3b47c832a9849ad09c7dd480a