### PR TITLE
Add global barcode scanner component

### DIFF
--- a/magazyn/static/js/barcode_scanner.js
+++ b/magazyn/static/js/barcode_scanner.js
@@ -1,0 +1,210 @@
+(function () {
+    const form = document.getElementById('global-barcode-form');
+    const input = document.getElementById('global-barcode-input');
+    const csrfInput = document.getElementById('barcode-csrf-token');
+    const beepSound = document.getElementById('barcode-beep');
+    const toast = document.getElementById('global-barcode-toast');
+    const toastSuccess = toast ? toast.querySelector('[data-barcode-result]') : null;
+    const toastError = toast ? toast.querySelector('[data-barcode-error]') : null;
+    const AUTO_HIDE_DELAY = 6000;
+    let hideToastTimer = null;
+
+    if (!form || !input) {
+        return;
+    }
+
+    const getCsrfToken = () => (csrfInput ? csrfInput.value : '');
+
+    const focusInput = () => {
+        if (document.activeElement === input) {
+            return;
+        }
+        input.focus({ preventScroll: true });
+        input.select();
+    };
+
+    const hideToast = () => {
+        if (!toast) {
+            return;
+        }
+        toast.classList.add('d-none');
+        if (toastSuccess) {
+            toastSuccess.classList.add('d-none');
+            toastSuccess.textContent = '';
+        }
+        if (toastError) {
+            toastError.classList.add('d-none');
+            toastError.textContent = '';
+        }
+    };
+
+    const scheduleToastHide = () => {
+        if (!toast) {
+            return;
+        }
+        if (hideToastTimer) {
+            window.clearTimeout(hideToastTimer);
+        }
+        hideToastTimer = window.setTimeout(hideToast, AUTO_HIDE_DELAY);
+    };
+
+    const playBeep = () => {
+        if (!beepSound) {
+            return;
+        }
+        try {
+            beepSound.currentTime = 0;
+            const playPromise = beepSound.play();
+            if (playPromise instanceof Promise) {
+                playPromise.catch((err) => {
+                    console.warn('Nie udało się odtworzyć dźwięku', err);
+                });
+            }
+        } catch (err) {
+            console.warn('Nie udało się odtworzyć dźwięku', err);
+        }
+    };
+
+    const speak = (message) => {
+        if (!message || !('speechSynthesis' in window)) {
+            return;
+        }
+        try {
+            window.speechSynthesis.cancel();
+            const utterance = new SpeechSynthesisUtterance(message);
+            window.speechSynthesis.speak(utterance);
+        } catch (err) {
+            console.warn('Nie udało się odtworzyć komunikatu głosowego', err);
+        }
+    };
+
+    const formatProductInfo = (data) => {
+        const parts = [];
+        if (data.name) {
+            parts.push(data.name);
+        }
+        if (data.color) {
+            parts.push(`kolor ${data.color}`);
+        }
+        if (data.size) {
+            parts.push(`rozmiar ${data.size}`);
+        }
+        return parts.join(', ');
+    };
+
+    const formatSpeechInfo = (data) => {
+        const parts = [];
+        if (data.name) {
+            parts.push(`Produkt ${data.name}`);
+        }
+        if (data.size) {
+            parts.push(`Rozmiar ${data.size}`);
+        }
+        if (data.color) {
+            parts.push(`Kolor ${data.color}`);
+        }
+        return parts.join('. ');
+    };
+
+    const updateElements = (selector, updater) => {
+        document.querySelectorAll(selector).forEach((element) => {
+            updater(element);
+        });
+    };
+
+    const showSuccess = (data, code) => {
+        const info = formatProductInfo(data);
+        const message = info ? `Znaleziono produkt: ${info}` : 'Znaleziono produkt.';
+        updateElements('[data-barcode-result]', (element) => {
+            element.textContent = message;
+            element.classList.remove('d-none');
+            element.setAttribute('role', 'status');
+        });
+        updateElements('[data-barcode-error]', (element) => {
+            element.classList.add('d-none');
+            element.textContent = '';
+        });
+        updateElements('[data-barcode-code]', (element) => {
+            element.textContent = code || '';
+        });
+        if (toast) {
+            toast.classList.remove('d-none');
+        }
+        playBeep();
+        speak(formatSpeechInfo(data));
+        scheduleToastHide();
+        document.dispatchEvent(new CustomEvent('barcode:success', { detail: { data, code } }));
+    };
+
+    const showError = (message = 'Nie znaleziono produktu o podanym kodzie kreskowym.') => {
+        updateElements('[data-barcode-result]', (element) => {
+            if (!element.hasAttribute('data-barcode-persistent')) {
+                element.classList.add('d-none');
+                element.textContent = '';
+            }
+        });
+        updateElements('[data-barcode-error]', (element) => {
+            element.textContent = message;
+            element.classList.remove('d-none');
+            element.setAttribute('role', 'alert');
+        });
+        if (toast) {
+            toast.classList.remove('d-none');
+        }
+        speak(message);
+        scheduleToastHide();
+        document.dispatchEvent(new CustomEvent('barcode:error', { detail: { message } }));
+    };
+
+    const submitCode = (code) => {
+        if (!code) {
+            showError('Wprowadź kod kreskowy.');
+            return Promise.resolve();
+        }
+
+        return fetch('/barcode_scan', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'X-CSRFToken': getCsrfToken(),
+                'Accept': 'application/json',
+            },
+            body: JSON.stringify({ barcode: code }),
+        })
+            .then((response) => {
+                if (!response.ok) {
+                    throw new Error('request-failed');
+                }
+                return response.json();
+            })
+            .then((data) => {
+                if (!data || typeof data !== 'object') {
+                    throw new Error('invalid-response');
+                }
+                showSuccess(data, code);
+            })
+            .catch(() => {
+                showError();
+            });
+    };
+
+    form.addEventListener('submit', (event) => {
+        event.preventDefault();
+        const code = (input.value || '').trim();
+        input.value = '';
+        submitCode(code).finally(() => {
+            focusInput();
+        });
+    });
+
+    document.addEventListener('visibilitychange', () => {
+        if (document.visibilityState === 'visible') {
+            focusInput();
+        }
+    });
+
+    window.addEventListener('focus', focusInput);
+    window.addEventListener('pageshow', focusInput);
+
+    focusInput();
+})();

