### PR TITLE
Fix CSRF token error on Allegro offers refresh form

### DIFF
--- a/magazyn/templates/allegro/offers.html
+++ b/magazyn/templates/allegro/offers.html
@@ -2,6 +2,7 @@
 {% block content %}
 <h1>Oferty Allegro</h1>
 <form method="post" action="{{ url_for('allegro.refresh') }}" class="mb-3">
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
     <button type="submit" class="btn btn-primary">Odśwież</button>
     </form>
 {% for group in groups %}


### PR DESCRIPTION
## Summary
- add the CSRF token field to the Allegro offers refresh form so the request passes CSRF validation

## Testing
- ./run-tests.sh

------
https://chatgpt.com/codex/tasks/task_e_68ce970b54c8832aaf5666e4bc934529