### PR TITLE
Add courier code support

### DIFF
--- a/magazyn/print_agent.py
+++ b/magazyn/print_agent.py
@@ -507,6 +507,7 @@ def send_messenger_message(data):
                 for p in data.get("products", [])
             )
             + f"🚚 Wysyłka: {data.get('shipping', '-')}\n"
+            f"🚛 Kurier: {data.get('courier_code', '-')}\n"
             f"🌐 Platforma: {data.get('platform', '-')}\n"
             f"📎 ID: {data.get('order_id', '-')}"
         )
@@ -620,6 +621,7 @@ def _agent_loop():
                     "platform": order.get("order_source", "brak"),
                     "shipping": order.get("delivery_method", "brak"),
                     "products": order.get("products", []),
+                    "courier_code": "",
                 }
 
                 if order_id in printed:
@@ -628,11 +630,14 @@ def _agent_loop():
                 # Skip logging order details to avoid sensitive data in logs
                 packages = get_order_packages(order_id)
                 labels = []
+                courier_code = ""
 
                 for p in packages:
                     package_id = p.get("package_id")
-                    courier_code = p.get("courier_code")
-                    if not package_id or not courier_code:
+                    code = p.get("courier_code")
+                    if code and not courier_code:
+                        courier_code = code
+                    if not package_id or not code:
                         logger.warning(
                             "  Brak danych: package_id lub courier_code"
                         )
@@ -646,6 +651,9 @@ def _agent_loop():
                     else:
                         # Missing label data
                         pass
+
+                if courier_code:
+                    last_order_data["courier_code"] = courier_code
 
                 if labels:
                     if is_quiet_time():

--- a/magazyn/templates/history.html
+++ b/magazyn/templates/history.html
@@ -4,7 +4,7 @@
 {# .table-responsive ensures horizontal scrolling when needed #}
 <div class="table-responsive">
 <table class="table table-striped table-sm w-100">
-    <thead><tr><th>ID zamówienia</th><th>Nazwa</th><th>Kolor</th><th>Rozmiar</th><th>Czas</th><th>Akcje</th></tr></thead>
+    <thead><tr><th>ID zamówienia</th><th>Nazwa</th><th>Kolor</th><th>Rozmiar</th><th>Kurier</th><th>Czas</th><th>Akcje</th></tr></thead>
     <tbody>
     {% for item in printed %}
     <tr>
@@ -12,6 +12,7 @@
         <td>{{ item.last_order_data.name or '' }}</td>
         <td>{{ item.last_order_data.color or '' }}</td>
         <td>{{ item.last_order_data.size or '' }}</td>
+        <td>{{ item.last_order_data.courier_code or '' }}</td>
         <td>{{ item.printed_at.strftime('%Y-%m-%d %H:%M') }}</td>
         <td>
             <form class="d-inline" method="post" action="{{ url_for('history.reprint_label', order_id=item.order_id) }}">
@@ -27,6 +28,7 @@
         <td>{{ item.last_order_data.name or '' }}</td>
         <td>{{ item.last_order_data.color or '' }}</td>
         <td>{{ item.last_order_data.size or '' }}</td>
+        <td>{{ item.last_order_data.courier_code or '' }}</td>
         <td>w kolejce</td>
         <td></td>
     </tr>

--- a/magazyn/tests/test_courier_code.py
+++ b/magazyn/tests/test_courier_code.py
@@ -1,0 +1,39 @@
+import importlib
+import magazyn.print_agent as pa
+
+
+def test_agent_loop_stores_courier_code(monkeypatch):
+    mod = importlib.reload(pa)
+
+    monkeypatch.setattr(mod, "_send_periodic_reports", lambda: None)
+    monkeypatch.setattr(mod, "clean_old_printed_orders", lambda: None)
+    monkeypatch.setattr(mod, "load_printed_orders", lambda: [])
+    monkeypatch.setattr(mod, "load_queue", lambda: [])
+    monkeypatch.setattr(mod, "save_queue", lambda q: None)
+    monkeypatch.setattr(mod, "is_quiet_time", lambda: False)
+    monkeypatch.setattr(mod, "consume_order_stock", lambda p: None)
+    monkeypatch.setattr(mod, "print_label", lambda d,e,o: None)
+
+    captured = {}
+    monkeypatch.setattr(mod, "mark_as_printed", lambda oid, data=None: captured.setdefault("marked", data))
+    monkeypatch.setattr(mod, "send_messenger_message", lambda data: captured.setdefault("mess", data))
+
+    monkeypatch.setattr(mod, "get_orders", lambda: [{"order_id": 1, "products": [{"name": "Prod", "quantity": 1}]}])
+    monkeypatch.setattr(mod, "get_order_packages", lambda oid: [{"package_id": "p1", "courier_code": "DHL"}])
+    monkeypatch.setattr(mod, "get_label", lambda code, pid: ("data", "pdf"))
+
+    class Stopper:
+        def __init__(self):
+            self.calls = 0
+        def is_set(self):
+            return self.calls > 0
+        def wait(self, t):
+            self.calls += 1
+    mod._stop_event = Stopper()
+    mod.POLL_INTERVAL = 0
+
+    mod._agent_loop()
+
+    assert mod.last_order_data.get("courier_code") == "DHL"
+    assert captured["mess"].get("courier_code") == "DHL"
+    assert captured["marked"].get("courier_code") == "DHL"

--- a/magazyn/tests/test_history.py
+++ b/magazyn/tests/test_history.py
@@ -6,7 +6,7 @@ def test_history_page_shows_reprint_form(app_mod, client, login, monkeypatch):
     item = {
         "order_id": "1",
         "printed_at": ts,
-        "last_order_data": {"name": "N", "color": "C", "size": "S"},
+        "last_order_data": {"name": "N", "color": "C", "size": "S", "courier_code": "K"},
     }
     monkeypatch.setattr(
         app_mod.print_agent, "load_printed_orders", lambda: [item]
@@ -28,6 +28,7 @@ def test_history_page_shows_reprint_form(app_mod, client, login, monkeypatch):
     assert "N" in html
     assert "C" in html
     assert "S" in html
+    assert "K" in html
 
 
 def test_reprint_route_uses_api(app_mod, client, login, monkeypatch):


### PR DESCRIPTION
## Summary
- handle courier code in print agent
- show courier info in Messenger alerts
- display courier column on history page
- test courier code extraction and display

## Testing
- `pip install -r magazyn/requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866d54cb758832a8f2a3d795b958357