### PR TITLE
Fix quantity decrease with no purchase batches

### DIFF
--- a/magazyn/db.py
+++ b/magazyn/db.py
@@ -211,9 +211,7 @@ def consume_stock(product_id, size, quantity, sale_price=0.0):
         for batch in batches:
             if remaining <= 0:
                 break
-            use = (
-                remaining if batch.quantity >= remaining else batch.quantity
-            )
+            use = remaining if batch.quantity >= remaining else batch.quantity
             batch.quantity -= use
             purchase_cost += use * batch.price
             remaining -= use
@@ -221,7 +219,11 @@ def consume_stock(product_id, size, quantity, sale_price=0.0):
                 session.delete(batch)
 
         consumed = to_consume - remaining
-        if consumed > 0 and ps:
+        if consumed == 0 and to_consume > 0 and ps and not batches:
+            # Adjust quantity even when no purchase batches exist
+            ps.quantity -= to_consume
+            consumed = to_consume
+        elif consumed > 0 and ps:
             ps.quantity -= consumed
             if ps.quantity < settings.LOW_STOCK_THRESHOLD:
                 try:

--- a/magazyn/templates/base.html
+++ b/magazyn/templates/base.html
@@ -19,7 +19,7 @@
     <div class="page-wrapper">
     <nav class="navbar navbar-dark bg-dark fixed-top">
         <div class="container">
-            <div class="d-flex flex-column">
+            <div class="d-flex flex-column w-100">
                 <div class="d-flex align-items-center w-100">
                     <span class="navbar-brand mb-2 mb-md-0">
                         <img src="https://retrievershop.pl/wp-content/uploads/2024/08/retriver-2.png" alt="Logo">

--- a/magazyn/tests/test_services.py
+++ b/magazyn/tests/test_services.py
@@ -41,6 +41,14 @@ def test_update_quantity_increase(app_mod):
     assert sizes["M"]["quantity"] == 2
 
 
+def test_update_quantity_decrease_without_batches(app_mod):
+    services = load_services()
+    prod = services.create_product("Prod", "Red", {"M": 1}, {"M": "111"})
+    services.update_quantity(prod.id, "M", "decrease")
+    info, sizes = services.get_product_details(prod.id)
+    assert sizes["M"]["quantity"] == 0
+
+
 def test_record_delivery(app_mod):
     services = load_services()
     prod = services.create_product("Prod", "Red", {"M": 0}, {"M": "111"})


### PR DESCRIPTION
## Summary
- handle missing purchase batches in `consume_stock`
- test decrementing product quantity without purchase batches

## Testing
- `./run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_686c55bae368832a8dcbe59958dde147