### PR TITLE
Add default request timeout

### DIFF
--- a/magazyn/allegro_api.py
+++ b/magazyn/allegro_api.py
@@ -5,6 +5,7 @@ import requests
 
 AUTH_URL = "https://allegro.pl/auth/oauth/token"
 API_BASE_URL = "https://api.allegro.pl"
+DEFAULT_TIMEOUT = 10
 
 
 def get_access_token(client_id: str, client_secret: str, code: str, redirect_uri: Optional[str] = None) -> dict:
@@ -30,7 +31,9 @@ def get_access_token(client_id: str, client_secret: str, code: str, redirect_uri
     if redirect_uri:
         data["redirect_uri"] = redirect_uri
 
-    response = requests.post(AUTH_URL, data=data, auth=(client_id, client_secret))
+    response = requests.post(
+        AUTH_URL, data=data, auth=(client_id, client_secret), timeout=DEFAULT_TIMEOUT
+    )
     response.raise_for_status()
     return response.json()
 
@@ -46,7 +49,7 @@ def refresh_token(refresh_token: str) -> dict:
     auth = (client_id, client_secret) if client_id and client_secret else None
 
     data = {"grant_type": "refresh_token", "refresh_token": refresh_token}
-    response = requests.post(AUTH_URL, data=data, auth=auth)
+    response = requests.post(AUTH_URL, data=data, auth=auth, timeout=DEFAULT_TIMEOUT)
     response.raise_for_status()
     return response.json()
 
@@ -73,7 +76,9 @@ def fetch_offers(access_token: str, page: int = 1) -> dict:
     params = {"page": page}
     url = f"{API_BASE_URL}/sale/offers"
 
-    response = requests.get(url, headers=headers, params=params)
+    response = requests.get(
+        url, headers=headers, params=params, timeout=DEFAULT_TIMEOUT
+    )
     response.raise_for_status()
     return response.json()
 
@@ -113,7 +118,9 @@ def fetch_product_listing(ean: str, page: int = 1) -> list:
     offers = []
 
     while True:
-        response = requests.get(url, headers=headers, params=params)
+        response = requests.get(
+            url, headers=headers, params=params, timeout=DEFAULT_TIMEOUT
+        )
         response.raise_for_status()
         data = response.json()
 

--- a/magazyn/notifications.py
+++ b/magazyn/notifications.py
@@ -6,6 +6,7 @@ from email.message import EmailMessage
 import requests
 
 from .config import settings
+from .allegro_api import DEFAULT_TIMEOUT
 
 logger = logging.getLogger(__name__)
 
@@ -27,6 +28,7 @@ def send_messenger(text: str) -> bool:
                     "message": {"text": text},
                 }
             ),
+            timeout=DEFAULT_TIMEOUT,
         )
         logger.info("Messenger response: %s %s", resp.status_code, resp.text)
         return resp.status_code == 200


### PR DESCRIPTION
## Summary
- define DEFAULT_TIMEOUT constant in Allegro API client
- apply timeout to all requests in Allegro API and notifications module

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b35fdb30bc832aa6491c31d7fcb882