### PR TITLE
Implement aggregated API logs and shipping costs

### DIFF
--- a/magazyn/app.py
+++ b/magazyn/app.py
@@ -58,6 +58,19 @@ app.secret_key = settings.SECRET_KEY
 CSRFProtect(app)
 app.jinja_env.globals["ALL_SIZES"] = ALL_SIZES
 
+
+@app.template_filter("format_dt")
+def format_dt(value, fmt="%d/%m/%Y %H:%M"):
+    """Return datetime formatted with day/month/year."""
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        try:
+            value = datetime.fromisoformat(value)
+        except Exception:
+            return value[:16]
+    return value.strftime(fmt)
+
 _print_agent_started = False
 
 app.register_blueprint(products_bp)

--- a/magazyn/db.py
+++ b/magazyn/db.py
@@ -179,7 +179,14 @@ def record_sale(
     )
 
 
-def consume_stock(product_id, size, quantity, sale_price=0.0):
+def consume_stock(
+    product_id,
+    size,
+    quantity,
+    sale_price=0.0,
+    shipping_cost=0.0,
+    commission_fee=0.0,
+):
     """Remove quantity from stock using cheapest purchase batches first."""
     with get_session() as session:
         ps = (
@@ -254,6 +261,20 @@ def consume_stock(product_id, size, quantity, sale_price=0.0):
             quantity,
             purchase_cost=purchase_cost,
             sale_price=sale_price,
+            shipping_cost=shipping_cost,
+            commission_fee=commission_fee,
         )
+
+        if consumed > 0:
+            product = (
+                session.query(Product).filter_by(id=product_id).first()
+            )
+            name = product.name if product else str(product_id)
+            logger.info(
+                "Pobrano z magazynu: %s %s x%s",
+                name,
+                size,
+                consumed,
+            )
 
     return consumed

--- a/magazyn/static/styles.css
+++ b/magazyn/static/styles.css
@@ -118,6 +118,15 @@ td:nth-child(n+3):nth-child(-n+8) {
     padding: 0; /* Usuń nadmiarowe odstępy */
 }
 
+/* Szerokości kolumn w historii drukowania (1,4,1,1,2,2,1 z podziału na 12) */
+.history-table col:nth-child(1) { width: 8.33%; }
+.history-table col:nth-child(2) { width: 33.33%; }
+.history-table col:nth-child(3) { width: 8.33%; }
+.history-table col:nth-child(4) { width: 8.33%; }
+.history-table col:nth-child(5) { width: 16.67%; }
+.history-table col:nth-child(6) { width: 16.67%; }
+.history-table col:nth-child(7) { width: 8.33%; }
+
 /* Ensure long tables remain usable on small screens */
 .table-responsive {
     width: 100%;

--- a/magazyn/templates/history.html
+++ b/magazyn/templates/history.html
@@ -6,7 +6,16 @@
 <h2 class="text-center">Historia drukowania</h2>
 {# .table-responsive ensures horizontal scrolling when needed #}
 <div class="table-responsive">
-<table class="table table-striped table-sm w-100">
+<table class="table table-striped table-sm w-100 history-table">
+    <colgroup>
+        <col style="width:8.33%">
+        <col style="width:33.33%">
+        <col style="width:8.33%">
+        <col style="width:8.33%">
+        <col style="width:16.67%">
+        <col style="width:16.67%">
+        <col style="width:8.33%">
+    </colgroup>
     <thead><tr><th>ID zamówienia</th><th>Nazwa</th><th>Kolor</th><th>Rozmiar</th><th>Kurier</th><th>Czas</th><th>Akcje</th></tr></thead>
     <tbody>
     {% for item in printed %}
@@ -16,7 +25,7 @@
         <td>{{ item.last_order_data.color or '' }}</td>
         <td>{{ item.last_order_data.size or '' }}</td>
         <td>{{ item.last_order_data.courier_code or '' }}</td>
-        <td>{{ item.printed_at.strftime('%Y-%m-%d %H:%M') }}</td>
+        <td>{{ item.printed_at | format_dt }}</td>
         <td>
             <form class="d-inline" method="post" action="{{ url_for('history.reprint_label', order_id=item.order_id) }}">
                 <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">

--- a/magazyn/templates/sales.html
+++ b/magazyn/templates/sales.html
@@ -17,7 +17,7 @@
     <tbody>
     {% for s in sales %}
     <tr>
-        <td>{{ s.date[:16] }}</td>
+        <td>{{ s.date | format_dt }}</td>
         <td>{{ s.product }}</td>
         <td>{{ '%.2f'|format(s.purchase_cost) }}</td>
         <td>{{ '%.2f'|format(s.commission) }}</td>

--- a/magazyn/templates/sales_list.html
+++ b/magazyn/templates/sales_list.html
@@ -17,7 +17,7 @@
     <tbody>
     {% for s in sales %}
     <tr>
-        <td>{{ s.date[:16] }}</td>
+        <td>{{ s.date | format_dt }}</td>
         <td>{{ s.product }}</td>
         <td>{{ '%.2f'|format(s.purchase_cost) }}</td>
         <td>{{ '%.2f'|format(s.commission) }}</td>

--- a/magazyn/tests/test_history.py
+++ b/magazyn/tests/test_history.py
@@ -24,7 +24,7 @@ def test_history_page_shows_reprint_form(app_mod, client, login, monkeypatch):
                 flask_session[k] = v
             token = app_mod.app.jinja_env.globals["csrf_token"]()
     assert token in html
-    assert ts.strftime("%Y-%m-%d %H:%M") in html
+    assert ts.strftime("%d/%m/%Y %H:%M") in html
     assert "N" in html
     assert "C" in html
     assert "S" in html


### PR DESCRIPTION
## Summary
- add hourly summary for BaseLinker API calls
- log product stock removal after each sale
- compute shipping and commission when consuming order stock
- format dates consistently in dd/mm/yyyy hh:mm on all pages
- adjust history table column widths for 1/4/1/1/2/2/1 layout

## Testing
- `./run-tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_686d23be85c0832a94cbbc849399edcb