### PR TITLE
Support multiple Allegro offers per product size

### DIFF
--- a/magazyn/migrations/create_allegro_offers_table.py
+++ b/magazyn/migrations/create_allegro_offers_table.py
@@ -11,10 +11,12 @@ def migrate():
         if not cur.fetchone():
             cur.execute(
                 "CREATE TABLE allegro_offers ("
-                "offer_id TEXT PRIMARY KEY, "
+                "id INTEGER PRIMARY KEY, "
+                "offer_id TEXT UNIQUE, "
                 "title TEXT NOT NULL, "
                 "price REAL NOT NULL, "
                 "product_id INTEGER NOT NULL REFERENCES products(id), "
+                "product_size_id INTEGER REFERENCES product_sizes(id), "
                 "synced_at TEXT)"
             )
             conn.commit()

--- a/magazyn/models.py
+++ b/magazyn/models.py
@@ -29,6 +29,7 @@ class ProductSize(Base):
     quantity = Column(Integer, nullable=False, default=0)
     barcode = Column(String, unique=True)
     product = relationship("Product", back_populates="sizes")
+    allegro_offers = relationship("AllegroOffer", back_populates="product_size")
 
 
 class PrintedOrder(Base):
@@ -79,10 +80,13 @@ class ShippingThreshold(Base):
 
 class AllegroOffer(Base):
     __tablename__ = "allegro_offers"
-    offer_id = Column(String, primary_key=True)
+    id = Column(Integer, primary_key=True)
+    offer_id = Column(String, unique=True)
     title = Column(String, nullable=False)
     price = Column(Float, nullable=False)
     product_id = Column(Integer, ForeignKey("products.id"), nullable=False)
+    product_size_id = Column(Integer, ForeignKey("product_sizes.id"))
     synced_at = Column(String)
 
     product = relationship("Product")
+    product_size = relationship("ProductSize", back_populates="allegro_offers")

--- a/magazyn/templates/allegro/offers.html
+++ b/magazyn/templates/allegro/offers.html
@@ -3,27 +3,28 @@
 <h1>Oferty Allegro</h1>
 <form method="post" action="{{ url_for('allegro.refresh') }}" class="mb-3">
     <button type="submit" class="btn btn-primary">Odśwież</button>
-</form>
+    </form>
+{% for group in groups %}
+<h3>{{ group.product_name }} {% if group.size %}- {{ group.size }}{% endif %}</h3>
 <table class="table table-striped">
     <thead>
         <tr>
             <th>ID</th>
             <th>Tytuł</th>
             <th>Cena</th>
-            <th>Produkt</th>
             <th></th>
         </tr>
     </thead>
     <tbody>
-    {% for offer in offers %}
+    {% for offer in group.offers %}
         <tr>
             <td>{{ offer.offer_id }}</td>
             <td>{{ offer.title }}</td>
             <td>{{ offer.price }}</td>
-            <td>{{ offer.product_name or 'brak' }}</td>
             <td><a href="{{ url_for('allegro.link_offer', offer_id=offer.offer_id) }}" class="btn btn-sm btn-secondary">Powiąż</a></td>
         </tr>
     {% endfor %}
     </tbody>
 </table>
+{% endfor %}
 {% endblock %}


### PR DESCRIPTION
## Summary
- allow Allegro offers to be linked to product sizes with new `product_size_id`
- sync and lookup offers by `offer_id`, creating separate records per size and price
- group offers by product size in Allegro offers view
- migrate `allegro_offers` table to use integer primary key and unique `offer_id`

## Testing
- `./run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68b348da4e9c832abb37b823fbfe5d81