### PR TITLE
Handle malformed Allegro offer responses

### DIFF
--- a/magazyn/allegro_sync.py
+++ b/magazyn/allegro_sync.py
@@ -2,6 +2,7 @@ from datetime import datetime, timezone
 import os
 import logging
 from decimal import Decimal, InvalidOperation
+from collections.abc import Mapping
 
 from requests.exceptions import HTTPError
 
@@ -109,6 +110,15 @@ def sync_offers():
                 message = f"Failed to fetch Allegro offers on page {page}"
                 logger.error(message, exc_info=True)
                 raise RuntimeError(message) from exc
+            if not isinstance(data, Mapping):
+                logger.error(
+                    "Malformed response from Allegro on page %s: %r", page, data
+                )
+                raise RuntimeError(
+                    "Failed to fetch Allegro offers on page "
+                    f"{page}: malformed response from Allegro"
+                )
+
             offers = data.get("offers") or data.get("items", {}).get("offers", [])
             if offers:
                 try:


### PR DESCRIPTION
## Summary
- validate Allegro offer sync payloads before accessing mapping data and raise descriptive errors for malformed responses
- cover the Allegro refresh flow with a regression test for empty API payloads so the user sees a friendly flash message

## Testing
- PYTHONPATH=. pytest magazyn/tests/test_allegro_refresh.py

------
https://chatgpt.com/codex/tasks/task_e_68cec14aced8832a9eb6a014f10aa41a