### PR TITLE
Report Allegro sync counts

### DIFF
--- a/magazyn/allegro.py
+++ b/magazyn/allegro.py
@@ -85,8 +85,14 @@ def offers():
 @login_required
 def refresh():
     try:
-        sync_offers()
-        flash("Oferty zaktualizowane")
+        result = sync_offers()
+        fetched = result.get("fetched", 0)
+        matched = result.get("matched", 0)
+        flash(
+            "Oferty zaktualizowane (pobrano {fetched}, zaktualizowano {matched})".format(
+                fetched=fetched, matched=matched
+            )
+        )
     except Exception as e:
         flash(f"Błąd synchronizacji ofert: {e}")
     return redirect(url_for("allegro.offers"))


### PR DESCRIPTION
## Summary
- include Allegro offer fetch/match counts in the sync success message so users know how many offers were processed
- update the sync routine to track fetched and matched offers and return these counts
- extend Allegro refresh tests to cover the new flash messaging and zero-match scenarios

## Testing
- `PYTHONPATH=. pytest magazyn/tests/test_allegro_refresh.py`


------
https://chatgpt.com/codex/tasks/task_e_68cebb736684832a9867a7a03f5b984b