### PR TITLE
Add Allegro offer synchronization

### DIFF
--- a/magazyn/allegro_sync.py
+++ b/magazyn/allegro_sync.py
@@ -1,0 +1,70 @@
+"""Utilities for synchronizing Allegro offers with local database."""
+
+import os
+from typing import Optional
+
+from .allegro_api import refresh_token, fetch_offers
+from .db import get_session
+from .models import AllegroOffer, ProductSize
+
+
+def _get_access_token() -> str:
+    """Return access token using refresh token from environment."""
+    refresh = os.getenv("ALLEGRO_REFRESH_TOKEN")
+    if not refresh:
+        raise RuntimeError("ALLEGRO_REFRESH_TOKEN not set")
+    data = refresh_token(refresh)
+    return data["access_token"]
+
+
+def sync_offers() -> None:
+    """Synchronize offers from Allegro into the local database.
+
+    Retrieves all offers using Allegro API, tries to match them with
+    ``ProductSize`` records by barcode and stores them in the
+    ``AllegroOffer`` table. Existing records are updated.
+    """
+    access_token = _get_access_token()
+    page = 1
+    while True:
+        data = fetch_offers(access_token, page=page)
+        offers = data.get("offers") or []
+        if not offers:
+            break
+        with get_session() as session:
+            for offer in offers:
+                offer_id: Optional[str] = offer.get("id")
+                if not offer_id:
+                    continue
+                barcode = offer.get("ean") or offer.get("barcode")
+                product_size = None
+                if barcode:
+                    product_size = (
+                        session.query(ProductSize)
+                        .filter(ProductSize.barcode == barcode)
+                        .first()
+                    )
+                allegro_offer = session.get(AllegroOffer, offer_id)
+                if allegro_offer:
+                    allegro_offer.name = offer.get("name")
+                    allegro_offer.barcode = barcode
+                    allegro_offer.product_size = product_size
+                else:
+                    session.add(
+                        AllegroOffer(
+                            id=offer_id,
+                            name=offer.get("name"),
+                            barcode=barcode,
+                            product_size=product_size,
+                        )
+                    )
+        page += 1
+
+
+def main() -> None:
+    """Entry point for CLI usage."""
+    sync_offers()
+
+
+if __name__ == "__main__":
+    main()

--- a/magazyn/models.py
+++ b/magazyn/models.py
@@ -75,3 +75,12 @@ class ShippingThreshold(Base):
     id = Column(Integer, primary_key=True)
     min_order_value = Column(Float, nullable=False)
     shipping_cost = Column(Float, nullable=False)
+
+
+class AllegroOffer(Base):
+    __tablename__ = "allegro_offers"
+    id = Column(String, primary_key=True)
+    name = Column(String)
+    barcode = Column(String)
+    product_size_id = Column(Integer, ForeignKey("product_sizes.id"))
+    product_size = relationship("ProductSize")

--- a/magazyn/tests/test_allegro_sync.py
+++ b/magazyn/tests/test_allegro_sync.py
@@ -1,0 +1,35 @@
+import magazyn.allegro_sync as allegro_sync
+from magazyn.db import get_session
+from magazyn.models import Product, ProductSize, AllegroOffer
+
+
+def test_sync_offers_creates_records(app_mod, monkeypatch):
+    # Prepare product with barcode
+    with get_session() as session:
+        prod = Product(name="P", color="C")
+        session.add(prod)
+        session.flush()
+        ps = ProductSize(product_id=prod.id, size="M", quantity=0, barcode="123")
+        session.add(ps)
+
+    # Setup fake API
+    monkeypatch.setenv("ALLEGRO_REFRESH_TOKEN", "ref")
+    monkeypatch.setattr(allegro_sync, "refresh_token", lambda token: {"access_token": "tok"})
+
+    pages = [
+        {"offers": [{"id": "1", "name": "Offer", "ean": "123"}]},
+        {"offers": []},
+    ]
+
+    def fake_fetch(token, page=1):
+        return pages[page - 1]
+
+    monkeypatch.setattr(allegro_sync, "fetch_offers", fake_fetch)
+
+    allegro_sync.sync_offers()
+
+    with get_session() as session:
+        offer = session.get(AllegroOffer, "1")
+        assert offer is not None
+        assert offer.product_size_id == ps.id
+        assert offer.name == "Offer"


### PR DESCRIPTION
## Summary
- add AllegroOffer model and synchronization script
- implement sync_offers CLI to fetch offers and map them by barcode
- cover synchronization with unit test

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b19d49b634832ab18b73a894319809