### PR TITLE
Move logo height to CSS

### DIFF
--- a/magazyn/static/styles.css
+++ b/magazyn/static/styles.css
@@ -80,6 +80,11 @@ header .logo img {
     vertical-align: middle;
 }
 
+/* Logo in the navigation bar */
+.navbar-brand img {
+    height: 140px;
+}
+
 
 footer {
     margin-top: auto;
@@ -241,9 +246,6 @@ th {
         text-decoration: none;
     }
 
-    .navbar-brand img {
-        height: 140px;
-    }
 
     .navbar-nav .dropdown-menu {
         position: absolute;

--- a/magazyn/templates/base.html
+++ b/magazyn/templates/base.html
@@ -22,7 +22,7 @@
             <div class="d-flex flex-column">
                 <div class="d-flex align-items-center justify-content-between">
                     <span class="navbar-brand d-flex align-items-center mb-2 mb-md-0">
-                        <img src="https://retrievershop.pl/wp-content/uploads/2024/08/retriver-2.png" alt="Logo" style="height: 140px;">
+                        <img src="https://retrievershop.pl/wp-content/uploads/2024/08/retriver-2.png" alt="Logo">
                         <span class="ms-2 w-100 text-center fs-3">Witaj w aplikacji magazynowej</span>
                     </span>
                     {% if show_menu %}


### PR DESCRIPTION
## Summary
- clean up inline height on navbar logo
- control logo height with `.navbar-brand img` rule

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686bcc523574832aaa730877d8d4d572