### PR TITLE
Add orange color handling

### DIFF
--- a/magazyn/constants.py
+++ b/magazyn/constants.py
@@ -21,4 +21,7 @@ KNOWN_COLORS = [
     "fioletowe",
     "srebrny",
     "srebrne",
+    "pomarańczowy",
+    "pomarańczowe",
+    "pomarańczowa",
 ]

--- a/magazyn/tests/test_utils.py
+++ b/magazyn/tests/test_utils.py
@@ -222,6 +222,15 @@ def test_parse_product_info_color_only():
     assert color.lower() == "czerwony"
 
 
+def test_parse_product_info_color_orange():
+    bl = get_bl()
+    item = {"name": "Zabawka dla psa pomarańczowy"}
+    name, size, color = bl.parse_product_info(item)
+    assert name == "Zabawka dla psa"
+    assert size == "Uniwersalny"
+    assert color.lower() == "pomarańczowy"
+
+
 def test_parse_product_info_size_and_color_from_name():
     bl = get_bl()
     item = {"name": "Szelki dla psa Truelove Front Line Premium XL czarne"}


### PR DESCRIPTION
## Summary
- extend `KNOWN_COLORS` with orange options
- test parsing of orange color

## Testing
- `pytest -q`
- `flake8`


------
https://chatgpt.com/codex/tasks/task_e_6869620f1264832a8696072920df16ff