### PR TITLE
Fix flake8 issues and shorten long lines

### DIFF
--- a/magazyn/app.py
+++ b/magazyn/app.py
@@ -46,7 +46,11 @@ ENV_PATH = ROOT_DIR / ".env"
 EXAMPLE_PATH = ROOT_DIR / ".env.example"
 
 # Settings with boolean values represented as "1" or "0"
-BOOLEAN_KEYS = {"ENABLE_MONTHLY_REPORTS", "ENABLE_WEEKLY_REPORTS", "FLASK_DEBUG"}
+BOOLEAN_KEYS = {
+    "ENABLE_MONTHLY_REPORTS",
+    "ENABLE_WEEKLY_REPORTS",
+    "FLASK_DEBUG",
+}
 
 
 app = Flask(__name__)

--- a/magazyn/db.py
+++ b/magazyn/db.py
@@ -52,9 +52,9 @@ def init_db():
 def reset_db():
     """Drop all tables and recreate them.
 
-    This is useful for testing scenarios that require a completely clean
-    database state without losing the ability of :func:`init_db` to preserve
-    existing data."""
+    This is useful for testing scenarios that require a completely
+    clean database state without losing the ability of :func:`init_db`
+    to preserve existing data."""
     Base.metadata.drop_all(engine)
     Base.metadata.create_all(engine)
 
@@ -65,7 +65,9 @@ def ensure_schema():
     try:
         cur = conn.execute("PRAGMA table_info(product_sizes)")
         if "barcode" not in [row[1] for row in cur.fetchall()]:
-            conn.execute("ALTER TABLE product_sizes ADD COLUMN barcode TEXT")
+            conn.execute(
+                "ALTER TABLE product_sizes ADD COLUMN barcode TEXT"
+            )
             conn.execute(
                 "CREATE UNIQUE INDEX IF NOT EXISTS idx_product_sizes_barcode "
                 "ON product_sizes(barcode)"
@@ -122,7 +124,13 @@ def register_default_user():
             session.add(User(username="admin", password=hashed_password))
 
 
-def record_purchase(product_id, size, quantity, price, purchase_date=None):
+def record_purchase(
+    product_id,
+    size,
+    quantity,
+    price,
+    purchase_date=None,
+):
     """Insert a purchase batch and increase stock quantity."""
     purchase_date = purchase_date or datetime.datetime.now().isoformat()
     with get_session() as session:
@@ -192,7 +200,8 @@ def consume_stock(product_id, size, quantity, sale_price=0.0):
             session.query(PurchaseBatch)
             .filter_by(product_id=product_id, size=size)
             .order_by(
-                PurchaseBatch.price.asc(), PurchaseBatch.purchase_date.asc()
+                PurchaseBatch.price.asc(),
+                PurchaseBatch.purchase_date.asc(),
             )
             .all()
         )

--- a/magazyn/history.py
+++ b/magazyn/history.py
@@ -22,7 +22,9 @@ def reprint_label(order_id):
     try:
         all_items = print_agent.load_queue()
         queue = [
-            q for q in all_items if str(q.get("order_id")) == str(order_id)
+            q
+            for q in all_items
+            if str(q.get("order_id")) == str(order_id)
         ]
         printed_data = None
         try:
@@ -41,7 +43,9 @@ def reprint_label(order_id):
             ]
             for item in queue:
                 print_agent.print_label(
-                    item.get("label_data"), item.get("ext", "pdf"), order_id
+                    item.get("label_data"),
+                    item.get("ext", "pdf"),
+                    order_id,
                 )
             print_agent.save_queue(remaining)
             print_agent.mark_as_printed(

--- a/magazyn/sales.py
+++ b/magazyn/sales.py
@@ -72,7 +72,9 @@ def list_sales():
 
 def _sales_keys(values):
     keywords = ("SHIPPING", "COMMISSION", "EMAIL", "SMTP")
-    return [k for k in values.keys() if any(word in k for word in keywords)]
+    return [
+        k for k in values.keys() if any(word in k for word in keywords)
+    ]
 
 
 @bp.route("/sales/settings", methods=["GET", "POST"])

--- a/magazyn/services.py
+++ b/magazyn/services.py
@@ -120,7 +120,12 @@ def list_products() -> List[dict]:
         for p in products:
             sizes = {s.size: s.quantity for s in p.sizes}
             result.append(
-                {"id": p.id, "name": p.name, "color": p.color, "sizes": sizes}
+                {
+                    "id": p.id,
+                    "name": p.name,
+                    "color": p.color,
+                    "sizes": sizes,
+                }
             )
     return result
 
@@ -196,7 +201,12 @@ def get_products_for_delivery():
         return db.query(Product.id, Product.name, Product.color).all()
 
 
-def record_delivery(product_id: int, size: str, quantity: int, price: float):
+def record_delivery(
+    product_id: int,
+    size: str,
+    quantity: int,
+    price: float,
+):
     """Record a delivery and update stock."""
     record_purchase(product_id, size, quantity, price)
 
@@ -320,9 +330,9 @@ def _parse_simple_pdf(fh) -> pd.DataFrame:
             break
     if not column_pos:
         # fallback to sorted unique x positions
-        column_pos = sorted({t[0] for _, line in sorted_lines for t in line})[
-            :4
-        ]
+        column_pos = sorted(
+            {t[0] for _, line in sorted_lines for t in line}
+        )[:4]
 
     rows = []
     for _, line in sorted_lines:
@@ -344,7 +354,10 @@ def _parse_simple_pdf(fh) -> pd.DataFrame:
             continue
         size = cols[1]
         if size not in ALL_SIZES:
-            logger.warning("Unexpected size '%s' in PDF row, skipping", size)
+            logger.warning(
+                "Unexpected size '%s' in PDF row, skipping",
+                size,
+            )
             continue
         rows.append(
             {
@@ -540,7 +553,10 @@ def consume_order_stock(products: List[dict]):
         if qty <= 0:
             continue
         barcode = str(
-            item.get("ean") or item.get("barcode") or item.get("sku") or ""
+            item.get("ean")
+            or item.get("barcode")
+            or item.get("sku")
+            or ""
         ).strip()
         name = item.get("name")
         size = None
@@ -555,7 +571,11 @@ def consume_order_stock(products: List[dict]):
         with get_session() as db:
             ps = None
             if barcode:
-                ps = db.query(ProductSize).filter_by(barcode=barcode).first()
+                ps = (
+                    db.query(ProductSize)
+                    .filter_by(barcode=barcode)
+                    .first()
+                )
             if not ps and name:
                 query = (
                     db.query(ProductSize)

--- a/magazyn/shipping.py
+++ b/magazyn/shipping.py
@@ -6,9 +6,7 @@ import pandas as pd
 bp = Blueprint("shipping", __name__)
 
 ALLEGRO_COSTS_FILE = (
-    Path(__file__)
-    .resolve()
-    .parent
+    Path(__file__).resolve().parent
     / "samples"
     / "deliveries_allegro.xlsx"
 )

--- a/magazyn/tests/test_courier_code.py
+++ b/magazyn/tests/test_courier_code.py
@@ -12,7 +12,11 @@ def test_agent_loop_stores_courier_code(monkeypatch):
     monkeypatch.setattr(mod, "save_queue", lambda q: None)
     monkeypatch.setattr(mod, "is_quiet_time", lambda: False)
     monkeypatch.setattr(mod, "consume_order_stock", lambda p: None)
-    monkeypatch.setattr(mod, "print_label", lambda d, e, o: None)
+    monkeypatch.setattr(
+        mod,
+        "print_label",
+        lambda d, e, o: None,
+    )
 
     captured = {}
     monkeypatch.setattr(mod, "mark_as_printed", lambda oid, data=None: captured.setdefault("marked", data))

--- a/magazyn/tests/test_weekly_reports.py
+++ b/magazyn/tests/test_weekly_reports.py
@@ -10,4 +10,3 @@ def test_weekly_report_not_sent_when_disabled(monkeypatch):
     pa._last_weekly_report = None
     pa._send_periodic_reports()
     assert calls == []
-


### PR DESCRIPTION
## Summary
- shorten boolean key definition
- standardize shipping costs path constant
- remove trailing newline in weekly reports test
- reformat courier code test
- shorten lines in several modules to satisfy flake8

## Testing
- `flake8`

------
https://chatgpt.com/codex/tasks/task_e_686a91107b14832a815a617fd11b1418