### PR TITLE
Fix history table layout

### DIFF
--- a/magazyn/templates/history.html
+++ b/magazyn/templates/history.html
@@ -5,7 +5,8 @@
 {% block content %}
 <h2 class="text-center">Historia drukowania</h2>
 {# .table-responsive ensures horizontal scrolling when needed #}
-<table class="table table-striped table-sm table-responsive">
+<div class="table-responsive">
+<table class="table table-striped table-sm w-100">
     <thead><tr><th>ID zamówienia</th><th>Nazwa</th><th>Kolor</th><th>Rozmiar</th><th>Czas</th><th>Akcje</th></tr></thead>
     <tbody>
     {% for item in printed %}
@@ -35,4 +36,5 @@
     {% endfor %}
     </tbody>
 </table>
+</div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- center history table and make it span full width

## Testing
- `pytest -q` *(fails: OperationalError - no such table: shipping_thresholds)*

------
https://chatgpt.com/codex/tasks/task_e_686443432b24832ab38d806e7239e62c