### PR TITLE
Fix shipping dtype warning

### DIFF
--- a/magazyn/shipping.py
+++ b/magazyn/shipping.py
@@ -30,15 +30,21 @@ def save_costs(df: pd.DataFrame, file_path: Path = ALLEGRO_COSTS_FILE) -> None:
 def shipping_costs():
     df = load_costs()
     columns = list(df.columns)
+    # Ensure numeric columns are floats to avoid dtype warnings
+    try:
+        df[columns[1:]] = df[columns[1:]].astype(float)
+    except (ValueError, TypeError):
+        pass
     if request.method == "POST":
         for r in range(len(df)):
             for c_idx, col in enumerate(columns[1:]):
                 key = f"val_{r}_{c_idx}"
-                val = request.form.get(key, "0")
+                val_raw = request.form.get(key, "0")
                 try:
-                    df.at[r, col] = float(val)
+                    val = float(val_raw)
                 except ValueError:
-                    df.at[r, col] = val
+                    val = val_raw
+                df.at[r, col] = val
         save_costs(df)
         flash("Zapisano koszty wysyłek.")
         return redirect(url_for("shipping.shipping_costs"))

--- a/magazyn/tests/test_shipping_costs.py
+++ b/magazyn/tests/test_shipping_costs.py
@@ -1,4 +1,5 @@
 import pandas as pd
+import warnings
 
 
 def _create_file(path):
@@ -56,6 +57,8 @@ def test_shipping_costs_edit(app_mod, client, login, tmp_path, monkeypatch):
             if i == 0 and j == 0:
                 val = "9.99"
             data[f"val_{i}_{j}"] = val
-    client.post("/shipping_costs", data=data)
+    with warnings.catch_warnings(record=True) as w:
+        client.post("/shipping_costs", data=data)
+    assert not w
     df2 = pd.read_excel(file_path, header=None)
     assert abs(float(df2.iloc[1, 1]) - 9.99) < 0.01


### PR DESCRIPTION
## Summary
- convert shipping cost columns to floats and parse form values before assignment
- check that editing shipping costs emits no warnings

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c03b9ea04832a940d67513362fbac