### PR TITLE
Move add delivery buttons above form rows

### DIFF
--- a/magazyn/templates/add_delivery.html
+++ b/magazyn/templates/add_delivery.html
@@ -4,6 +4,10 @@
 <h2 class="mb-3 text-center">Dodaj dostawę</h2>
 <form action="{{ url_for('products.add_delivery') }}" method="post" class="row g-3 w-100">
     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+    <div class="col-12 text-end mb-2">
+        <button type="button" id="addRow" class="btn btn-secondary btn-sm"><i class="bi bi-plus-circle"></i></button>
+        <a href="{{ url_for('products.import_invoice') }}" class="btn btn-secondary btn-sm ms-2" title="Dostawa z faktury"><i class="bi bi-file-earmark-text"></i></a>
+    </div>
     <div id="deliveryRows">
         <div class="delivery-row row row-cols-1 row-cols-md-2 g-3 align-items-end">
             <div class="col-md-6">
@@ -34,10 +38,6 @@
                 <button type="button" class="btn btn-danger btn-sm remove-row" style="display: none;"><i class="bi bi-trash"></i></button>
             </div>
         </div>
-    </div>
-    <div class="col-12 text-end">
-        <button type="button" id="addRow" class="btn btn-secondary btn-sm"><i class="bi bi-plus-circle"></i></button>
-        <a href="{{ url_for('products.import_invoice') }}" class="btn btn-secondary btn-sm ms-2" title="Dostawa z faktury"><i class="bi bi-file-earmark-text"></i></a>
     </div>
     <div class="col-12 form-actions text-center">
         <button type="submit" class="btn btn-primary">Dodaj</button>


### PR DESCRIPTION
## Summary
- show delivery buttons before dynamic rows so they appear at page load

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686552666c8c832a8152c77cd191c439