### PR TITLE
Fix width of shipping thresholds table

### DIFF
--- a/magazyn/templates/sales_settings.html
+++ b/magazyn/templates/sales_settings.html
@@ -26,8 +26,7 @@
             <h5 class="mt-4">Progi kosztów wysyłki</h5>
         </div>
     </div>
-    <div class="col-12">
-        <table class="table" id="thresholdTable">
+    <table class="table" id="thresholdTable">
         <thead>
         <tr>
             <th>Minimalna wartość zamówienia</th>
@@ -54,7 +53,6 @@
         {% endif %}
         </tbody>
         </table>
-    </div>
 </form>
 <div class="form-actions text-center mt-3">
     <button type="submit" form="salesSettingsForm" class="btn btn-primary">Zapisz</button>


### PR DESCRIPTION
## Summary
- remove column wrapper around shipping threshold table so it's inside the same `.center-form` container as the settings table

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686525cb2644832aa9d9f710a71145eb