### PR TITLE
Wrap thresholds heading with row

### DIFF
--- a/magazyn/templates/sales_settings.html
+++ b/magazyn/templates/sales_settings.html
@@ -21,8 +21,10 @@
         </tbody>
     </table>
 
-    <div class="col-12 text-center">
-        <h5 class="mt-4">Progi kosztów wysyłki</h5>
+    <div class="row">
+        <div class="col-12 text-center">
+            <h5 class="mt-4">Progi kosztów wysyłki</h5>
+        </div>
     </div>
     <div class="col-12">
         <table class="table" id="thresholdTable">


### PR DESCRIPTION
## Summary
- place shipping thresholds heading in its own full-width row

## Testing
- `pip install -r magazyn/requirements.txt`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686523835fdc832aba9d171252a483b2