### PR TITLE
Add Allegro blueprint with offer management

### DIFF
--- a/magazyn/allegro.py
+++ b/magazyn/allegro.py
@@ -1,0 +1,81 @@
+from flask import (
+    Blueprint,
+    render_template,
+    request,
+    redirect,
+    url_for,
+    flash,
+)
+
+from .db import get_session
+from .models import AllegroOffer, Product
+from .auth import login_required
+
+bp = Blueprint("allegro", __name__)
+
+
+def sync_offers():
+    """Synchronize offers from Allegro API (placeholder)."""
+    return []
+
+
+@bp.route("/allegro/offers")
+@login_required
+def offers():
+    with get_session() as db:
+        rows = (
+            db.query(AllegroOffer, Product)
+            .outerjoin(Product, AllegroOffer.product_id == Product.id)
+            .all()
+        )
+        offers = [
+            {
+                "offer_id": offer.offer_id,
+                "title": offer.title,
+                "price": offer.price,
+                "product_name": product.name if product else None,
+            }
+            for offer, product in rows
+        ]
+    return render_template("allegro/offers.html", offers=offers)
+
+
+@bp.route("/allegro/refresh", methods=["POST"])
+@login_required
+def refresh():
+    try:
+        sync_offers()
+        flash("Oferty zaktualizowane")
+    except Exception as e:
+        flash(f"Błąd synchronizacji ofert: {e}")
+    return redirect(url_for("allegro.offers"))
+
+
+@bp.route("/allegro/link/<offer_id>", methods=["GET", "POST"])
+@login_required
+def link_offer(offer_id):
+    with get_session() as db:
+        offer = db.query(AllegroOffer).filter_by(offer_id=offer_id).first()
+        if not offer:
+            flash("Nie znaleziono aukcji")
+            return redirect(url_for("allegro.offers"))
+
+        if request.method == "POST":
+            product_id = request.form.get("product_id", type=int)
+            if product_id:
+                product = db.query(Product).filter_by(id=product_id).first()
+                if product:
+                    offer.product_id = product.id
+                    flash("Powiązano aukcję z produktem")
+                    return redirect(url_for("allegro.offers"))
+                flash("Nie znaleziono produktu o podanym ID")
+            else:
+                flash("Nie podano ID produktu")
+
+        offer_data = {
+            "offer_id": offer.offer_id,
+            "title": offer.title,
+            "price": offer.price,
+            "product_id": offer.product_id or "",
+        }
+    return render_template("allegro/link.html", offer=offer_data)

--- a/magazyn/app.py
+++ b/magazyn/app.py
@@ -34,6 +34,7 @@ from .products import bp as products_bp
 from .history import bp as history_bp
 from .sales import bp as sales_bp, _sales_keys
 from .shipping import bp as shipping_bp
+from .allegro import bp as allegro_bp
 from .auth import login_required
 from .config import settings
 from . import print_agent
@@ -77,6 +78,7 @@ app.register_blueprint(products_bp)
 app.register_blueprint(history_bp)
 app.register_blueprint(sales_bp)
 app.register_blueprint(shipping_bp)
+app.register_blueprint(allegro_bp)
 
 
 @app.context_processor

--- a/magazyn/templates/allegro/link.html
+++ b/magazyn/templates/allegro/link.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>Powiąż aukcję</h1>
+<p><strong>{{ offer.title }}</strong> (ID: {{ offer.offer_id }})</p>
+<form method="post">
+    <div class="mb-3">
+        <label for="product_id" class="form-label">ID produktu</label>
+        <input type="number" name="product_id" id="product_id" class="form-control" value="{{ offer.product_id }}">
+    </div>
+    <button type="submit" class="btn btn-primary">Zapisz</button>
+</form>
+{% endblock %}

--- a/magazyn/templates/allegro/offers.html
+++ b/magazyn/templates/allegro/offers.html
@@ -1,0 +1,29 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>Oferty Allegro</h1>
+<form method="post" action="{{ url_for('allegro.refresh') }}" class="mb-3">
+    <button type="submit" class="btn btn-primary">Odśwież</button>
+</form>
+<table class="table table-striped">
+    <thead>
+        <tr>
+            <th>ID</th>
+            <th>Tytuł</th>
+            <th>Cena</th>
+            <th>Produkt</th>
+            <th></th>
+        </tr>
+    </thead>
+    <tbody>
+    {% for offer in offers %}
+        <tr>
+            <td>{{ offer.offer_id }}</td>
+            <td>{{ offer.title }}</td>
+            <td>{{ offer.price }}</td>
+            <td>{{ offer.product_name or 'brak' }}</td>
+            <td><a href="{{ url_for('allegro.link_offer', offer_id=offer.offer_id) }}" class="btn btn-sm btn-secondary">Powiąż</a></td>
+        </tr>
+    {% endfor %}
+    </tbody>
+</table>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add `allegro` blueprint with routes for listing offers, manual refresh, and linking offers to products
- create simple HTML templates for viewing and linking offers
- register Allegro blueprint in the application

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b332152950832a809b3d4f53fcc831