### PR TITLE
Remove unused Allegro shipping settings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,12 +34,6 @@ DB_PATH=/app/database.db
 SECRET_KEY=changeme
 FLASK_DEBUG=1
 
-# Default shipping costs
-DEFAULT_SHIPPING_ALLEGRO=10.0
-
-# Free shipping thresholds
-FREE_SHIPPING_THRESHOLD_ALLEGRO=0
-
 # Platform commission percentages
 COMMISSION_ALLEGRO=10.0
 

--- a/README.md
+++ b/README.md
@@ -42,8 +42,6 @@ This repository contains the code for the RetrieverShop warehouse application an
 | `SECRET_KEY` | Secret key for Flask sessions |
 | `FLASK_DEBUG` | Set to `1` to enable Flask debug mode |
 | `FLASK_ENV` | Flask configuration environment |
-| `DEFAULT_SHIPPING_ALLEGRO` | Default shipping cost when selling on Allegro |
-| `FREE_SHIPPING_THRESHOLD_ALLEGRO` | Sale price above which Allegro shipping is free |
 | `COMMISSION_ALLEGRO` | Commission percentage charged by Allegro |
 | `ENABLE_MONTHLY_REPORTS` | Set to `1` to send monthly sales reports |
 

--- a/magazyn/config.py
+++ b/magazyn/config.py
@@ -28,12 +28,6 @@ def load_config():
         ),
         SECRET_KEY=os.getenv("SECRET_KEY", "default_secret_key"),
         FLASK_DEBUG=os.getenv("FLASK_DEBUG") == "1",
-        DEFAULT_SHIPPING_ALLEGRO=float(
-            os.getenv("DEFAULT_SHIPPING_ALLEGRO", "0")
-        ),
-        FREE_SHIPPING_THRESHOLD_ALLEGRO=float(
-            os.getenv("FREE_SHIPPING_THRESHOLD_ALLEGRO", "0")
-        ),
         COMMISSION_ALLEGRO=float(os.getenv("COMMISSION_ALLEGRO", "0")),
         LOW_STOCK_THRESHOLD=int(os.getenv("LOW_STOCK_THRESHOLD", "1")),
         ALERT_EMAIL=os.getenv("ALERT_EMAIL"),

--- a/magazyn/env_info.py
+++ b/magazyn/env_info.py
@@ -43,14 +43,6 @@ ENV_INFO = {
         "Ustaw 1 aby włączyć tryb debugowania Flask",
     ),
     "FLASK_ENV": ("Środowisko Flask", "Konfiguracja środowiska Flask"),
-    "DEFAULT_SHIPPING_ALLEGRO": (
-        "Wysyłka Allegro",
-        "Domyślny koszt wysyłki dla platformy Allegro",
-    ),
-    "FREE_SHIPPING_THRESHOLD_ALLEGRO": (
-        "Próg darmowej wysyłki Allegro",
-        "Kwota sprzedaży powyżej której wysyłka jest darmowa",
-    ),
     "COMMISSION_ALLEGRO": (
         "Prowizja Allegro (%)",
         "Procent prowizji pobieranej przez Allegro",

--- a/magazyn/tests/conftest.py
+++ b/magazyn/tests/conftest.py
@@ -8,8 +8,6 @@ import magazyn.config as cfg
 @pytest.fixture
 def app_mod(tmp_path, monkeypatch):
     monkeypatch.setattr(cfg.settings, "DB_PATH", ":memory:")
-    monkeypatch.setattr(cfg.settings, "DEFAULT_SHIPPING_ALLEGRO", 8.0)
-    monkeypatch.setattr(cfg.settings, "FREE_SHIPPING_THRESHOLD_ALLEGRO", 150.0)
     monkeypatch.setattr(cfg.settings, "COMMISSION_ALLEGRO", 10.0)
     import magazyn.sales as sales_mod
 

--- a/magazyn/tests/test_sales_settings.py
+++ b/magazyn/tests/test_sales_settings.py
@@ -1,7 +1,5 @@
 def _sales_keys():
     return [
-        "DEFAULT_SHIPPING_ALLEGRO",
-        "FREE_SHIPPING_THRESHOLD_ALLEGRO",
         "COMMISSION_ALLEGRO",
         "ALERT_EMAIL",
         "SMTP_SERVER",


### PR DESCRIPTION
## Summary
- drop `DEFAULT_SHIPPING_ALLEGRO` and `FREE_SHIPPING_THRESHOLD_ALLEGRO`
- update config and environment info
- clean up sales settings tests

## Testing
- `pip install -q -r magazyn/requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866d4090c04832a961ce4f65da0f016