### PR TITLE
Parse Allegro titles for product matching

### DIFF
--- a/magazyn/parsing.py
+++ b/magazyn/parsing.py
@@ -66,3 +66,56 @@ def parse_product_info(item: dict) -> tuple[str, str, str]:
     name = PRODUCT_ALIASES.get(name, name)
     color = normalize_color(color)
     return name, size, color
+
+
+def parse_offer_title(title: str) -> tuple[str, str, str]:
+    """Split an Allegro offer title into product name, color and size.
+
+    Parameters
+    ----------
+    title:
+        Raw title string fetched from Allegro.
+
+    Returns
+    -------
+    tuple[str, str, str]
+        ``(name, color, size)`` tuple where size defaults to ``"Uniwersalny"``
+        when it could not be inferred from the title.
+    """
+
+    if not title:
+        return "", "", "Uniwersalny"
+
+    words = [word for word in (title or "").strip().split() if word]
+    size_lookup = {size.upper(): size for size in ALL_SIZES}
+    known_colors = {color.lower() for color in KNOWN_COLORS}
+
+    color = ""
+    size = ""
+
+    cleaned_words: list[str] = []
+    for word in words:
+        cleaned_words.append(word.strip(",.;:!"))
+
+    # Work on a copy so we can safely remove identified size/color tokens.
+    remaining_words = cleaned_words.copy()
+
+    for index in range(len(cleaned_words) - 1, -1, -1):
+        word = cleaned_words[index]
+        upper_word = word.upper()
+        if not size and upper_word in size_lookup:
+            size = size_lookup[upper_word]
+            remaining_words.pop(index)
+            continue
+        lower_word = word.lower()
+        if not color and lower_word in known_colors:
+            color = normalize_color(word)
+            remaining_words.pop(index)
+
+    name = " ".join(remaining_words).strip()
+    name = PRODUCT_ALIASES.get(name, name)
+
+    if not size:
+        size = "Uniwersalny"
+
+    return name, color, size


### PR DESCRIPTION
## Summary
- add a parser that extracts product name, color and size from Allegro offer titles with a Uniwersalny default
- match Allegro offers to products by joined name/color/size instead of barcodes in the sync logic
- adjust Allegro sync tests to assert name-based matching with parsed titles and without relying on EANs

## Testing
- PYTHONPATH=. pytest magazyn/tests/test_allegro_refresh.py


------
https://chatgpt.com/codex/tasks/task_e_68ced1fbc99c832a92d966d0de466c43