### PR TITLE
Improve order item parsing

### DIFF
--- a/magazyn/constants.py
+++ b/magazyn/constants.py
@@ -1,1 +1,24 @@
 ALL_SIZES = ["XS", "S", "M", "L", "XL", "Uniwersalny"]
+
+# Common color names that may appear in product titles.  They are stored in
+# lowercase form to simplify comparisons when parsing strings.
+KNOWN_COLORS = [
+    "czerwony",
+    "czerwone",
+    "niebieski",
+    "niebieskie",
+    "zielony",
+    "zielone",
+    "czarny",
+    "czarne",
+    "biały",
+    "białe",
+    "brązowy",
+    "brązowe",
+    "różowy",
+    "różowe",
+    "fioletowy",
+    "fioletowe",
+    "srebrny",
+    "srebrne",
+]

--- a/magazyn/print_agent.py
+++ b/magazyn/print_agent.py
@@ -1,7 +1,6 @@
 from .notifications import send_report
 from .services import consume_order_stock, get_sales_summary
-from .constants import ALL_SIZES
-import re
+from .constants import ALL_SIZES, KNOWN_COLORS
 from magazyn import DB_PATH
 from .config import settings, load_config
 import os
@@ -472,14 +471,22 @@ def parse_product_info(item: dict) -> tuple[str, str, str]:
         elif aname in {"kolor", "color"} and not color:
             color = attr.get("value", "")
 
-    if not size or not color:
+    if not size:
         words = name.strip().split()
         if len(words) >= 3:
             maybe_size = words[-1]
             if maybe_size.upper() in {s.upper() for s in ALL_SIZES}:
-                size = size or maybe_size
-                color = color or words[-2]
+                size = maybe_size
+                if not color:
+                    color = words[-2]
                 name = " ".join(words[:-2])
+        if not size and len(words) >= 2:
+            maybe_color = words[-1].lower()
+            if maybe_color in {c.lower() for c in KNOWN_COLORS}:
+                if not color:
+                    color = words[-1]
+                size = "Uniwersalny"
+                name = " ".join(words[:-1])
 
     return name.strip(), size, color
 

--- a/magazyn/tests/test_utils.py
+++ b/magazyn/tests/test_utils.py
@@ -210,3 +210,12 @@ def test_ensure_db_migrates_wrong_name(tmp_path, monkeypatch):
     assert data["name"] == "Widget"
     assert data["color"] == "Blue"
     assert data["size"] == "XL"
+
+
+def test_parse_product_info_color_only():
+    bl = get_bl()
+    item = {"name": "Smycz dla psa czerwony"}
+    name, size, color = bl.parse_product_info(item)
+    assert name == "Smycz dla psa"
+    assert size == "Uniwersalny"
+    assert color.lower() == "czerwony"


### PR DESCRIPTION
## Summary
- detect colors in product titles when size info is missing
- update tests for the new `parse_product_info` behaviour

## Testing
- `pytest -q` *(fails: OperationalError - no such table: sales)*

------
https://chatgpt.com/codex/tasks/task_e_6865b9d5270c832a88455be8692afdfd