### PR TITLE
Add shipping costs management

### DIFF
--- a/magazyn/app.py
+++ b/magazyn/app.py
@@ -33,6 +33,7 @@ from .db import (
 from .products import bp as products_bp
 from .history import bp as history_bp
 from .sales import bp as sales_bp, _sales_keys
+from .shipping import bp as shipping_bp
 from .auth import login_required
 from .config import settings
 from . import print_agent
@@ -56,6 +57,7 @@ app.jinja_env.globals["ALL_SIZES"] = ALL_SIZES
 app.register_blueprint(products_bp)
 app.register_blueprint(history_bp)
 app.register_blueprint(sales_bp)
+app.register_blueprint(shipping_bp)
 
 
 @app.context_processor

--- a/magazyn/sales.py
+++ b/magazyn/sales.py
@@ -82,19 +82,6 @@ def sales_settings():
         for key in keys:
             values[key] = request.form.get(key, "")
         write_env(values)
-        mins = request.form.getlist("threshold_min")
-        costs = request.form.getlist("threshold_cost")
-        with get_session() as db:
-            db.query(ShippingThreshold).delete()
-            for m, c in zip(mins, costs):
-                if not m and not c:
-                    continue
-                db.add(
-                    ShippingThreshold(
-                        min_order_value=float(m or 0),
-                        shipping_cost=float(c or 0),
-                    )
-                )
         print_agent.reload_config()
         flash("Zapisano ustawienia.")
         return redirect(url_for("sales.sales_settings"))
@@ -110,12 +97,6 @@ def sales_settings():
                 "value": values[key],
             }
         )
-    with get_session() as db:
-        thresholds = (
-            db.query(ShippingThreshold)
-            .order_by(ShippingThreshold.min_order_value)
-            .all()
-        )
     return render_template(
-        "sales_settings.html", settings=settings_list, thresholds=thresholds
+        "sales_settings.html", settings=settings_list
     )

--- a/magazyn/shipping.py
+++ b/magazyn/shipping.py
@@ -1,0 +1,46 @@
+from flask import Blueprint, render_template, request, redirect, url_for, flash
+from .auth import login_required
+from pathlib import Path
+import pandas as pd
+
+bp = Blueprint("shipping", __name__)
+
+ALLEGRO_COSTS_FILE = Path(__file__).resolve().parent / "samples" / "deliveries_allegro.xlsx"
+
+
+def load_costs(file_path: Path = ALLEGRO_COSTS_FILE) -> pd.DataFrame:
+    """Load Allegro shipping costs from Excel."""
+    try:
+        return pd.read_excel(file_path, header=1)
+    except Exception:
+        return pd.DataFrame()
+
+
+def save_costs(df: pd.DataFrame, file_path: Path = ALLEGRO_COSTS_FILE) -> None:
+    """Save costs DataFrame back to Excel."""
+    df.to_excel(file_path, index=False)
+
+
+@bp.route("/shipping_costs", methods=["GET", "POST"])
+@login_required
+def shipping_costs():
+    df = load_costs()
+    columns = list(df.columns)
+    if request.method == "POST":
+        for r in range(len(df)):
+            for c_idx, col in enumerate(columns[1:]):
+                key = f"val_{r}_{c_idx}"
+                val = request.form.get(key, "0")
+                try:
+                    df.at[r, col] = float(val)
+                except ValueError:
+                    df.at[r, col] = val
+        save_costs(df)
+        flash("Zapisano koszty wysyłek.")
+        return redirect(url_for("shipping.shipping_costs"))
+
+    rows = df.to_dict(orient="records")
+    return render_template(
+        "shipping_costs.html", columns=columns, rows=rows
+    )
+

--- a/magazyn/templates/base.html
+++ b/magazyn/templates/base.html
@@ -49,6 +49,7 @@
                         <ul class="dropdown-menu dropdown-menu-dark">
                             <li><a class="dropdown-item" href="{{ url_for('settings_page') }}">Ustawienia</a></li>
                             <li><a class="dropdown-item" href="{{ url_for('sales.sales_settings') }}">Ustawienia sprzedaży</a></li>
+                            <li><a class="dropdown-item" href="{{ url_for('shipping.shipping_costs') }}">Koszty wysyłek</a></li>
                             <li><a class="dropdown-item" href="{{ url_for('agent_logs') }}">Logi</a></li>
                             <li><a class="dropdown-item" href="{{ url_for('test_print') }}">Testuj drukarkę</a></li>
                         </ul>
@@ -72,6 +73,7 @@
             <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('sales.list_sales') }}">Sprzedaż</a></li>
             <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('history.print_history') }}">Historia drukowania</a></li>
             <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('settings_page') }}">Ustawienia</a></li>
