### PR TITLE
Add manual inventory matching dropdown for Allegro offers

### DIFF
--- a/magazyn/templates/allegro/link.html
+++ b/magazyn/templates/allegro/link.html
@@ -6,6 +6,12 @@
     <div class="mb-3">
         <label for="product_id" class="form-label">ID produktu</label>
         <input type="number" name="product_id" id="product_id" class="form-control" value="{{ offer.product_id }}">
+        <div class="form-text">Pozostaw puste, jeśli chcesz wskazać konkretny rozmiar.</div>
+    </div>
+    <div class="mb-3">
+        <label for="product_size_id" class="form-label">ID rozmiaru produktu</label>
+        <input type="number" name="product_size_id" id="product_size_id" class="form-control" value="{{ offer.product_size_id }}">
+        <div class="form-text">Wprowadź ID pozycji z magazynu, aby powiązać ofertę z konkretnym rozmiarem.</div>
     </div>
     <button type="submit" class="btn btn-primary">Zapisz</button>
 </form>

--- a/magazyn/templates/allegro/offers.html
+++ b/magazyn/templates/allegro/offers.html
@@ -5,27 +5,102 @@
     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
     <button type="submit" class="btn btn-primary">Odśwież</button>
     </form>
-{% for group in groups %}
-<h3>{{ group.product_name }} {% if group.size %}- {{ group.size }}{% endif %}</h3>
-<table class="table table-striped">
-    <thead>
-        <tr>
-            <th>ID</th>
-            <th>Tytuł</th>
-            <th>Cena</th>
-            <th></th>
-        </tr>
-    </thead>
-    <tbody>
-    {% for offer in group.offers %}
-        <tr>
-            <td>{{ offer.offer_id }}</td>
-            <td>{{ offer.title }}</td>
-            <td>{{ offer.price }}</td>
-            <td><a href="{{ url_for('allegro.link_offer', offer_id=offer.offer_id) }}" class="btn btn-sm btn-secondary">Powiąż</a></td>
-        </tr>
-    {% endfor %}
-    </tbody>
-</table>
-{% endfor %}
+<div class="table-responsive">
+    <table class="table table-striped align-middle">
+        <thead>
+            <tr>
+                <th scope="col">ID</th>
+                <th scope="col">Tytuł</th>
+                <th scope="col">Cena</th>
+                <th scope="col" class="w-50">Powiązanie z magazynem</th>
+            </tr>
+        </thead>
+        <tbody>
+        {% for offer in offers %}
+            <tr>
+                <td>{{ offer.offer_id }}</td>
+                <td>{{ offer.title }}</td>
+                <td>{{ offer.price }}</td>
+                <td>
+                    <form method="post" action="{{ url_for('allegro.link_offer', offer_id=offer.offer_id) }}" class="d-flex align-items-center gap-2 flex-wrap">
+                        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                        <input type="hidden" name="product_size_id" value="{{ offer.product_size_id or '' }}" data-selected-input>
+                        <div class="dropdown flex-grow-1 search-dropdown" data-offer-id="{{ offer.offer_id }}">
+                            <button class="btn btn-outline-light dropdown-toggle w-100 text-start" type="button" data-bs-toggle="dropdown" aria-expanded="false" data-selected-label data-placeholder="Wybierz z magazynu">
+                                {{ offer.selected_label or 'Wybierz z magazynu' }}
+                            </button>
+                            <div class="dropdown-menu dropdown-menu-dark w-100 p-3">
+                                <input type="text" class="form-control form-control-sm mb-2 search-dropdown-input" placeholder="Szukaj..." autocomplete="off" data-search-input>
+                                <div class="list-group search-dropdown-options" data-options>
+                                    <button type="button" class="list-group-item list-group-item-action" data-value="" data-label="Wybierz z magazynu" data-filter="">
+                                        <div class="fw-semibold">Brak powiązania</div>
+                                        <div class="small text-muted">Zostaw ofertę bez przypisania</div>
+                                    </button>
+                                    {% for item in inventory %}
+                                    <button type="button" class="list-group-item list-group-item-action" data-value="{{ item.id }}" data-label="{{ item.label }}" data-filter="{{ item.filter }}">
+                                        <div class="fw-semibold">{{ item.label }}</div>
+                                        <div class="small text-muted">{{ item.extra }}</div>
+                                    </button>
+                                    {% endfor %}
+                                </div>
+                            </div>
+                        </div>
+                        <button type="submit" class="btn btn-primary btn-sm">Zapisz</button>
+                    </form>
+                </td>
+            </tr>
+        {% endfor %}
+        </tbody>
+    </table>
+</div>
+
+<script>
+document.addEventListener('DOMContentLoaded', () => {
+    document.querySelectorAll('.search-dropdown').forEach(dropdown => {
+        const toggleButton = dropdown.querySelector('[data-selected-label]');
+        const hiddenInput = dropdown.closest('form').querySelector('[data-selected-input]');
+        const searchInput = dropdown.querySelector('[data-search-input]');
+        const options = dropdown.querySelectorAll('[data-value]');
+        const placeholder = toggleButton.dataset.placeholder || toggleButton.textContent.trim();
+
+        const updateLabel = (text) => {
+            toggleButton.textContent = text && text.trim() ? text : placeholder;
+        };
+
+        const dropdownInstance = bootstrap.Dropdown.getOrCreateInstance(toggleButton);
+
+        options.forEach(option => {
+            option.addEventListener('click', () => {
+                hiddenInput.value = option.dataset.value;
+                updateLabel(option.dataset.label || placeholder);
+                dropdownInstance.hide();
+            });
+        });
+
+        if (hiddenInput.value) {
+            const selectedOption = Array.from(options).find(option => option.dataset.value === hiddenInput.value);
+            if (selectedOption) {
+                updateLabel(selectedOption.dataset.label || placeholder);
+            }
+        }
+
+        searchInput.addEventListener('input', () => {
+            const query = searchInput.value.trim().toLowerCase();
+            options.forEach(option => {
+                if (!option.dataset.filter) {
+                    option.classList.toggle('d-none', Boolean(query));
+                    return;
+                }
+                const matches = option.dataset.filter.includes(query);
+                option.classList.toggle('d-none', !matches);
+            });
+        });
+
+        dropdown.addEventListener('hidden.bs.dropdown', () => {
+            searchInput.value = '';
+            options.forEach(option => option.classList.remove('d-none'));
+        });
+    });
+});
+</script>
 {% endblock %}

