### PR TITLE
Address flake8 line length issues

### DIFF
--- a/magazyn/db.py
+++ b/magazyn/db.py
@@ -181,7 +181,9 @@ def consume_stock(product_id, size, quantity, sale_price=0.0):
         )
         if not ps:
             logger.warning(
-                "Stock entry missing for product_id=%s size=%s", product_id, size
+                "Missing stock entry for product_id=%s size=%s",
+                product_id,
+                size,
             )
         available = ps.quantity if ps else 0
         to_consume = min(available, quantity)
@@ -224,7 +226,8 @@ def consume_stock(product_id, size, quantity, sale_price=0.0):
 
         if consumed < quantity:
             logger.warning(
-                "Insufficient stock for product_id=%s size=%s: requested=%s consumed=%s",
+                "Insufficient stock for product_id=%s size=%s:"
+                " requested=%s consumed=%s",
                 product_id,
                 size,
                 quantity,

--- a/magazyn/history.py
+++ b/magazyn/history.py
@@ -42,7 +42,10 @@ def reprint_label(order_id):
                     item.get("label_data"), item.get("ext", "pdf"), order_id
                 )
             print_agent.save_queue(remaining)
-            print_agent.mark_as_printed(order_id, queue[0].get("last_order_data", printed_data))
+            print_agent.mark_as_printed(
+                order_id,
+                queue[0].get("last_order_data", printed_data),
+            )
         else:
             packages = print_agent.get_order_packages(order_id)
             for p in packages:

--- a/magazyn/sales.py
+++ b/magazyn/sales.py
@@ -44,7 +44,11 @@ def list_sales():
             )
             name = "unknown" if not product else product.name
             color = "" if not product else product.color
-            descr = f"{name} ({color}) {sale.size}" if color else f"{name} {sale.size}"
+            descr = (
+                f"{name} ({color}) {sale.size}"
+                if color
+                else f"{name} {sale.size}"
+            )
             sales.append(
                 {
                     "date": sale.sale_date,

--- a/magazyn/services.py
+++ b/magazyn/services.py
@@ -169,7 +169,7 @@ def update_quantity(product_id: int, size: str, action: str):
                 )
         else:
             logger.warning(
-                "Product id %s with size %s not found, quantity update skipped",
+                "Product id %s size %s not found, quantity update skipped",
                 product_id,
                 size,
             )
@@ -578,7 +578,11 @@ def consume_order_stock(products: List[dict]):
                 logger.warning(
                     "Unable to match product for order item: %s", item
                 )
-                placeholder = db.query(Product).filter_by(name="Unknown").first()
+                placeholder = (
+                    db.query(Product)
+                    .filter_by(name="Unknown")
+                    .first()
+                )
                 if not placeholder:
                     placeholder = Product(name="Unknown", color="")
                     db.add(placeholder)

--- a/magazyn/shipping.py
+++ b/magazyn/shipping.py
@@ -5,7 +5,9 @@ import pandas as pd
 
 bp = Blueprint("shipping", __name__)
 
-ALLEGRO_COSTS_FILE = Path(__file__).resolve().parent / "samples" / "deliveries_allegro.xlsx"
+ALLEGRO_COSTS_FILE = (
+    Path(__file__).resolve().parent / "samples" / "deliveries_allegro.xlsx"
+)
 
 
 def load_costs(file_path: Path = ALLEGRO_COSTS_FILE) -> pd.DataFrame:
@@ -43,4 +45,3 @@ def shipping_costs():
     return render_template(
         "shipping_costs.html", columns=columns, rows=rows
     )
-

--- a/magazyn/tests/test_courier_code.py
+++ b/magazyn/tests/test_courier_code.py
@@ -12,7 +12,7 @@ def test_agent_loop_stores_courier_code(monkeypatch):
     monkeypatch.setattr(mod, "save_queue", lambda q: None)
     monkeypatch.setattr(mod, "is_quiet_time", lambda: False)
     monkeypatch.setattr(mod, "consume_order_stock", lambda p: None)
-    monkeypatch.setattr(mod, "print_label", lambda d,e,o: None)
+    monkeypatch.setattr(mod, "print_label", lambda d, e, o: None)
 
     captured = {}
     monkeypatch.setattr(mod, "mark_as_printed", lambda oid, data=None: captured.setdefault("marked", data))
@@ -25,8 +25,10 @@ def test_agent_loop_stores_courier_code(monkeypatch):
     class Stopper:
         def __init__(self):
             self.calls = 0
+
         def is_set(self):
             return self.calls > 0
+
         def wait(self, t):
             self.calls += 1
     mod._stop_event = Stopper()

--- a/magazyn/tests/test_sales_settings.py
+++ b/magazyn/tests/test_sales_settings.py
@@ -35,5 +35,3 @@ def test_sales_settings_post_saves(
     for key, val in values.items():
         assert f"{key}={val}" in env_text
     assert reloaded["called"] is True
-
-

--- a/magazyn/tests/test_shipping_costs.py
+++ b/magazyn/tests/test_shipping_costs.py
@@ -59,4 +59,3 @@ def test_shipping_costs_edit(app_mod, client, login, tmp_path, monkeypatch):
     client.post("/shipping_costs", data=data)
     df2 = pd.read_excel(file_path, header=None)
     assert abs(float(df2.iloc[1, 1]) - 9.99) < 0.01
-

--- a/magazyn/tests/test_utils.py
+++ b/magazyn/tests/test_utils.py
@@ -171,6 +171,7 @@ def test_load_queue_handles_corrupted_json(tmp_path, monkeypatch):
 
 def test_call_api_handles_http_error(monkeypatch):
     bl = get_bl()
+
     class DummyResp:
         status_code = 500
 


### PR DESCRIPTION
## Summary
- shorten long log messages in `db.py`
- break long `mark_as_printed` call in `history.py`
- wrap long log strings in services and sales
- wrap long path for `ALLEGRO_COSTS_FILE`
- clean up tests formatting

## Testing
- `flake8`
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6866eb83e6f4832aa369a0ecad00e501