### PR TITLE
Add main container wrapper

### DIFF
--- a/magazyn/templates/base.html
+++ b/magazyn/templates/base.html
@@ -82,7 +82,8 @@
     {% endif %}
 
     <main class="container-fluid mt-4 pt-4{% if full_width %} full-width{% endif %}">
-	{% with messages = get_flashed_messages() %}
+        <div class="container">
+            {% with messages = get_flashed_messages() %}
   {% if messages %}
     <div class="alert alert-info" role="alert">
       {% for message in messages %}
@@ -92,7 +93,8 @@
   {% endif %}
 {% endwith %}
 
-        {% block content %}{% endblock %}
+            {% block content %}{% endblock %}
+        </div>
     </main>
     <footer>
         <p>&copy; 2024-{{ current_year }} <a href="https://retrievershop.pl/">Retriever Shop</a> - Magazyn</p>

--- a/magazyn/templates/edit_item.html
+++ b/magazyn/templates/edit_item.html
@@ -1,7 +1,6 @@
 {% extends "base.html" %}
 
 {% block content %}
-<div class="container mt-4">
     <h3 class="text-center">Edytuj przedmiot</h3>
     <form method="POST" action="{{ url_for('products.edit_item', product_id=product['id']) }}" class="row row-cols-1 row-cols-md-2 g-3 wide-form mx-auto">
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
@@ -38,7 +37,6 @@
             <button type="submit" class="btn btn-primary">Zapisz zmiany</button>
         </div>
     </form>
-</div>
 
 
 {% endblock %}


### PR DESCRIPTION
## Summary
- wrap all page content in a bootstrap container
- remove redundant container in edit item page

## Testing
- `pip install -r magazyn/requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686475f34c0c832a90ad6a875e87c8be