### PR TITLE
Fix container usage in base template

### DIFF
--- a/magazyn/static/styles.css
+++ b/magazyn/static/styles.css
@@ -60,11 +60,24 @@ label, input, button {
 
 .navbar .custom-container {
     margin: 0 auto;
-    max-width: 1140px;
     width: 100%;
+    padding-left: 1rem;
+    padding-right: 1rem;
 }
-@media (max-width: 768px) {
-    .navbar .custom-container { max-width: 100%; padding: 0 1rem; }
+@media (min-width: 576px) {
+    .navbar .custom-container { max-width: 540px; }
+}
+@media (min-width: 768px) {
+    .navbar .custom-container { max-width: 720px; }
+}
+@media (min-width: 992px) {
+    .navbar .custom-container { max-width: 960px; }
+}
+@media (min-width: 1200px) {
+    .navbar .custom-container { max-width: 1140px; }
+}
+@media (min-width: 1400px) {
+    .navbar .custom-container { max-width: 1320px; }
 }
 
 .actions {

--- a/magazyn/templates/base.html
+++ b/magazyn/templates/base.html
@@ -82,7 +82,9 @@
     {% endif %}
 
     <main class="container-fluid mt-4 pt-4{% if full_width %} full-width{% endif %}">
+        {% if not full_width %}
         <div class="container">
+        {% endif %}
             {% with messages = get_flashed_messages() %}
   {% if messages %}
     <div class="alert alert-info" role="alert">
@@ -94,7 +96,9 @@
 {% endwith %}
 
             {% block content %}{% endblock %}
+        {% if not full_width %}
         </div>
+        {% endif %}
     </main>
     <footer>
         <p>&copy; 2024-{{ current_year }} <a href="https://retrievershop.pl/">Retriever Shop</a> - Magazyn</p>


### PR DESCRIPTION
## Summary
- avoid double containers by wrapping content conditionally
- match navbar width with page content

## Testing
- `pip install -q -r magazyn/requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864f724388c832a9557e54528f791b9