### PR TITLE
Use Allegro sync helper and test refresh endpoint

### DIFF
--- a/magazyn/allegro.py
+++ b/magazyn/allegro.py
@@ -10,13 +10,9 @@ from flask import (
 from .db import get_session
 from .models import AllegroOffer, Product, ProductSize
 from .auth import login_required
+from .allegro_sync import sync_offers
 
 bp = Blueprint("allegro", __name__)
-
-
-def sync_offers():
-    """Synchronize offers from Allegro API (placeholder)."""
-    return []
 
 
 @bp.route("/allegro/offers")

--- a/magazyn/tests/test_allegro_refresh.py
+++ b/magazyn/tests/test_allegro_refresh.py
@@ -1,0 +1,47 @@
+import magazyn.allegro_sync as sync_mod
+from magazyn.db import get_session
+from magazyn.models import Product, ProductSize, AllegroOffer
+
+
+def test_refresh_fetches_and_saves_offers(client, login, monkeypatch):
+    monkeypatch.setenv("ALLEGRO_ACCESS_TOKEN", "token")
+
+    def fake_fetch_offers(token, page):
+        assert token == "token"
+        assert page == 1
+        return {
+            "items": {
+                "offers": [
+                    {
+                        "id": "O1",
+                        "name": "Test offer",
+                        "ean": "123456",
+                        "sellingMode": {"price": {"amount": "15.00"}},
+                    }
+                ]
+            },
+            "links": {},
+        }
+
+    monkeypatch.setattr(sync_mod.allegro_api, "fetch_offers", fake_fetch_offers)
+
+    with get_session() as session:
+        product = Product(name="Prod", color="red")
+        ps = ProductSize(product=product, size="L", barcode="123456")
+        session.add(product)
+        session.add(ps)
+        session.flush()
+        product_id = product.id
+
+    response = client.post("/allegro/refresh")
+    assert response.status_code == 302
+
+    with get_session() as session:
+        offers = session.query(AllegroOffer).all()
+        assert len(offers) == 1
+        offer = offers[0]
+        assert offer.offer_id == "O1"
+        assert offer.title == "Test offer"
+        assert offer.price == 15.0
+        assert offer.product_id == product_id
+


### PR DESCRIPTION
## Summary
- remove placeholder `sync_offers` from allegro view
- import real synchronizer from `allegro_sync` and call in refresh endpoint
- add test ensuring `/allegro/refresh` fetches and saves offers

## Testing
- `./run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68b35a45acf4832aa58a9ab6436c2876