### PR TITLE
Prioritize unlinked Allegro offers

### DIFF
--- a/magazyn/allegro.py
+++ b/magazyn/allegro.py
@@ -7,6 +7,8 @@ from flask import (
     flash,
 )
 
+from sqlalchemy import case
+
 from .db import get_session
 from .models import AllegroOffer, Product, ProductSize
 from .auth import login_required
@@ -23,7 +25,10 @@ def offers():
             db.query(AllegroOffer, ProductSize, Product)
             .outerjoin(ProductSize, AllegroOffer.product_size_id == ProductSize.id)
             .outerjoin(Product, ProductSize.product_id == Product.id)
-            .order_by(AllegroOffer.title)
+            .order_by(
+                case((AllegroOffer.product_size_id.is_(None), 0), else_=1),
+                AllegroOffer.title,
+            )
             .all()
         )
         offers = []

--- a/magazyn/tests/test_allegro_offers.py
+++ b/magazyn/tests/test_allegro_offers.py
@@ -1,4 +1,5 @@
 from decimal import Decimal
+import re
 
 from magazyn.db import get_session
 from magazyn.models import AllegroOffer, Product, ProductSize
@@ -79,3 +80,56 @@ def test_link_offer_to_product_size_updates_relation(client, login):
         )
         assert updated.product_size_id == size_target.id
         assert updated.product_id == product_target.id
+
+
+def test_offers_without_inventory_are_listed_first(client, login):
+    with get_session() as session:
+        product_a = Product(name="Produkt A")
+        product_b = Product(name="Produkt B")
+        session.add_all([product_a, product_b])
+        session.flush()
+
+        size_a = ProductSize(product_id=product_a.id, size="S")
+        size_b = ProductSize(product_id=product_b.id, size="M")
+        session.add_all([size_a, size_b])
+        session.flush()
+
+        session.add_all(
+            [
+                AllegroOffer(
+                    offer_id="offer-unlinked",
+                    title="ZZZ Oferta bez przypisania",
+                    price=Decimal("10.00"),
+                ),
+                AllegroOffer(
+                    offer_id="offer-alpha",
+                    title="AAA Oferta powiązana",
+                    price=Decimal("20.00"),
+                    product_size_id=size_a.id,
+                    product_id=product_a.id,
+                ),
+                AllegroOffer(
+                    offer_id="offer-omega",
+                    title="OOO Oferta powiązana",
+                    price=Decimal("30.00"),
+                    product_size_id=size_b.id,
+                    product_id=product_b.id,
+                ),
+            ]
+        )
+
+    response = client.get("/allegro/offers")
+    body = response.data.decode("utf-8")
+
+    table_match = re.search(r"<tbody>(.*?)</tbody>", body, re.S)
+    assert table_match, "Expected offers table body in the response"
+    rows = re.findall(r"<tr>(.*?)</tr>", table_match.group(1), re.S)
+
+    titles = []
+    for row in rows:
+        columns = re.findall(r"<td>(.*?)</td>", row, re.S)
+        if len(columns) >= 2:
+            titles.append(re.sub(r"\s+", " ", columns[1]).strip())
+
+    assert titles[0] == "ZZZ Oferta bez przypisania"
+    assert titles[1:] == sorted(titles[1:])


### PR DESCRIPTION
## Summary
- ensure the Allegro offers view orders results so unlinked offers appear before alphabetically sorted linked items
- add a regression test covering the expected ordering of offers on the listing page

## Testing
- PYTHONPATH=. pytest magazyn/tests/test_allegro_offers.py

------
https://chatgpt.com/codex/tasks/task_e_68ced37443b0832a8e82fc1942723ee2