### PR TITLE
Enhance login inputs with ids and autofocus

### DIFF
--- a/magazyn/templates/login.html
+++ b/magazyn/templates/login.html
@@ -6,12 +6,12 @@
     {{ form.csrf_token }}
     <div class="col-12">
         <label for="username" class="form-label">Nazwa użytkownika:</label>
-        <input type="text" name="username" required class="form-control">
+        <input id="username" type="text" name="username" required class="form-control" autofocus>
     </div>
 
     <div class="col-12">
         <label for="password" class="form-label">Hasło:</label>
-        <input type="password" name="password" required class="form-control">
+        <input id="password" type="password" name="password" required class="form-control">
     </div>
 
     <div class="col-12 form-actions text-center">


### PR DESCRIPTION
## Summary
- add `id` attributes to login inputs
- allow username field to autofocus on page load

## Testing
- `pip install -r magazyn/requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68678be830c4832a94be0dbf60c7aafb