### PR TITLE
Hide environment keys in settings pages

### DIFF
--- a/magazyn/templates/sales_settings.html
+++ b/magazyn/templates/sales_settings.html
@@ -11,7 +11,6 @@
             <th scope="row">
                 {{ item.label }}
                 {% if item.desc %}<br><small class="text-muted">{{ item.desc }}</small>{% endif %}
-                {% if item.label != item.key %}<br><small class="text-muted">{{ item.key }}</small>{% endif %}
             </th>
             <td>
                 <input type="number" step="0.01" class="form-control" id="{{ item.key }}" name="{{ item.key }}" value="{{ item.value }}">

--- a/magazyn/templates/settings.html
+++ b/magazyn/templates/settings.html
@@ -17,7 +17,6 @@
             <th scope="row">
                 {{ item.label }}
                 {% if item.desc %}<br><small class="text-muted">{{ item.desc }}</small>{% endif %}
-                {% if item.label != item.key %}<br><small class="text-muted">{{ item.key }}</small>{% endif %}
             </th>
             <td>
                 {% set lower = item.key.lower() %}

--- a/magazyn/tests/test_sales_settings.py
+++ b/magazyn/tests/test_sales_settings.py
@@ -14,8 +14,10 @@ def test_sales_settings_list_keys(app_mod, client, login, tmp_path):
     resp = client.get("/sales/settings")
     assert resp.status_code == 200
     html = resp.get_data(as_text=True)
+    from magazyn.env_info import ENV_INFO
     for key in _sales_keys():
-        assert key in html
+        label = ENV_INFO.get(key, (key, None))[0]
+        assert label in html
 
 
 def test_sales_settings_post_saves(

--- a/magazyn/tests/test_settings.py
+++ b/magazyn/tests/test_settings.py
@@ -12,12 +12,14 @@ def test_settings_list_all_keys(app_mod, client, login, tmp_path):
     text = resp.get_data(as_text=True)
     values = app_mod.load_settings()
     from magazyn.sales import _sales_keys
+    from magazyn.env_info import ENV_INFO
     sales_keys = _sales_keys(values)
     for key in values.keys():
+        label = ENV_INFO.get(key, (key, None))[0]
         if key in sales_keys:
-            assert key not in text
+            assert label not in text
         else:
-            assert key in text
+            assert label in text
 
 
 def test_settings_post_saves_and_reloads(
@@ -85,7 +87,9 @@ def test_extra_keys_display_and_save(
     resp = client.get("/settings")
     assert resp.status_code == 200
     html = resp.get_data(as_text=True)
-    assert "EXTRA_KEY" in html
+    from magazyn.env_info import ENV_INFO
+    label = ENV_INFO.get("EXTRA_KEY", ("EXTRA_KEY", None))[0]
+    assert label in html
 
     values = app_mod.load_settings()
     assert values.get("EXTRA_KEY") == "foo"


### PR DESCRIPTION
## Summary
- remove conditional block displaying raw key names in `settings.html` and `sales_settings.html`
- check for labels in settings-related tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686794d8a464832aa29a855df8f0ac8a