### PR TITLE
Remove TTS labels for size and color

### DIFF
--- a/magazyn/templates/scan_barcode.html
+++ b/magazyn/templates/scan_barcode.html
@@ -94,10 +94,10 @@
                                 speechParts.push(`Produkt ${data.name}`);
                             }
                             if (data.size) {
-                                speechParts.push(`Rozmiar ${data.size}`);
+                                speechParts.push(`${data.size}`);
                             }
                             if (data.color) {
-                                speechParts.push(`Kolor ${data.color}`);
+                                speechParts.push(`${data.color}`);
                             }
                             const message = speechParts.join('. ');
                             if (message) {


### PR DESCRIPTION
## Summary
- stop prefixing size and color values with spoken labels in the barcode scan TTS message

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cd8613620c832a88a2cc6fbc256adb