### PR TITLE
Mask password inputs in settings pages

### DIFF
--- a/magazyn/templates/sales_settings.html
+++ b/magazyn/templates/sales_settings.html
@@ -13,7 +13,19 @@
                 {% if item.desc %}<br><small class="text-muted">{{ item.desc }}</small>{% endif %}
             </th>
             <td>
+                {% set lower = item.key.lower() %}
+                {% if 'password' in lower or 'secret' in lower %}
+                <div class="input-group">
+                    <input type="password" class="form-control" id="{{ item.key }}" name="{{ item.key }}" value="{{ item.value }}">
+                    <span class="input-group-text toggle-password" data-target="{{ item.key }}">
+                        <i class="bi bi-eye"></i>
+                    </span>
+                </div>
+                {% elif 'commission' in lower or 'port' in lower %}
                 <input type="number" step="0.01" class="form-control" id="{{ item.key }}" name="{{ item.key }}" value="{{ item.value }}">
+                {% else %}
+                <input type="text" class="form-control" id="{{ item.key }}" name="{{ item.key }}" value="{{ item.value }}">
+                {% endif %}
             </td>
         </tr>
         {% endfor %}
@@ -23,4 +35,19 @@
 <div class="form-actions text-center mt-3">
     <button type="submit" form="salesSettingsForm" class="btn btn-primary">Zapisz</button>
 </div>
+<script>
+    document.querySelectorAll('.toggle-password').forEach(btn => {
+        btn.addEventListener('click', () => {
+            const input = document.getElementById(btn.dataset.target);
+            if (!input) return;
+            if (input.type === 'password') {
+                input.type = 'text';
+                btn.innerHTML = '<i class="bi bi-eye-slash"></i>';
+            } else {
+                input.type = 'password';
+                btn.innerHTML = '<i class="bi bi-eye"></i>';
+            }
+        });
+    });
+</script>
 {% endblock %}

--- a/magazyn/templates/settings.html
+++ b/magazyn/templates/settings.html
@@ -39,6 +39,13 @@
                     <option value="{{ env }}" {% if item.value == env %}selected{% endif %}>{{ env }}</option>
                     {% endfor %}
                 </select>
+                {% elif 'password' in lower or 'secret' in lower %}
+                <div class="input-group">
+                    <input type="password" class="form-control" id="{{ item.key }}" name="{{ item.key }}" value="{{ item.value }}">
+                    <span class="input-group-text toggle-password" data-target="{{ item.key }}">
+                        <i class="bi bi-eye"></i>
+                    </span>
+                </div>
                 {% else %}
                 <input type="text" class="form-control" id="{{ item.key }}" name="{{ item.key }}" value="{{ item.value }}">
                 {% endif %}
@@ -51,4 +58,19 @@
 <div class="form-actions text-center mt-3">
     <button type="submit" form="settingsForm" class="btn btn-primary">Zapisz</button>
 </div>
+<script>
+    document.querySelectorAll('.toggle-password').forEach(btn => {
+        btn.addEventListener('click', () => {
+            const input = document.getElementById(btn.dataset.target);
+            if (!input) return;
+            if (input.type === 'password') {
+                input.type = 'text';
+                btn.innerHTML = '<i class="bi bi-eye-slash"></i>';
+            } else {
+                input.type = 'password';
+                btn.innerHTML = '<i class="bi bi-eye"></i>';
+            }
+        });
+    });
+</script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- hide password and secret variables in `settings.html`
- allow revealing hidden secrets with an eye icon
- do the same for sales settings page

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868276064a4832a9a09cd7ca7984f9e