### PR TITLE
Fix flake8 lint issues

### DIFF
--- a/magazyn/db.py
+++ b/magazyn/db.py
@@ -217,7 +217,9 @@ def consume_stock(product_id, size, quantity, sale_price=0.0):
             if ps.quantity < settings.LOW_STOCK_THRESHOLD:
                 try:
                     product = (
-                        session.query(Product).filter_by(id=product_id).first()
+                        session.query(Product)
+                        .filter_by(id=product_id)
+                        .first()
                     )
                     name = product.name if product else str(product_id)
                     send_stock_alert(name, size, ps.quantity)

--- a/magazyn/history.py
+++ b/magazyn/history.py
@@ -35,7 +35,9 @@ def reprint_label(order_id):
 
         if queue:
             remaining = [
-                q for q in all_items if str(q.get("order_id")) != str(order_id)
+                q
+                for q in all_items
+                if str(q.get("order_id")) != str(order_id)
             ]
             for item in queue:
                 print_agent.print_label(

--- a/magazyn/sales.py
+++ b/magazyn/sales.py
@@ -1,4 +1,11 @@
-from flask import Blueprint, render_template, request, redirect, url_for, flash
+from flask import (
+    Blueprint,
+    render_template,
+    request,
+    redirect,
+    url_for,
+    flash,
+)
 from .auth import login_required
 from .env_info import ENV_INFO
 from . import print_agent

--- a/magazyn/services.py
+++ b/magazyn/services.py
@@ -213,7 +213,9 @@ def export_rows():
                 ProductSize.quantity,
             )
             .join(
-                ProductSize, Product.id == ProductSize.product_id, isouter=True
+                ProductSize,
+                Product.id == ProductSize.product_id,
+                isouter=True,
             )
             .all()
         )
@@ -471,7 +473,9 @@ def _import_invoice_df(df: pd.DataFrame):
 
             if not product:
                 product = (
-                    db.query(Product).filter_by(name=name, color=color).first()
+                    db.query(Product)
+                    .filter_by(name=name, color=color)
+                    .first()
                 )
                 if not product:
                     product = Product(name=name, color=color)
@@ -624,7 +628,10 @@ def get_sales_summary(days: int = 7) -> List[dict]:
     for name, color, size, qty in rows:
         remaining = stock.get(
             (
-                db.query(Product).filter_by(name=name, color=color).first().id,
+                db.query(Product)
+                .filter_by(name=name, color=color)
+                .first()
+                .id,
                 size,
             ),
             0,

--- a/magazyn/shipping.py
+++ b/magazyn/shipping.py
@@ -6,7 +6,11 @@ import pandas as pd
 bp = Blueprint("shipping", __name__)
 
 ALLEGRO_COSTS_FILE = (
-    Path(__file__).resolve().parent / "samples" / "deliveries_allegro.xlsx"
+    Path(__file__)
+    .resolve()
+    .parent
+    / "samples"
+    / "deliveries_allegro.xlsx"
 )
 
 


### PR DESCRIPTION
## Summary
- break long lines in db, history, services, and sales modules
- reformat shipping cost file path constant
- keep courier code test spacing intact
- verify style with flake8

## Testing
- `flake8 | wc -l`

------
https://chatgpt.com/codex/tasks/task_e_68683e088cac832a9255e1b4d2c282d6