### PR TITLE
Add icon add button to threshold table

### DIFF
--- a/magazyn/templates/sales_settings.html
+++ b/magazyn/templates/sales_settings.html
@@ -30,7 +30,9 @@
         <tr>
             <th>Minimalna wartość zamówienia</th>
             <th>Koszt wysyłki</th>
-            <th></th>
+            <th class="text-end">
+                <button type="button" id="addThresholdRow" class="btn btn-secondary btn-sm"><i class="bi bi-plus-circle"></i></button>
+            </th>
         </tr>
         </thead>
         <tbody id="thresholdRows">
@@ -50,9 +52,6 @@
         {% endif %}
         </tbody>
         </table>
-    </div>
-    <div class="col-12 text-center mb-3">
-        <button type="button" id="addThresholdRow" class="btn btn-secondary">Dodaj próg</button>
     </div>
 </form>
 <div class="form-actions text-center mt-3">


### PR DESCRIPTION
## Summary
- restyle the shipping threshold add button to use an icon
- move the add button inside the table header

## Testing
- `pip install -r magazyn/requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686470d23664832aa4ee31576e92d122