### PR TITLE
Fix login form width and cleanup style

### DIFF
--- a/magazyn/app.py
+++ b/magazyn/app.py
@@ -46,7 +46,11 @@ ENV_PATH = ROOT_DIR / ".env"
 EXAMPLE_PATH = ROOT_DIR / ".env.example"
 
 # Settings with boolean values represented as "1" or "0"
-BOOLEAN_KEYS = {"ENABLE_MONTHLY_REPORTS", "ENABLE_WEEKLY_REPORTS", "FLASK_DEBUG"}
+BOOLEAN_KEYS = {
+    "ENABLE_MONTHLY_REPORTS",
+    "ENABLE_WEEKLY_REPORTS",
+    "FLASK_DEBUG",
+}
 
 
 app = Flask(__name__)

--- a/magazyn/static/styles.css
+++ b/magazyn/static/styles.css
@@ -23,7 +23,7 @@ h2, h3 {
 
 /* Centered layout for the login page form */
 .login-form {
-    max-width: 300px;
+    max-width: none;
     margin: auto;
 }
 

--- a/magazyn/tests/test_weekly_reports.py
+++ b/magazyn/tests/test_weekly_reports.py
@@ -10,4 +10,3 @@ def test_weekly_report_not_sent_when_disabled(monkeypatch):
     pa._last_weekly_report = None
     pa._send_periodic_reports()
     assert calls == []
-


### PR DESCRIPTION
## Summary
- widen login form by removing width limit
- break BOOLEAN_KEYS across lines
- cleanup newline at EOF in weekly report test

## Testing
- `pytest -q`
- `flake8`


------
https://chatgpt.com/codex/tasks/task_e_6866e9ddff00832a9649e88b2d7f4fc1