### PR TITLE
Adjust layout width for history page

### DIFF
--- a/magazyn/templates/history.html
+++ b/magazyn/templates/history.html
@@ -1,4 +1,7 @@
 {% extends "base.html" %}
+{% block page_vars %}
+{% set full_width = True %}
+{% endblock %}
 {% block content %}
 <h2 class="text-center">Historia drukowania</h2>
 {# .table-responsive ensures horizontal scrolling when needed #}


### PR DESCRIPTION
## Summary
- make the history page use full-width layout so its table has more space

## Testing
- `./run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_686c3b442774832a8581700360d3c632