### PR TITLE
Fix shipping thresholds heading

### DIFF
--- a/magazyn/templates/sales_settings.html
+++ b/magazyn/templates/sales_settings.html
@@ -24,7 +24,8 @@
     <div class="col-12 text-center">
         <h5 class="mt-4">Progi kosztów wysyłki</h5>
     </div>
-    <table class="table" id="thresholdTable">
+    <div class="col-12">
+        <table class="table" id="thresholdTable">
         <thead>
         <tr>
             <th>Minimalna wartość zamówienia</th>
@@ -48,7 +49,8 @@
         </tr>
         {% endif %}
         </tbody>
-    </table>
+        </table>
+    </div>
     <div class="col-12 text-center mb-3">
         <button type="button" id="addThresholdRow" class="btn btn-secondary">Dodaj próg</button>
     </div>


### PR DESCRIPTION
## Summary
- adjust shipping thresholds heading layout

## Testing
- `pip install -r magazyn/requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68646fcbbcac832abf8b2f0e259ce76f