### PR TITLE
Prevent duplicate print agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,13 @@ This repository contains the code for the RetrieverShop warehouse application an
 `DB_PATH` is read only during application startup, so changing it requires
 restarting the server.
 
+### Single printing agent
+
+Only one printing agent should run at a time. The application uses a lock
+file (`agent.lock` next to the log file) to ensure additional processes skip
+starting the agent. When multiple workers load the application, only the first
+one obtains the lock and launches the background thread.
+
 ## Modifying settings via the web interface
 
 After starting the application you can modify the values stored in your `.env` file without touching the filesystem. Log in to the web interface and open the **Ustawienia** tab from the navigation bar.


### PR DESCRIPTION
## Summary
- prevent repeated start_print_agent calls in a process
- add file lock for cross-process guarding in start_agent_thread
- update README with single agent requirement

## Testing
- `./run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_686cebed8860832aaf19f7a599aee062