### PR TITLE
Fix sale price extraction from BaseLinker orders

### DIFF
--- a/magazyn/print_agent.py
+++ b/magazyn/print_agent.py
@@ -388,9 +388,11 @@ def call_api(method, parameters=None):
 
 
 def get_orders():
-    response = call_api("getOrders", {"status_id": STATUS_ID})
-    orders = response.get("orders", [])
-    return orders
+    response = call_api(
+        "getOrders",
+        {"status_id": STATUS_ID, "include_products": 1},
+    )
+    return response.get("orders", [])
 
 
 def get_order_packages(order_id):


### PR DESCRIPTION
## Summary
- include product data when downloading orders
- test that sale price is stored and displayed

## Testing
- `./run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_686d25468a3c832aab93a6f2976b274a