### PR TITLE
Add FLASK_ENV config and update settings form

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,6 +33,7 @@ DB_PATH=/app/database.db
 # Web app settings
 SECRET_KEY=changeme
 FLASK_DEBUG=1
+FLASK_ENV=production
 
 # Platform commission percentages
 COMMISSION_ALLEGRO=10.0

--- a/magazyn/config.py
+++ b/magazyn/config.py
@@ -28,6 +28,7 @@ def load_config():
         ),
         SECRET_KEY=os.getenv("SECRET_KEY", "default_secret_key"),
         FLASK_DEBUG=os.getenv("FLASK_DEBUG") == "1",
+        FLASK_ENV=os.getenv("FLASK_ENV", "production"),
         COMMISSION_ALLEGRO=float(os.getenv("COMMISSION_ALLEGRO", "0")),
         LOW_STOCK_THRESHOLD=int(os.getenv("LOW_STOCK_THRESHOLD", "1")),
         ALERT_EMAIL=os.getenv("ALERT_EMAIL"),

--- a/magazyn/templates/settings.html
+++ b/magazyn/templates/settings.html
@@ -27,6 +27,18 @@
                 </select>
                 {% elif 'shipping' in lower or 'commission' in lower %}
                 <input type="number" step="0.01" class="form-control" id="{{ item.key }}" name="{{ item.key }}" value="{{ item.value }}">
+                {% elif item.key == 'LOG_LEVEL' %}
+                <select class="form-select" id="{{ item.key }}" name="{{ item.key }}">
+                    {% for lvl in ['DEBUG','INFO','WARNING','ERROR','CRITICAL'] %}
+                    <option value="{{ lvl }}" {% if item.value == lvl %}selected{% endif %}>{{ lvl }}</option>
+                    {% endfor %}
+                </select>
+                {% elif item.key == 'FLASK_ENV' %}
+                <select class="form-select" id="{{ item.key }}" name="{{ item.key }}">
+                    {% for env in ['production','development'] %}
+                    <option value="{{ env }}" {% if item.value == env %}selected{% endif %}>{{ env }}</option>
+                    {% endfor %}
+                </select>
                 {% else %}
                 <input type="text" class="form-control" id="{{ item.key }}" name="{{ item.key }}" value="{{ item.value }}">
                 {% endif %}


### PR DESCRIPTION
## Summary
- support `FLASK_ENV` in configuration
- add dropdowns for log level and Flask environment on settings page
- list `FLASK_ENV` in `.env.example`

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68679c125ff8832a9f2ae1c14a2a9bbf