### PR TITLE
feat: add Allegro menu links

### DIFF
--- a/magazyn/templates/base.html
+++ b/magazyn/templates/base.html
@@ -42,6 +42,18 @@
                     <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('products.add_delivery') }}">Dostawy</a></li>
                     <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('sales.list_sales') }}">Sprzedaż</a></li>
                     <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('history.print_history') }}">Historia drukowania</a></li>
+                    <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('allegro.offers') }}">Oferty Allegro</a></li>
+                    {#
+                    <li class="nav-item dropdown">
+                        <a class="nav-link dropdown-toggle text-white" href="#" id="navbarAllegro" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+                            Allegro
+                        </a>
+                        <ul class="dropdown-menu dropdown-menu-dark">
+                            <li><a class="dropdown-item" href="{{ url_for('allegro.offers') }}">Oferty</a></li>
+                            <li><a class="dropdown-item" href="#">Monitor cen</a></li>
+                        </ul>
+                    </li>
+                    #}
                     <li class="nav-item dropdown">
                         <a class="nav-link dropdown-toggle text-white" href="#" id="navbarSettings" role="button" aria-expanded="false">
                             Ustawienia
@@ -72,6 +84,18 @@
             <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('products.add_delivery') }}">Dostawy</a></li>
             <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('sales.list_sales') }}">Sprzedaż</a></li>
             <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('history.print_history') }}">Historia drukowania</a></li>
+            <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('allegro.offers') }}">Oferty Allegro</a></li>
+            {#
+            <li class="nav-item dropdown">
+                <a class="nav-link dropdown-toggle text-white" href="#" id="mobileAllegro" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+                    Allegro
+                </a>
+                <ul class="dropdown-menu dropdown-menu-dark">
+                    <li><a class="dropdown-item" href="{{ url_for('allegro.offers') }}">Oferty</a></li>
+                    <li><a class="dropdown-item" href="#">Monitor cen</a></li>
+                </ul>
+            </li>
+            #}
             <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('settings_page') }}">Ustawienia</a></li>
             <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('shipping.shipping_costs') }}">Koszty wysyłek</a></li>
             <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('agent_logs') }}">Logi</a></li>

--- a/magazyn/tests/test_base_template.py
+++ b/magazyn/tests/test_base_template.py
@@ -45,3 +45,13 @@ def test_nav_contains_shipping_link(app_mod, client, login):
     resp = client.get("/")
     html = resp.get_data(as_text=True)
     assert f'href="{shipping_url}"' in html
+
+
+def test_nav_contains_allegro_offers_link(app_mod, client, login):
+    from flask import url_for
+
+    with app_mod.app.test_request_context():
+        offers_url = url_for("allegro.offers")
+    resp = client.get("/")
+    html = resp.get_data(as_text=True)
+    assert f'href="{offers_url}"' in html


### PR DESCRIPTION
## Summary
- add link to Allegro offers in desktop and mobile menus
- prepare commented dropdown for future Allegro options
- test navigation includes Allegro offers link

## Testing
- `./run-tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b36dfaf250832ab5d2a95cea5712a6