### PR TITLE
Use default width on history page

### DIFF
--- a/magazyn/templates/history.html
+++ b/magazyn/templates/history.html
@@ -1,7 +1,4 @@
 {% extends "base.html" %}
-{% block page_vars %}
-{% set full_width = True %}
-{% endblock %}
 {% block content %}
 <h2 class="text-center">Historia drukowania</h2>
 {# .table-responsive ensures horizontal scrolling when needed #}


### PR DESCRIPTION
## Summary
- remove `full_width` override from `history.html`

## Testing
- `pip install -r magazyn/requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865169f7140832aa6d7ae711a022c1b