### PR TITLE
Fix login form width and cleanup style

### DIFF
--- a/magazyn/app.py
+++ b/magazyn/app.py
@@ -46,7 +46,11 @@ ENV_PATH = ROOT_DIR / ".env"
 EXAMPLE_PATH = ROOT_DIR / ".env.example"
 
 # Settings with boolean values represented as "1" or "0"
-BOOLEAN_KEYS = {"ENABLE_MONTHLY_REPORTS", "ENABLE_WEEKLY_REPORTS", "FLASK_DEBUG"}
+BOOLEAN_KEYS = {
+    "ENABLE_MONTHLY_REPORTS",
+    "ENABLE_WEEKLY_REPORTS",
+    "FLASK_DEBUG",
+}
 
 
 app = Flask(__name__)

--- a/magazyn/static/styles.css
+++ b/magazyn/static/styles.css
@@ -23,7 +23,7 @@ h2, h3 {
 
 /* Centered layout for the login page form */
 .login-form {
-    max-width: 300px;
+    max-width: none;
     margin: auto;
 }
 
@@ -241,9 +241,14 @@ th {
         text-decoration: none;
     }
 
-    .navbar-brand img {
-        height: 70px;
-    }
+.navbar-brand img {
+    height: 140px;
+}
+
+.app-title {
+    font-size: 2rem;
+    text-align: center;
+}
 
     .navbar-nav .dropdown-menu {
         position: absolute;
@@ -298,7 +303,7 @@ th {
 
 /* Additional mobile menu styling */
 .mobile-logo {
-    height: 20px;
+    height: 40px;
     display: block;
 }
 

--- a/magazyn/templates/base.html
+++ b/magazyn/templates/base.html
@@ -22,8 +22,8 @@
             <div class="d-flex flex-column">
                 <div class="d-flex align-items-center justify-content-between">
                     <span class="navbar-brand d-flex align-items-center mb-2 mb-md-0">
-                        <img src="https://retrievershop.pl/wp-content/uploads/2024/08/retriver-2.png" alt="Logo" style="height: 70px;">
-                        <span class="ms-2">Witaj w aplikacji magazynowej</span>
+                        <img src="https://retrievershop.pl/wp-content/uploads/2024/08/retriver-2.png" alt="Logo">
+                        <span class="ms-2 app-title">Witaj w aplikacji magazynowej</span>
                     </span>
                     {% if show_menu %}
                     <div class="d-flex align-items-center">

--- a/magazyn/tests/test_weekly_reports.py
+++ b/magazyn/tests/test_weekly_reports.py
@@ -10,4 +10,3 @@ def test_weekly_report_not_sent_when_disabled(monkeypatch):
     pa._last_weekly_report = None
     pa._send_periodic_reports()
     assert calls == []
-


### PR DESCRIPTION
## Summary
- widen login form by removing width limit
- break BOOLEAN_KEYS across lines
- cleanup newline at EOF in weekly report test
- center brand title and enlarge logo

## Testing
- `pytest -q`
- `flake8`


------
https://chatgpt.com/codex/tasks/task_e_6866e9ddff00832a9649e88b2d7f4fc1