--- a/magazyn/static/styles.css
+++ b/magazyn/static/styles.css
@@ -326,3 +326,32 @@ th {
         right: 0;
     }
 }
+
+.barcode-capture-input {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 1px;
+    height: 1px;
+    opacity: 0;
+    border: none;
+    background: transparent;
+    color: transparent;
+    caret-color: transparent;
+}
+
+.barcode-toast {
+    position: fixed;
+    bottom: 1.5rem;
+    right: 1.5rem;
+    max-width: 320px;
+    z-index: 1080;
+}
+
+.barcode-toast .alert {
+    box-shadow: 0 0 12px rgba(0, 0, 0, 0.35);
+}
+
+.barcode-result-large {
+    font-size: 1.25rem;
+}

--- a/magazyn/templates/base.html
+++ b/magazyn/templates/base.html
@@ -129,7 +129,9 @@
     <footer>
         <p>&copy; 2024-{{ current_year }} <a href="https://retrievershop.pl/">Retriever Shop</a> - Magazyn</p>
     </footer>
+    {% include "components/barcode_scanner.html" %}
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="{{ url_for('static', filename='js/barcode_scanner.js') }}" defer></script>
     <script>
         const btn = document.getElementById('mobileMenuBtn');
         const menu = document.getElementById('mobileMenu');

--- a/magazyn/templates/components/barcode_scanner.html
+++ b/magazyn/templates/components/barcode_scanner.html
@@ -1,0 +1,20 @@
+<div id="global-barcode-scanner" class="barcode-scanner" aria-hidden="false">
+    <form id="global-barcode-form" class="barcode-scanner__form" autocomplete="off">
+        <label for="global-barcode-input" class="visually-hidden">Kod kreskowy</label>
+        <input
+            id="global-barcode-input"
+            type="text"
+            name="barcode"
+            class="barcode-capture-input"
+            autocomplete="off"
+            spellcheck="false"
+            autocapitalize="off"
+        >
+        <input type="hidden" id="barcode-csrf-token" value="{{ csrf_token() }}">
+    </form>
+    <audio id="barcode-beep" src="{{ url_for('static', filename='beep.mp3') }}" preload="auto"></audio>
+    <div id="global-barcode-toast" class="barcode-toast d-none" role="status" aria-live="polite">
+        <div class="alert alert-success mb-2 d-none" data-barcode-result></div>
+        <div class="alert alert-danger mb-0 d-none" data-barcode-error></div>
+    </div>
+</div>

--- a/magazyn/templates/scan_barcode.html
+++ b/magazyn/templates/scan_barcode.html
@@ -1,128 +1,16 @@
 {% extends "base.html" %}
 {% block content %}
     <div class="container text-center">
-        <h2 class="mb-4">Skanuj kod kreskowy</h2>
-        <form id="barcode-form" class="row justify-content-center">
-            <div class="col-md-6">
-                <label for="barcode-input" class="form-label visually-hidden">Kod kreskowy</label>
-                <input type="text"
-                       id="barcode-input"
-                       class="form-control form-control-lg text-center"
-                       placeholder="Przyłóż czytnik kodów kreskowych"
-                       autocomplete="off"
-                       autofocus>
+        <h2 class="mb-3">Skanuj kod kreskowy</h2>
+        <p class="lead">Przyłóż czytnik kodów kreskowych do produktu. Wynik pojawi się automatycznie.</p>
+        <div class="card mt-4 shadow-sm">
+            <div class="card-body">
+                <p class="text-muted mb-1">Ostatni zeskanowany kod:</p>
+                <p class="barcode-result-large fw-semibold" data-barcode-code></p>
+                <div class="alert alert-success mt-3 d-none" data-barcode-result></div>
+                <div class="alert alert-danger mt-3 d-none" data-barcode-error></div>
             </div>
