### PR TITLE
Add sale_price argument to consume_stock

### DIFF
--- a/magazyn/db.py
+++ b/magazyn/db.py
@@ -171,7 +171,7 @@ def record_sale(
     )
 
 
-def consume_stock(product_id, size, quantity):
+def consume_stock(product_id, size, quantity, sale_price=0.0):
     """Remove quantity from stock using cheapest purchase batches first."""
     with get_session() as session:
         ps = (
@@ -237,6 +237,7 @@ def consume_stock(product_id, size, quantity):
             size,
             quantity,
             purchase_cost=purchase_cost,
+            sale_price=sale_price,
         )
 
     return consumed

--- a/magazyn/services.py
+++ b/magazyn/services.py
@@ -160,7 +160,7 @@ def update_quantity(product_id: int, size: str, action: str):
             if action == "increase":
                 ps.quantity += 1
             elif action == "decrease" and ps.quantity > 0:
-                consume_stock(product_id, size, 1)
+                consume_stock(product_id, size, 1, sale_price=0)
             elif action == "decrease":
                 logger.warning(
                     "No stock to decrease for product_id=%s size=%s",
@@ -565,7 +565,12 @@ def consume_order_stock(products: List[dict]):
                 ps = query.first()
 
             if ps:
-                consume_stock(ps.product_id, ps.size, qty)
+                consume_stock(
+                    ps.product_id,
+                    ps.size,
+                    qty,
+                    sale_price=item.get("price_brutto", 0),
+                )
             else:
                 logger.warning(
                     "Unable to match product for order item: %s", item

--- a/magazyn/tests/test_deliveries.py
+++ b/magazyn/tests/test_deliveries.py
@@ -121,7 +121,7 @@ def test_consume_stock_cheapest(app_mod):
 
     app_mod.record_purchase(pid, "M", 2, 5.0)
     app_mod.record_purchase(pid, "M", 1, 4.0)
-    consumed = app_mod.consume_stock(pid, "M", 2)
+    consumed = app_mod.consume_stock(pid, "M", 2, sale_price=0)
 
     with app_mod.get_session() as db:
         qty = db.execute(

--- a/magazyn/tests/test_excel.py
+++ b/magazyn/tests/test_excel.py
@@ -123,7 +123,7 @@ def test_consume_stock_multiple_batches(app_mod):
     app_mod.record_purchase(pid, "M", 1, 5.0)
     app_mod.record_purchase(pid, "M", 1, 6.0)
 
-    consumed = app_mod.consume_stock(pid, "M", 2)
+    consumed = app_mod.consume_stock(pid, "M", 2, sale_price=0)
 
     with app_mod.get_session() as db:
         qty = db.execute(

--- a/magazyn/tests/test_reports.py
+++ b/magazyn/tests/test_reports.py
@@ -13,7 +13,7 @@ def test_low_stock_alert(app_mod, monkeypatch):
     importlib.reload(services)
     prod = services.create_product("Prod", "Red", {"M": 0}, {"M": "111"})
     app_mod.record_purchase(prod.id, "M", 3, 1.0)
-    app_mod.consume_stock(prod.id, "M", 2)
+    app_mod.consume_stock(prod.id, "M", 2, sale_price=0)
     assert alerts and alerts[0][2] == 1
 
 
@@ -23,7 +23,7 @@ def test_sales_summary(app_mod, monkeypatch):
     importlib.reload(services)
     prod = services.create_product("Prod", "Red", {"M": 0}, {"M": "111"})
     app_mod.record_purchase(prod.id, "M", 5, 1.0)
-    app_mod.consume_stock(prod.id, "M", 2)
+    app_mod.consume_stock(prod.id, "M", 2, sale_price=0)
     summary = services.get_sales_summary(7)
     assert summary[0]["sold"] == 2
     assert summary[0]["remaining"] == 3

--- a/magazyn/tests/test_sales.py
+++ b/magazyn/tests/test_sales.py
@@ -18,7 +18,7 @@ def test_sales_profit_calculated(app_mod, client, login):
         db.add(ProductSize(product_id=prod.id, size="M", quantity=0))
         pid = prod.id
     app_mod.record_purchase(pid, "M", 1, 10.0)
-    app_mod.consume_stock(pid, "M", 1)
+    app_mod.consume_stock(pid, "M", 1, sale_price=0)
     with app_mod.get_session() as db:
         sale = db.query(Sale).first()
         sale.sale_price = 20.0
@@ -43,7 +43,7 @@ def test_profit_uses_threshold(app_mod, client, login):
             ]
         )
     app_mod.record_purchase(pid, "M", 1, 10.0)
-    app_mod.consume_stock(pid, "M", 1)
+    app_mod.consume_stock(pid, "M", 1, sale_price=0)
     with app_mod.get_session() as db:
         sale = db.query(Sale).first()
         sale.sale_price = 120.0
@@ -62,7 +62,7 @@ def test_consume_stock_records_sale_without_inventory(app_mod):
         db.add(ProductSize(product_id=prod.id, size="M", quantity=0))
         pid = prod.id
 
-    consumed = app_mod.consume_stock(pid, "M", 2)
+    consumed = app_mod.consume_stock(pid, "M", 2, sale_price=0)
 
     assert consumed == 0
     with app_mod.get_session() as db:


### PR DESCRIPTION
## Summary
- propagate sale price info when consuming stock
- record printed order price through consume_order_stock
- adjust tests for the new consume_stock signature

## Testing
- `pytest -q magazyn/tests`

------
https://chatgpt.com/codex/tasks/task_e_6865c0548548832a9bae9323e36d5b6f