### PR TITLE
Remove Vinted exclusion from sales keys

### DIFF
--- a/magazyn/sales.py
+++ b/magazyn/sales.py
@@ -61,13 +61,7 @@ def list_sales():
 
 def _sales_keys(values):
     keywords = ("SHIPPING", "COMMISSION", "EMAIL", "SMTP")
-    excluded = ("_VINTED",)
-    return [
-        k
-        for k in values.keys()
-        if any(word in k for word in keywords)
-        and not any(ex in k for ex in excluded)
-    ]
+    return [k for k in values.keys() if any(word in k for word in keywords)]
 
 
 @bp.route("/sales/settings", methods=["GET", "POST"])


### PR DESCRIPTION
## Summary
- clean up obsolete Vinted filtering from `_sales_keys`

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866de4c51a0832ab89fa4c7e7942d60