### PR TITLE
Refactor barcode scanning into shared component

### DIFF
--- a/magazyn/static/barcode-scanner.js
+++ b/magazyn/static/barcode-scanner.js
@@ -1,0 +1,218 @@
+(function () {
+    const SUCCESS_CLASS = 'alert-success';
+    const ERROR_CLASS = 'alert-danger';
+    const HIDDEN_CLASS = 'd-none';
+    const SCAN_ERROR_MESSAGE = 'Nie znaleziono produktu o podanym kodzie kreskowym.';
+
+    const speechSupport = () => 'speechSynthesis' in window;
+
+    const getResultElements = () => Array.from(document.querySelectorAll('[data-barcode-result]'));
+    const getErrorElements = () => Array.from(document.querySelectorAll('[data-barcode-error]'));
+
+    const hideElement = (element) => {
+        if (!element || element.classList.contains(HIDDEN_CLASS)) {
+            return;
+        }
+        element.classList.add(HIDDEN_CLASS);
+    };
+
+    const showElement = (element, text, className) => {
+        if (!element) {
+            return;
+        }
+        element.textContent = text;
+        element.classList.remove(HIDDEN_CLASS, SUCCESS_CLASS, ERROR_CLASS);
+        if (className) {
+            element.classList.add(className);
+        }
+    };
+
+    const speak = (message) => {
+        if (!speechSupport() || !message) {
+            return;
+        }
+        try {
+            window.speechSynthesis.cancel();
+            const utterance = new SpeechSynthesisUtterance(message);
+            window.speechSynthesis.speak(utterance);
+        } catch (error) {
+            console.warn('Nie udało się odtworzyć komunikatu głosowego', error);
+        }
+    };
+
+    const playBeep = (audioElement) => {
+        if (!audioElement) {
+            return;
+        }
+        try {
+            audioElement.currentTime = 0;
+            void audioElement.play();
+        } catch (error) {
+            console.warn('Nie udało się odtworzyć dźwięku', error);
+        }
+    };
+
+    const focusScannerInput = (input) => {
+        if (!input) {
+            return;
+        }
+        const active = document.activeElement;
+        if (active && active !== document.body && active !== document.documentElement) {
+            const tagName = active.tagName ? active.tagName.toLowerCase() : '';
+            const isTextual = ['input', 'textarea', 'select'].includes(tagName) || active.isContentEditable;
+            if (isTextual && active !== input) {
+                return;
+            }
+        }
+        input.focus({ preventScroll: true });
+        input.select();
+    };
+
+    const buildInfoText = (data) => {
+        const infoParts = [];
+        if (data.name) {
+            infoParts.push(data.name);
+        }
+        if (data.color) {
+            infoParts.push(`kolor ${data.color}`);
+        }
+        if (data.size) {
+            infoParts.push(`rozmiar ${data.size}`);
+        }
+        return infoParts.join(', ');
+    };
+
+    const buildSpeechText = (data) => {
+        const speechParts = [];
+        if (data.name) {
+            speechParts.push(`Produkt ${data.name}`);
+        }
+        if (data.size) {
+            speechParts.push(`${data.size}`);
+        }
+        if (data.color) {
+            speechParts.push(`${data.color}`);
+        }
+        return speechParts.join('. ');
+    };
+
+    const showSuccess = (data, beepElement) => {
+        const info = buildInfoText(data);
+        const message = info ? `Znaleziono produkt: ${info}` : 'Znaleziono produkt.';
+        getResultElements().forEach((element) => showElement(element, message, SUCCESS_CLASS));
+        getErrorElements().forEach((element) => hideElement(element));
+        playBeep(beepElement);
+        const speechMessage = buildSpeechText(data);
+        speak(speechMessage);
+    };
+
+    const showError = (message) => {
+        const errorMessage = message || SCAN_ERROR_MESSAGE;
+        getErrorElements().forEach((element) => showElement(element, errorMessage, ERROR_CLASS));
+        getResultElements().forEach((element) => hideElement(element));
+        speak(errorMessage);
+    };
+
+    const submitBarcode = (barcode, options) => {
+        const { csrfToken, input, beepElement } = options || {};
+        if (!barcode) {
+            showError('Wprowadź kod kreskowy.');
+            if (input) {
+                input.value = '';
+                focusScannerInput(input);
+            }
+            return;
+        }
+        fetch('/barcode_scan', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'X-CSRFToken': csrfToken || ''
+            },
+            body: JSON.stringify({ barcode })
+        })
+            .then((response) => {
+                if (!response.ok) {
+                    throw new Error('request-failed');
+                }
+                return response.json();
+            })
+            .then((data) => {
+                showSuccess(data, beepElement);
+            })
+            .catch(() => {
+                showError(SCAN_ERROR_MESSAGE);
+            })
+            .finally(() => {
+                if (input) {
+                    input.value = '';
+                    focusScannerInput(input);
+                }
+            });
+    };
+
+    document.addEventListener('DOMContentLoaded', () => {
+        const hiddenInput = document.getElementById('barcode-scanner-input');
+        const beepElement = document.getElementById('barcode-beep-sound');
+        const csrfElement = document.getElementById('barcode-csrf-token');
+        const csrfToken = csrfElement ? csrfElement.value : '';
+
+        focusScannerInput(hiddenInput);
+        if (hiddenInput) {
+            hiddenInput.addEventListener('keydown', (event) => {
+                if (event.key === 'Enter') {
+                    event.preventDefault();
+                    submitBarcode(hiddenInput.value.trim(), {
+                        csrfToken,
+                        input: hiddenInput,
+                        beepElement
+                    });
+                }
+            });
+            hiddenInput.addEventListener('blur', () => {
+                setTimeout(() => focusScannerInput(hiddenInput), 50);
+            });
+        }
+
+        document.querySelectorAll('[data-barcode-source="manual"]').forEach((input) => {
+            const form = input.form;
+            if (form) {
+                form.addEventListener('submit', (event) => {
+                    event.preventDefault();
+                    submitBarcode(input.value.trim(), {
+                        csrfToken,
+                        input,
+                        beepElement
+                    });
+                });
+            } else {
+                input.addEventListener('keydown', (event) => {
+                    if (event.key === 'Enter') {
+                        event.preventDefault();
+                        submitBarcode(input.value.trim(), {
+                            csrfToken,
+                            input,
+                            beepElement
+                        });
+                    }
+                });
+            }
+            input.addEventListener('blur', () => {
+                setTimeout(() => focusScannerInput(hiddenInput), 100);
+            });
+        });
+
+        document.addEventListener('barcode:scan', (event) => {
+            const detail = event.detail || {};
+            const barcode = detail.barcode;
+            if (!barcode) {
+                return;
+            }
+            submitBarcode(barcode, {
+                csrfToken,
+                input: hiddenInput,
+                beepElement
+            });
+        });
+    });
+})();