-        </form>
-        <div id="barcode-result" class="alert alert-success mt-4 d-none"></div>
-        <div id="barcode-error" class="alert alert-danger mt-4 d-none"></div>
+        </div>
+        <p class="mt-4 text-muted">Czytnik pozostaje aktywny także na innych podstronach aplikacji.</p>
     </div>
-
-    <audio id="beep-sound" src="{{ url_for('static', filename='beep.mp3') }}" preload="auto"></audio>
-    <input type="hidden" id="csrf-token" value="{{ csrf_token() }}">
-
-    <script>
-        document.addEventListener('DOMContentLoaded', () => {
-            const form = document.getElementById('barcode-form');
-            const input = document.getElementById('barcode-input');
-            const resultEl = document.getElementById('barcode-result');
-            const errorEl = document.getElementById('barcode-error');
-            const beepSound = document.getElementById('beep-sound');
-            const csrfToken = document.getElementById('csrf-token').value;
-
-            const focusInput = () => {
-                if (input) {
-                    input.focus();
-                    input.select();
-                }
-            };
-
-            focusInput();
-
-            form.addEventListener('submit', (event) => {
-                event.preventDefault();
-                const code = input.value.trim();
-                if (!code) {
-                    errorEl.textContent = 'Wprowadź kod kreskowy.';
-                    errorEl.classList.remove('d-none');
-                    resultEl.classList.add('d-none');
-                    focusInput();
-                    return;
-                }
-
-                fetch('/barcode_scan', {
-                    method: 'POST',
-                    headers: {
-                        'Content-Type': 'application/json',
-                        'X-CSRFToken': csrfToken,
-                    },
-                    body: JSON.stringify({ barcode: code })
-                })
-                    .then((response) => {
-                        if (!response.ok) {
-                            throw new Error('request-failed');
-                        }
-                        return response.json();
-                    })
-                    .then((data) => {
-                        const infoParts = [];
-                        if (data.name) {
-                            infoParts.push(data.name);
-                        }
-                        if (data.color) {
-                            infoParts.push(`kolor ${data.color}`);
-                        }
-                        if (data.size) {
-                            infoParts.push(`rozmiar ${data.size}`);
-                        }
-                        const info = infoParts.join(', ');
-                        resultEl.textContent = `Znaleziono produkt: ${info}`;
-                        resultEl.classList.remove('d-none');
-                        errorEl.classList.add('d-none');
-
-                        if (beepSound) {
-                            try {
-                                beepSound.currentTime = 0;
-                                void beepSound.play();
-                            } catch (err) {
-                                console.warn('Nie udało się odtworzyć dźwięku', err);
-                            }
-                        }
-
-                        if ('speechSynthesis' in window) {
-                            const speechParts = [];
-                            if (data.name) {
-                                speechParts.push(`Produkt ${data.name}`);
-                            }
-                            if (data.size) {
-                                speechParts.push(`Rozmiar ${data.size}`);
-                            }
-                            if (data.color) {
-                                speechParts.push(`Kolor ${data.color}`);
-                            }
-                            const message = speechParts.join('. ');
-                            if (message) {
-                                window.speechSynthesis.cancel();
-                                const utterance = new SpeechSynthesisUtterance(message);
-                                window.speechSynthesis.speak(utterance);
-                            }
-                        }
-                    })
-                    .catch(() => {
-                        errorEl.textContent = 'Nie znaleziono produktu o podanym kodzie kreskowym.';
-                        errorEl.classList.remove('d-none');
-                        resultEl.classList.add('d-none');
-
-                        if ('speechSynthesis' in window) {
-                            window.speechSynthesis.cancel();
-                            const utterance = new SpeechSynthesisUtterance('Nie znaleziono produktu o podanym kodzie kreskowym.');
-                            window.speechSynthesis.speak(utterance);
-                        }
-                    })
-                    .finally(() => {
-                        input.value = '';
-                        focusInput();
-                    });
-            });
-        });
-    </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- extract the barcode scanning UI into a shared component included from the base template so scanning works on every view
- add a reusable JavaScript module that keeps a hidden input focused, calls `/barcode_scan`, plays audio feedback and emits TTS
- refresh the dedicated scan page and styles to show the last scanned code while relying on the shared logic

## Testing
- pytest magazyn/tests/test_base_template.py *(fails: ModuleNotFoundError: No module named 'magazyn')*


------
https://chatgpt.com/codex/tasks/task_e_68cd8733e268832aa315e6e16e869b71