### PR TITLE
Fix shipping threshold heading width

### DIFF
--- a/magazyn/templates/sales_settings.html
+++ b/magazyn/templates/sales_settings.html
@@ -21,10 +21,8 @@
         </tbody>
     </table>
 
-    <div class="row">
-        <div class="col-12 text-center">
-            <h5 class="mt-4">Progi kosztów wysyłki</h5>
-        </div>
+    <div class="col-12 text-center">
+        <h5 class="mt-4">Progi kosztów wysyłki</h5>
     </div>
     <table class="table" id="thresholdTable">
         <thead>


### PR DESCRIPTION
## Summary
- adjust sales_settings heading markup so it spans the full form width

## Testing
- `pip install -r magazyn/requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686541595000832a8fe9cef5a1366bb5