--- a/magazyn/static/styles.css
+++ b/magazyn/static/styles.css
@@ -101,6 +101,21 @@ footer a:hover {
     text-decoration: underline;
 }
 
+.barcode-feedback {
+    position: fixed;
+    top: 220px;
+    right: 1rem;
+    max-width: 360px;
+    width: min(90vw, 360px);
+    z-index: 1100;
+    pointer-events: none;
+}
+
+.barcode-feedback .alert {
+    margin-bottom: 0.5rem;
+    pointer-events: auto;
+}
+
 /* Ustawienie szerokości tabeli */
 table {
     width: 100%; /* Zmniejsz szerokość, aby tabela była bardziej kompaktowa */

--- a/magazyn/templates/base.html
+++ b/magazyn/templates/base.html
@@ -129,7 +129,25 @@
     <footer>
         <p>&copy; 2024-{{ current_year }} <a href="https://retrievershop.pl/">Retriever Shop</a> - Magazyn</p>
     </footer>
+
+    <div id="barcode-feedback" class="barcode-feedback">
+        <div class="alert alert-success d-none" role="status" data-barcode-result></div>
+        <div class="alert alert-danger d-none" role="alert" data-barcode-error></div>
+    </div>
+
+    <audio id="barcode-beep-sound" src="{{ url_for('static', filename='beep.mp3') }}" preload="auto"></audio>
+    <div class="visually-hidden">
+        <label for="barcode-scanner-input">Skaner kodów kreskowych</label>
+        <input type="text"
+               id="barcode-scanner-input"
+               autocomplete="off"
+               inputmode="none"
+               aria-label="Pole przechwytujące kody kreskowe">
+    </div>
+    <input type="hidden" id="barcode-csrf-token" value="{{ csrf_token() }}">
+
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="{{ url_for('static', filename='barcode-scanner.js') }}"></script>
     <script>
         const btn = document.getElementById('mobileMenuBtn');
         const menu = document.getElementById('mobileMenu');

--- a/magazyn/templates/scan_barcode.html
+++ b/magazyn/templates/scan_barcode.html
@@ -2,127 +2,19 @@
 {% block content %}
     <div class="container text-center">
         <h2 class="mb-4">Skanuj kod kreskowy</h2>
+        <p class="lead">Przyłóż czytnik kodów kreskowych do produktu lub wpisz kod ręcznie.</p>
         <form id="barcode-form" class="row justify-content-center">
             <div class="col-md-6">
                 <label for="barcode-input" class="form-label visually-hidden">Kod kreskowy</label>
                 <input type="text"
                        id="barcode-input"
                        class="form-control form-control-lg text-center"
-                       placeholder="Przyłóż czytnik kodów kreskowych"
+                       placeholder="Przyłóż czytnik lub wpisz kod"
                        autocomplete="off"
-                       autofocus>
+                       data-barcode-source="manual">
             </div>
         </form>
-        <div id="barcode-result" class="alert alert-success mt-4 d-none"></div>
-        <div id="barcode-error" class="alert alert-danger mt-4 d-none"></div>
+        <div class="alert alert-success mt-4 d-none" data-barcode-result></div>
+        <div class="alert alert-danger mt-4 d-none" data-barcode-error></div>
     </div>
-
-    <audio id="beep-sound" src="{{ url_for('static', filename='beep.mp3') }}" preload="auto"></audio>
-    <input type="hidden" id="csrf-token" value="{{ csrf_token() }}">
-
-    <script>
-        document.addEventListener('DOMContentLoaded', () => {
-            const form = document.getElementById('barcode-form');
-            const input = document.getElementById('barcode-input');
-            const resultEl = document.getElementById('barcode-result');
-            const errorEl = document.getElementById('barcode-error');
-            const beepSound = document.getElementById('beep-sound');
-            const csrfToken = document.getElementById('csrf-token').value;
-
-            const focusInput = () => {
-                if (input) {
-                    input.focus();
-                    input.select();
-                }
-            };
-
-            focusInput();
-
-            form.addEventListener('submit', (event) => {
-                event.preventDefault();
-                const code = input.value.trim();
-                if (!code) {
-                    errorEl.textContent = 'Wprowadź kod kreskowy.';
-                    errorEl.classList.remove('d-none');
-                    resultEl.classList.add('d-none');
-                    focusInput();
-                    return;
-                }
-
-                fetch('/barcode_scan', {
-                    method: 'POST',
-                    headers: {
-                        'Content-Type': 'application/json',
-                        'X-CSRFToken': csrfToken,
-                    },
-                    body: JSON.stringify({ barcode: code })
-                })
-                    .then((response) => {
-                        if (!response.ok) {
-                            throw new Error('request-failed');
-                        }
-                        return response.json();
-                    })
-                    .then((data) => {
-                        const infoParts = [];
-                        if (data.name) {
-                            infoParts.push(data.name);
-                        }
-                        if (data.color) {
-                            infoParts.push(`kolor ${data.color}`);
-                        }
-                        if (data.size) {
-                            infoParts.push(`rozmiar ${data.size}`);
-                        }
-                        const info = infoParts.join(', ');
-                        resultEl.textContent = `Znaleziono produkt: ${info}`;
-                        resultEl.classList.remove('d-none');
-                        errorEl.classList.add('d-none');
-
-                        if (beepSound) {
-                            try {
-                                beepSound.currentTime = 0;
-                                void beepSound.play();
-                            } catch (err) {
-                                console.warn('Nie udało się odtworzyć dźwięku', err);
-                            }
-                        }
-
-                        if ('speechSynthesis' in window) {
-                            const speechParts = [];
-                            if (data.name) {
-                                speechParts.push(`Produkt ${data.name}`);
-                            }
-                            if (data.size) {
-                                speechParts.push(`${data.size}`);
-                            }
-                            if (data.color) {
-                                speechParts.push(`${data.color}`);
-                            }
-                            const message = speechParts.join('. ');
-                            if (message) {
-                                window.speechSynthesis.cancel();
-                                const utterance = new SpeechSynthesisUtterance(message);
-                                window.speechSynthesis.speak(utterance);
-                            }
-                        }
-                    })
-                    .catch(() => {
-                        errorEl.textContent = 'Nie znaleziono produktu o podanym kodzie kreskowym.';
-                        errorEl.classList.remove('d-none');
-                        resultEl.classList.add('d-none');
-
-                        if ('speechSynthesis' in window) {
-                            window.speechSynthesis.cancel();
-                            const utterance = new SpeechSynthesisUtterance('Nie znaleziono produktu o podanym kodzie kreskowym.');
-                            window.speechSynthesis.speak(utterance);
-                        }
-                    })
-                    .finally(() => {
-                        input.value = '';
-                        focusInput();
-                    });
-            });
-        });
-    </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add a global barcode scanner component with shared JS logic, CSRF handling, and speech/beep feedback
- extend the base template with hidden scanner input, reusable result containers, and floating feedback styling
- simplify the dedicated scan page to reuse the shared component while keeping manual entry support

## Testing
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_e_68cd8c627164832a893dfc9e6e7cc3c8