### PR TITLE
Replace custom form classes with Bootstrap utilities

### DIFF
--- a/magazyn/static/styles.css
+++ b/magazyn/static/styles.css
@@ -27,24 +27,6 @@ h2, h3 {
     margin: auto;
 }
 
-/* Centered layout shared by item forms */
-.center-form {
-    width: 60%;
-    max-width: 650px;
-    margin: auto;
-}
-
-/* Full-width layout for edit item page */
-.wide-form {
-    width: 100%;
-    margin: auto;
-}
-
-@media (max-width: 768px) {
-    .center-form {
-        width: 100%;
-    }
-}
 
 
 label, input, button {
@@ -52,33 +34,6 @@ label, input, button {
     padding: 8px;
 }
 
-.custom-container {
-    text-align: center;
-    margin: 30px auto;
-    width: 100%;
-}
-
-.navbar .custom-container {
-    margin: 0 auto;
-    width: 100%;
-    padding-left: 1rem;
-    padding-right: 1rem;
-}
-@media (min-width: 576px) {
-    .navbar .custom-container { max-width: 540px; }
-}
-@media (min-width: 768px) {
-    .navbar .custom-container { max-width: 720px; }
-}
-@media (min-width: 992px) {
-    .navbar .custom-container { max-width: 960px; }
-}
-@media (min-width: 1200px) {
-    .navbar .custom-container { max-width: 1140px; }
-}
-@media (min-width: 1400px) {
-    .navbar .custom-container { max-width: 1320px; }
-}
 
 .actions {
     margin-top: 20px;

--- a/magazyn/templates/add_delivery.html
+++ b/magazyn/templates/add_delivery.html
@@ -2,7 +2,7 @@
 
 {% block content %}
 <h2 class="mb-3 text-center">Dodaj dostawę</h2>
-<form action="{{ url_for('products.add_delivery') }}" method="post" class="row g-3 wide-form mx-auto">
+<form action="{{ url_for('products.add_delivery') }}" method="post" class="row g-3 w-100">
     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
     <div id="deliveryRows">
         <div class="delivery-row row row-cols-1 row-cols-md-2 g-3 align-items-end">

--- a/magazyn/templates/add_item.html
+++ b/magazyn/templates/add_item.html
@@ -2,7 +2,7 @@
 
 {% block content %}
 <h2 class="mb-3 text-center">Dodaj nowy przedmiot</h2>
-    <form action="{{ url_for('products.add_item') }}" method="post" class="row row-cols-1 row-cols-md-2 g-3 wide-form mx-auto">
+    <form action="{{ url_for('products.add_item') }}" method="post" class="row row-cols-1 row-cols-md-2 g-3 w-100">
         {{ form.csrf_token }}
         <div class="col-md-6">
             <label for="name" class="form-label">Nazwa produktu:</label>

--- a/magazyn/templates/base.html
+++ b/magazyn/templates/base.html
@@ -18,7 +18,7 @@
     {% block page_vars %}{% endblock %}
     <div class="page-wrapper">
     <nav class="navbar navbar-dark bg-dark fixed-top">
-        <div class="custom-container">
+        <div class="container">
             <div class="d-flex flex-column">
                 <div class="d-flex align-items-center justify-content-between">
                     <span class="navbar-brand d-flex align-items-center mb-2 mb-md-0">

--- a/magazyn/templates/edit_item.html
+++ b/magazyn/templates/edit_item.html
@@ -2,7 +2,7 @@
 
 {% block content %}
     <h3 class="text-center">Edytuj przedmiot</h3>
-    <form method="POST" action="{{ url_for('products.edit_item', product_id=product['id']) }}" class="row g-3 wide-form mx-auto">
+    <form method="POST" action="{{ url_for('products.edit_item', product_id=product['id']) }}" class="row g-3 w-100">
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
         <div class="col-md-6">
             <label for="name" class="form-label">Nazwa:</label>

--- a/magazyn/templates/import_invoice.html
+++ b/magazyn/templates/import_invoice.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% block content %}
-<form action="{{ url_for('products.import_invoice') }}" method="POST" enctype="multipart/form-data" class="row row-cols-1 row-cols-md-2 g-3 center-form mx-auto">
+<form action="{{ url_for('products.import_invoice') }}" method="POST" enctype="multipart/form-data" class="row row-cols-1 row-cols-md-2 g-3 col-md-6 mx-auto">
     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
     <div class="col-auto">
         <input type="file" name="file" required class="form-control">

--- a/magazyn/templates/import_products.html
+++ b/magazyn/templates/import_products.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 
 {% block content %}
-<form action="{{ url_for('products.import_products') }}" method="POST" enctype="multipart/form-data" class="row row-cols-1 row-cols-md-2 g-3 center-form mx-auto">
+<form action="{{ url_for('products.import_products') }}" method="POST" enctype="multipart/form-data" class="row row-cols-1 row-cols-md-2 g-3 col-md-6 mx-auto">
     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
     <div class="col-auto">
         <input type="file" name="file" required class="form-control">

--- a/magazyn/templates/login.html
+++ b/magazyn/templates/login.html
@@ -2,7 +2,7 @@
 
 {% block content %}
 <h2 class="mb-3 text-center">Logowanie</h2>
-<form action="{{ url_for('login') }}" method="POST" class="row row-cols-1 row-cols-md-2 g-3 login-form center-form mx-auto">
+<form action="{{ url_for('login') }}" method="POST" class="row row-cols-1 row-cols-md-2 g-3 login-form col-md-6 mx-auto">
     {{ form.csrf_token }}
     <div class="col-12">
         <label for="username" class="form-label">Nazwa użytkownika:</label>

--- a/magazyn/templates/sales_settings.html
+++ b/magazyn/templates/sales_settings.html
@@ -2,7 +2,7 @@
 
 {% block content %}
 <h2 class="mb-3 text-center">Ustawienia sprzedaży</h2>
-<form method="post" id="salesSettingsForm" class="row row-cols-1 row-cols-md-2 g-3 center-form mx-auto">
+<form method="post" id="salesSettingsForm" class="row row-cols-1 row-cols-md-2 g-3 col-md-6 mx-auto">
     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
     <table class="table">
         <tbody>

--- a/magazyn/templates/settings.html
+++ b/magazyn/templates/settings.html
@@ -8,7 +8,7 @@
   Aby zmienić lokalizację, edytuj plik <code>.env</code> i zrestartuj serwer.
 </div>
 {% endif %}
-<form method="post" id="settingsForm" class="row row-cols-1 row-cols-md-2 g-3 center-form mx-auto">
+<form method="post" id="settingsForm" class="row row-cols-1 row-cols-md-2 g-3 col-md-6 mx-auto">
     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
     <table class="table">
         <tbody>

--- a/magazyn/templates/test.html
+++ b/magazyn/templates/test.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% block content %}
 <h2 class="mb-3 text-center">Test wiadomości</h2>
