### PR TITLE
Remove wide-form styling from delivery form

### DIFF
--- a/magazyn/templates/add_delivery.html
+++ b/magazyn/templates/add_delivery.html
@@ -2,7 +2,7 @@
 
 {% block content %}
 <h2 class="mb-3 text-center">Dodaj dostawę</h2>
-<form action="{{ url_for('products.add_delivery') }}" method="post" class="row row-cols-1 row-cols-md-2 g-3 wide-form mx-auto">
+<form action="{{ url_for('products.add_delivery') }}" method="post" class="row row-cols-1 row-cols-md-2 g-3 mx-auto">
     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
     <div id="deliveryRows">
         <div class="delivery-row row row-cols-1 row-cols-md-2 g-3 align-items-end">


### PR DESCRIPTION
## Summary
- adjust add_delivery form layout by removing `wide-form` class

## Testing
- `pip install -r magazyn/requirements.txt`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68652c1693b4832a858129fc63fb7333