### PR TITLE
Refine settings UI and cleanup sales options

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,11 +43,8 @@ This repository contains the code for the RetrieverShop warehouse application an
 | `FLASK_DEBUG` | Set to `1` to enable Flask debug mode |
 | `FLASK_ENV` | Flask configuration environment |
 | `DEFAULT_SHIPPING_ALLEGRO` | Default shipping cost when selling on Allegro |
-| `DEFAULT_SHIPPING_VINTED` | Default shipping cost when selling on Vinted |
 | `FREE_SHIPPING_THRESHOLD_ALLEGRO` | Sale price above which Allegro shipping is free |
-| `FREE_SHIPPING_THRESHOLD_VINTED` | Sale price above which Vinted shipping is free |
 | `COMMISSION_ALLEGRO` | Commission percentage charged by Allegro |
-| `COMMISSION_VINTED` | Commission percentage charged by Vinted |
 
 `DB_PATH` is read only during application startup, so changing it requires
 restarting the server.

--- a/magazyn/app.py
+++ b/magazyn/app.py
@@ -44,6 +44,9 @@ ROOT_DIR = Path(__file__).resolve().parents[1]
 ENV_PATH = ROOT_DIR / ".env"
 EXAMPLE_PATH = ROOT_DIR / ".env.example"
 
+# Settings with boolean values represented as "1" or "0"
+BOOLEAN_KEYS = {"ENABLE_MONTHLY_REPORTS", "FLASK_DEBUG"}
+
 
 app = Flask(__name__)
 app.secret_key = settings.SECRET_KEY
@@ -231,7 +234,10 @@ def settings_page():
             {"key": key, "label": label, "desc": desc, "value": val}
         )
     return render_template(
-        "settings.html", settings=settings_list, db_path_notice=db_path_notice
+        "settings.html",
+        settings=settings_list,
+        db_path_notice=db_path_notice,
+        boolean_keys=BOOLEAN_KEYS,
     )
 
 

--- a/magazyn/sales.py
+++ b/magazyn/sales.py
@@ -61,7 +61,13 @@ def list_sales():
 
 def _sales_keys(values):
     keywords = ("SHIPPING", "COMMISSION", "EMAIL", "SMTP")
-    return [k for k in values.keys() if any(word in k for word in keywords)]
+    excluded = ("_VINTED",)
+    return [
+        k
+        for k in values.keys()
+        if any(word in k for word in keywords)
+        and not any(ex in k for ex in excluded)
+    ]
 
 
 @bp.route("/sales/settings", methods=["GET", "POST"])

--- a/magazyn/templates/settings.html
+++ b/magazyn/templates/settings.html
@@ -21,7 +21,12 @@
             </th>
             <td>
                 {% set lower = item.key.lower() %}
-                {% if 'shipping' in lower or 'commission' in lower %}
+                {% if item.key in boolean_keys %}
+                <select class="form-select" id="{{ item.key }}" name="{{ item.key }}">
+                    <option value="1" {% if item.value|string == '1' %}selected{% endif %}>Tak</option>
+                    <option value="0" {% if item.value|string != '1' %}selected{% endif %}>Nie</option>
+                </select>
+                {% elif 'shipping' in lower or 'commission' in lower %}
                 <input type="number" step="0.01" class="form-control" id="{{ item.key }}" name="{{ item.key }}" value="{{ item.value }}">
                 {% else %}
                 <input type="text" class="form-control" id="{{ item.key }}" name="{{ item.key }}" value="{{ item.value }}">


### PR DESCRIPTION
## Summary
- ignore deprecated Vinted variables in `sales_settings`
- offer dropdowns for boolean options on settings page
- document only active sales variables

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68654cab70fc832abafb608e44627f3a