### PR TITLE
Add warnings for missing stock and safe sales query

### DIFF
--- a/magazyn/db.py
+++ b/magazyn/db.py
@@ -179,6 +179,10 @@ def consume_stock(product_id, size, quantity):
             .filter_by(product_id=product_id, size=size)
             .first()
         )
+        if not ps:
+            logger.warning(
+                "Stock entry missing for product_id=%s size=%s", product_id, size
+            )
         available = ps.quantity if ps else 0
         to_consume = min(available, quantity)
 
@@ -224,5 +228,13 @@ def consume_stock(product_id, size, quantity):
                     send_stock_alert(name, size, ps.quantity)
                 except Exception as exc:
                     logger.error("Low stock alert failed: %s", exc)
+        else:
+            logger.warning(
+                "Sale not recorded for product_id=%s size=%s: requested=%s available=%s",
+                product_id,
+                size,
+                quantity,
+                available,
+            )
 
     return consumed

--- a/magazyn/sales.py
+++ b/magazyn/sales.py
@@ -27,7 +27,7 @@ def list_sales():
     with get_session() as db:
         rows = (
             db.query(Sale, Product)
-            .join(Product, Sale.product_id == Product.id)
+            .outerjoin(Product, Sale.product_id == Product.id)
             .order_by(Sale.sale_date.desc())
             .all()
         )
@@ -42,10 +42,13 @@ def list_sales():
                 - shipping
                 - sale.commission_fee
             )
+            name = "unknown" if not product else product.name
+            color = "" if not product else product.color
+            descr = f"{name} ({color}) {sale.size}" if color else f"{name} {sale.size}"
             sales.append(
                 {
                     "date": sale.sale_date,
-                    "product": f"{product.name} ({product.color}) {sale.size}",
+                    "product": descr,
                     "purchase_cost": sale.purchase_cost,
                     "commission": sale.commission_fee,
                     "shipping": shipping,

--- a/magazyn/services.py
+++ b/magazyn/services.py
@@ -161,6 +161,18 @@ def update_quantity(product_id: int, size: str, action: str):
                 ps.quantity += 1
             elif action == "decrease" and ps.quantity > 0:
                 consume_stock(product_id, size, 1)
+            elif action == "decrease":
+                logger.warning(
+                    "No stock to decrease for product_id=%s size=%s",
+                    product_id,
+                    size,
+                )
+        else:
+            logger.warning(
+                "Product id %s with size %s not found, quantity update skipped",
+                product_id,
+                size,
+            )
 
 
 def find_by_barcode(barcode: str) -> Optional[dict]:


### PR DESCRIPTION
## Summary
- warn when sales aren't recorded due to missing product or stock
- add warnings on quantity updates that can't reduce stock
- show sales even when product entry is missing using outer join

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686552880894832a91e403aee6aa2903