### PR TITLE
Fix add-item button alignment

### DIFF
--- a/magazyn/templates/add_item.html
+++ b/magazyn/templates/add_item.html
@@ -35,7 +35,7 @@
             </div>
         {% endfor %}
 
-        <div class="col-md-6 offset-md-3 form-actions text-center">
+        <div class="col-12 form-actions text-center">
             <button type="submit" class="btn btn-primary">Dodaj przedmiot</button>
         </div>
     </form>


### PR DESCRIPTION
## Summary
- center the add item button across the form

## Testing
- `pip install -r magazyn/requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68650c1ba058832aa7289acfe5fdd9b0