+            <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('shipping.shipping_costs') }}">Koszty wysyłek</a></li>
             <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('agent_logs') }}">Logi</a></li>
             <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('test_print') }}">Testuj drukarkę</a></li>
             <li class="nav-item mt-auto text-center">

--- a/magazyn/templates/sales_settings.html
+++ b/magazyn/templates/sales_settings.html
@@ -20,66 +20,8 @@
         {% endfor %}
         </tbody>
     </table>
-
-    <div class="col-12 text-center">
-        <h5 class="mt-4">Progi kosztów wysyłki</h5>
-    </div>
-    <table class="table" id="thresholdTable">
-        <thead>
-        <tr>
-            <th>Minimalna wartość zamówienia</th>
-            <th>Koszt wysyłki</th>
-            <th class="text-end">
-                <button type="button" id="addThresholdRow" class="btn btn-secondary btn-sm"><i class="bi bi-plus-circle"></i></button>
-            </th>
-        </tr>
-        </thead>
-        <tbody id="thresholdRows">
-        {% for t in thresholds %}
-        <tr class="threshold-row">
-            <td><input type="number" step="0.01" class="form-control" name="threshold_min" value="{{ '%.2f'|format(t.min_order_value) }}"></td>
-            <td><input type="number" step="0.01" class="form-control" name="threshold_cost" value="{{ '%.2f'|format(t.shipping_cost) }}"></td>
-            <td><button type="button" class="btn btn-danger btn-sm remove-row"><i class="bi bi-trash"></i></button></td>
-        </tr>
-        {% endfor %}
-        {% if thresholds|length == 0 %}
-        <tr class="threshold-row">
-            <td><input type="number" step="0.01" class="form-control" name="threshold_min"></td>
-            <td><input type="number" step="0.01" class="form-control" name="threshold_cost"></td>
-            <td><button type="button" class="btn btn-danger btn-sm remove-row"><i class="bi bi-trash"></i></button></td>
-        </tr>
-        {% endif %}
-        </tbody>
-        </table>
 </form>
 <div class="form-actions text-center mt-3">
     <button type="submit" form="salesSettingsForm" class="btn btn-primary">Zapisz</button>
 </div>
-<script>
-    function updateDeleteVisibility() {
-        const rows = document.querySelectorAll('.threshold-row');
-        rows.forEach((r, idx) => {
-            const btn = r.querySelector('.remove-row');
-            if (btn) btn.style.display = idx > 0 ? 'inline-block' : 'none';
-        });
-    }
-
-    document.getElementById('addThresholdRow').addEventListener('click', () => {
-        const container = document.getElementById('thresholdRows');
-        const row = container.querySelector('.threshold-row').cloneNode(true);
-        row.querySelectorAll('input').forEach(i => i.value = '');
-        container.appendChild(row);
-        updateDeleteVisibility();
-    });
-    document.addEventListener('click', e => {
-        if (e.target.classList.contains('remove-row')) {
-            const rows = document.querySelectorAll('.threshold-row');
-            if (rows.length > 1) {
-                e.target.closest('.threshold-row').remove();
-                updateDeleteVisibility();
-            }
-        }
-    });
-    updateDeleteVisibility();
-</script>
 {% endblock %}

--- a/magazyn/templates/shipping_costs.html
+++ b/magazyn/templates/shipping_costs.html
@@ -1,0 +1,46 @@
+{% extends "base.html" %}
+{% block content %}
+<h2 class="mb-3 text-center">Koszty wysyłek Allegro</h2>
+<form method="post" id="shippingForm" class="table-responsive">
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+    <div class="form-check form-switch text-end mb-2">
+        <input class="form-check-input" type="checkbox" id="editToggle">
+        <label class="form-check-label" for="editToggle">Tryb edycji</label>
+    </div>
+    <table class="table" id="shippingTable">
+        <thead>
+            <tr>
+                <th>{{ columns[0] }}</th>
+                {% for col in columns[1:] %}
+                <th>{{ col }}</th>
+                {% endfor %}
+            </tr>
+        </thead>
+        <tbody>
+            {% for row in rows %}
+            {% set ridx = loop.index0 %}
+            <tr>
+                <td>{{ row[columns[0]] }}</td>
+                {% for col in columns[1:] %}
+                <td>
+                    <input type="number" step="0.01" class="form-control" name="val_{{ ridx }}_{{ loop.index0 }}" value="{{ row[col] }}" disabled>
+                </td>
+                {% endfor %}
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+    <div class="text-center">
+        <button type="submit" class="btn btn-primary mt-3" id="saveBtn" disabled>Zapisz</button>
+    </div>
+</form>
+<script>
+    const toggle = document.getElementById('editToggle');
+    const inputs = document.querySelectorAll('#shippingTable input');
+    const saveBtn = document.getElementById('saveBtn');
+    toggle.addEventListener('change', () => {
+        inputs.forEach(i => i.disabled = !toggle.checked);
+        saveBtn.disabled = !toggle.checked;
+    });
+</script>
+{% endblock %}

