### PR TITLE
Update parse_product_info logic

### DIFF
--- a/magazyn/print_agent.py
+++ b/magazyn/print_agent.py
@@ -483,10 +483,16 @@ def parse_product_info(item: dict) -> tuple[str, str, str]:
         if not size and len(words) >= 2:
             maybe_color = words[-1].lower()
             if maybe_color in {c.lower() for c in KNOWN_COLORS}:
-                if not color:
-                    color = words[-1]
-                size = "Uniwersalny"
-                name = " ".join(words[:-1])
+                if len(words) >= 3 and words[-2].upper() in {s.upper() for s in ALL_SIZES}:
+                    size = words[-2]
+                    if not color:
+                        color = words[-1]
+                    name = " ".join(words[:-2])
+                else:
+                    if not color:
+                        color = words[-1]
+                    size = "Uniwersalny"
+                    name = " ".join(words[:-1])
 
     return name.strip(), size, color
 

--- a/magazyn/tests/test_utils.py
+++ b/magazyn/tests/test_utils.py
@@ -219,3 +219,11 @@ def test_parse_product_info_color_only():
     assert name == "Smycz dla psa"
     assert size == "Uniwersalny"
     assert color.lower() == "czerwony"
+
+
+def test_parse_product_info_size_and_color_from_name():
+    bl = get_bl()
+    item = {"name": "Szelki dla psa Truelove Front Line Premium XL czarne"}
+    name, size, color = bl.parse_product_info(item)
+    assert size == "XL"
+    assert color.lower() == "czarne"


### PR DESCRIPTION
## Summary
- support size followed by color in product name parsing
- test parse_product_info handles size and color trailing tokens

## Testing
- `python -m pytest -q magazyn/tests/test_utils.py -vv`

------
https://chatgpt.com/codex/tasks/task_e_6866cd8cd008832a92c98c87fe9225c1