### PR TITLE
Fix login form label wrapping

### DIFF
--- a/magazyn/static/styles.css
+++ b/magazyn/static/styles.css
@@ -27,6 +27,10 @@ h2, h3 {
     margin: auto;
 }
 
+.login-form label {
+    white-space: nowrap;
+}
+
 
 
 label, input, button {


### PR DESCRIPTION
## Summary
- prevent login labels from wrapping so fields align better

## Testing
- `pip install -r magazyn/requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68678fd7eaac832a94b0328e5104655d