### PR TITLE
Fix delivery form width and center edit item elements

### DIFF
--- a/magazyn/templates/add_delivery.html
+++ b/magazyn/templates/add_delivery.html
@@ -2,7 +2,7 @@
 
 {% block content %}
 <h2 class="mb-3 text-center">Dodaj dostawę</h2>
-<form action="{{ url_for('products.add_delivery') }}" method="post" class="row row-cols-1 row-cols-md-2 g-3 mx-auto">
+<form action="{{ url_for('products.add_delivery') }}" method="post" class="row g-3 wide-form mx-auto">
     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
     <div id="deliveryRows">
         <div class="delivery-row row row-cols-1 row-cols-md-2 g-3 align-items-end">
@@ -37,6 +37,7 @@
     </div>
     <div class="col-12 text-end">
         <button type="button" id="addRow" class="btn btn-secondary btn-sm"><i class="bi bi-plus-circle"></i></button>
+        <a href="{{ url_for('products.import_invoice') }}" class="btn btn-secondary btn-sm ms-2" title="Dostawa z faktury"><i class="bi bi-file-earmark-text"></i></a>
     </div>
     <div class="col-12 form-actions text-center">
         <button type="submit" class="btn btn-primary">Dodaj</button>

--- a/magazyn/templates/edit_item.html
+++ b/magazyn/templates/edit_item.html
@@ -2,7 +2,7 @@
 
 {% block content %}
     <h3 class="text-center">Edytuj przedmiot</h3>
-    <form method="POST" action="{{ url_for('products.edit_item', product_id=product['id']) }}" class="row row-cols-1 row-cols-md-2 g-3 wide-form mx-auto">
+    <form method="POST" action="{{ url_for('products.edit_item', product_id=product['id']) }}" class="row g-3 wide-form mx-auto">
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
         <div class="col-md-6">
             <label for="name" class="form-label">Nazwa:</label>


### PR DESCRIPTION
## Summary
- adjust delivery form to span full width and add invoice link icon
- center size label and submit button in edit item form

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864682ffefc832abb8d93a962d2a42f