### PR TITLE
Switch to pypdf for PDF handling

### DIFF
--- a/magazyn/requirements.txt
+++ b/magazyn/requirements.txt
@@ -6,4 +6,4 @@ requests==2.32.4
 python-dotenv==1.1.1
 SQLAlchemy==2.0.41
 Flask-WTF==1.2.2
-PyPDF2==3.0.1
+pypdf==3.17.4

--- a/magazyn/services.py
+++ b/magazyn/services.py
@@ -9,7 +9,7 @@ from .constants import ALL_SIZES, PRODUCT_ALIASES
 from .parsing import parse_product_info
 from datetime import datetime
 from .config import settings
-from PyPDF2 import PdfReader
+from pypdf import PdfReader
 import logging
 import io
 import re


### PR DESCRIPTION
## Summary
- replace deprecated PyPDF2 import with pypdf
- update requirements to use pypdf

## Testing
- `./run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68b36390b8f4832ab0bd9f42fe6d6bcf