--- a/magazyn/tests/test_base_template.py
+++ b/magazyn/tests/test_base_template.py
@@ -35,3 +35,13 @@ def test_nav_contains_sales_settings_link(app_mod, client, login):
     resp = client.get("/")
     html = resp.get_data(as_text=True)
     assert f'href="{settings_url}"' in html
+
+
+def test_nav_contains_shipping_link(app_mod, client, login):
+    from flask import url_for
+
+    with app_mod.app.test_request_context():
+        shipping_url = url_for("shipping.shipping_costs")
+    resp = client.get("/")
+    html = resp.get_data(as_text=True)
+    assert f'href="{shipping_url}"' in html

--- a/magazyn/tests/test_sales_settings.py
+++ b/magazyn/tests/test_sales_settings.py
@@ -39,23 +39,3 @@ def test_sales_settings_post_saves(
     assert reloaded["called"] is True
 
 
-def test_thresholds_saved_and_displayed(app_mod, client, login):
-    from magazyn.models import ShippingThreshold
-
-    with app_mod.get_session() as db:
-        db.add(ShippingThreshold(min_order_value=0.0, shipping_cost=10.0))
-
-    resp = client.get("/sales/settings")
-    assert resp.status_code == 200
-    assert "10.00" in resp.get_data(as_text=True)
-
-    data = {
-        "threshold_min": ["0", "100"],
-        "threshold_cost": ["8", "0"],
-    }
-    client.post("/sales/settings", data=data)
-
-    with app_mod.get_session() as db:
-        rows = db.query(ShippingThreshold).order_by(ShippingThreshold.min_order_value).all()
-        assert len(rows) == 2
-        assert rows[1].min_order_value == 100.0

--- a/magazyn/tests/test_shipping_costs.py
+++ b/magazyn/tests/test_shipping_costs.py
@@ -1,0 +1,62 @@
+import pandas as pd
+
+
+def _create_file(path):
+    cols = [
+        "Metoda dostawy",
+        "30-44",
+        "45-64",
+        "65-99",
+        "100-149",
+        "150+",
+        "Max",
+    ]
+    df = pd.DataFrame([
+        ["ignored", "", "", "", "", "", ""],
+        cols,
+        ["M1", 1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
+        ["M2", 2.0, 3.0, 4.0, 5.0, 6.0, 7.0],
+    ])
+    df.to_excel(path, index=False, header=False)
+
+
+def test_shipping_costs_load(app_mod, client, login, tmp_path, monkeypatch):
+    from magazyn import shipping
+
+    file_path = tmp_path / "costs.xlsx"
+    _create_file(file_path)
+    monkeypatch.setattr(shipping, "ALLEGRO_COSTS_FILE", file_path)
+    original_load = shipping.load_costs
+    original_save = shipping.save_costs
+    monkeypatch.setattr(shipping, "load_costs", lambda fp=file_path: original_load(fp))
+    monkeypatch.setattr(shipping, "save_costs", lambda df, fp=file_path: original_save(df, fp))
+    resp = client.get("/shipping_costs")
+    assert resp.status_code == 200
+    html = resp.get_data(as_text=True)
+    assert "M1" in html
+    assert "M2" in html
+
+
+def test_shipping_costs_edit(app_mod, client, login, tmp_path, monkeypatch):
+    from magazyn import shipping
+
+    file_path = tmp_path / "costs.xlsx"
+    _create_file(file_path)
+    monkeypatch.setattr(shipping, "ALLEGRO_COSTS_FILE", file_path)
+    original_load = shipping.load_costs
+    original_save = shipping.save_costs
+    monkeypatch.setattr(shipping, "load_costs", lambda fp=file_path: original_load(fp))
+    monkeypatch.setattr(shipping, "save_costs", lambda df, fp=file_path: original_save(df, fp))
+
+    df = shipping.load_costs(file_path)
+    data = {}
+    for i in range(len(df)):
+        for j, col in enumerate(df.columns[1:]):
+            val = str(df.iloc[i][col])
+            if i == 0 and j == 0:
+                val = "9.99"
+            data[f"val_{i}_{j}"] = val
+    client.post("/shipping_costs", data=data)
+    df2 = pd.read_excel(file_path, header=None)
+    assert abs(float(df2.iloc[1, 1]) - 9.99) < 0.01
+


### PR DESCRIPTION
## Summary
- create new `shipping` blueprint with `/shipping_costs` view
- add page and table template for Allegro shipping costs
- link "Koszty wysyłek" from settings dropdown and mobile menu
- simplify sales settings page and route
- add unit tests for new view

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866cfb471cc832a8daeccc179c98436