### PR TITLE
Handle non-mapping selling mode in Allegro sync

### DIFF
--- a/magazyn/allegro_sync.py
+++ b/magazyn/allegro_sync.py
@@ -129,10 +129,15 @@ def sync_offers():
                 offers = []
             fetched_count += len(offers)
             for offer in offers:
-                price_data = (
-                    offer.get("price")
-                    or offer.get("sellingMode", {}).get("price", {}).get("amount")
-                )
+                price_data = offer.get("price")
+                if price_data is None:
+                    selling_mode = offer.get("sellingMode")
+                    if not isinstance(selling_mode, Mapping):
+                        selling_mode = {}
+                    price = selling_mode.get("price")
+                    if not isinstance(price, Mapping):
+                        price = {}
+                    price_data = price.get("amount")
                 if price_data is not None:
                     try:
                         price = Decimal(price_data).quantize(Decimal("0.01"))


### PR DESCRIPTION
## Summary
- guard Allegro offer selling mode and price payloads against non-mapping values before reading price amounts
- add regression test ensuring sync_offers handles offers missing selling mode price structures and still matches products

## Testing
- PYTHONPATH=. pytest magazyn/tests/test_allegro_refresh.py -k "non_mapping" -q

------
https://chatgpt.com/codex/tasks/task_e_68cec6805378832a8d88090e7522c7f2