--- a/magazyn/tests/test_allegro_offers.py
+++ b/magazyn/tests/test_allegro_offers.py
@@ -1,0 +1,81 @@
+from decimal import Decimal
+
+from magazyn.db import get_session
+from magazyn.models import AllegroOffer, Product, ProductSize
+
+
+def test_offers_page_shows_manual_mapping_dropdown(client, login):
+    with get_session() as session:
+        product = Product(name="Szelki spacerowe", color="Czerwone")
+        session.add(product)
+        session.flush()
+        size = ProductSize(
+            product_id=product.id,
+            size="M",
+            quantity=5,
+            barcode="1234567890123",
+        )
+        session.add(size)
+        session.flush()
+        session.add(
+            AllegroOffer(
+                offer_id="offer-1",
+                title="Szelki na spacery",
+                price=Decimal("129.99"),
+                product_id=product.id,
+                product_size_id=size.id,
+            )
+        )
+
+    response = client.get("/allegro/offers")
+
+    body = response.data.decode("utf-8")
+    assert "data-search-input" in body
+    assert "Brak powiązania" in body
+    assert "Szelki spacerowe" in body
+    assert "EAN: 1234567890123" in body
+
+
+def test_link_offer_to_product_size_updates_relation(client, login):
+    with get_session() as session:
+        product_current = Product(name="Smycz stara")
+        product_target = Product(name="Smycz nowa", color="Granatowa")
+        session.add_all([product_current, product_target])
+        session.flush()
+
+        size_target = ProductSize(
+            product_id=product_target.id,
+            size="L",
+            quantity=3,
+            barcode="ABC123",
+        )
+        session.add(size_target)
+        session.flush()
+
+        offer_id = "offer-2"
+        session.add(
+            AllegroOffer(
+                offer_id=offer_id,
+                title="Oferta Smyczy",
+                price=Decimal("59.99"),
+                product_id=product_current.id,
+            )
+        )
+
+    response = client.post(
+        f"/allegro/link/{offer_id}",
+        data={"product_size_id": size_target.id},
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 302
+    assert response.headers["Location"].endswith("/allegro/offers")
+
+    with get_session() as session:
+        updated = (
+            session.query(AllegroOffer)
+            .filter(AllegroOffer.offer_id == offer_id)
+            .one()
+        )
+        assert updated.product_size_id == size_target.id
+        assert updated.product_id == product_target.id


### PR DESCRIPTION
## Summary
- replace the Allegro offers list with a searchable dropdown per offer for manual inventory matching
- update the linking endpoint to accept product size selections and expose matching fields in the fallback form
- add regression tests covering the offers page UI and linking a product size to an offer

## Testing
- ./run-tests.sh

------
https://chatgpt.com/codex/tasks/task_e_68ce9b04d780832aa5beb7bdb5c8bbc0