### PR TITLE
Fix barcode assignment when fulfilling orders

### DIFF
--- a/magazyn/services.py
+++ b/magazyn/services.py
@@ -563,6 +563,9 @@ def consume_order_stock(products: List[dict]):
                 if size is not None:
                     query = query.filter(ProductSize.size == size)
                 ps = query.first()
+                if ps and barcode and not ps.barcode:
+                    ps.barcode = barcode
+                    db.commit()
 
             if ps:
                 consume_stock(


### PR DESCRIPTION
## Summary
- update `consume_order_stock` to set missing barcodes when matching products

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865c3633090832a98375bb5afcb4ebf