-<form method="post" class="mb-3 row row-cols-1 row-cols-md-2 g-3 center-form mx-auto">
+<form method="post" class="mb-3 row row-cols-1 row-cols-md-2 g-3 col-md-6 mx-auto">
     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
     <div class="col-12 form-actions text-center">
         <button type="submit" class="btn btn-primary">Wyślij testową wiadomość</button>

--- a/magazyn/templates/testprint.html
+++ b/magazyn/templates/testprint.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% block content %}
 <h2 class="mb-3 text-center">Test wydruku</h2>
-<form method="post" class="mb-3 row row-cols-1 row-cols-md-2 g-3 center-form mx-auto">
+<form method="post" class="mb-3 row row-cols-1 row-cols-md-2 g-3 col-md-6 mx-auto">
     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
     <div class="col-12 form-actions text-center">
         <button type="submit" class="btn btn-primary">Wydrukuj stronę testową</button>

--- a/magazyn/tests/test_base_template.py
+++ b/magazyn/tests/test_base_template.py
@@ -14,7 +14,7 @@ def test_nav_container_class(app_mod, client, login):
     assert nav_match, "nav section missing"
     nav_html = nav_match.group(1)
     assert "container-fluid" not in nav_html
-    assert 'class="custom-container"' in nav_html
+    assert 'class="container"' in nav_html
 
 
 def test_nav_contains_sales_link(app_mod, client, login):


### PR DESCRIPTION
## Summary
- streamline navbar markup to use Bootstrap `.container`
- drop obsolete `.center-form` and `.wide-form` CSS rules
- rely on Bootstrap grid classes in templates
- update base template test for new container class

## Testing
- `pytest -q` *(fails: Database session error)*

------
https://chatgpt.com/codex/tasks/task_e_686542e00e08832aa86de40bfa69cd98