### PR TITLE
Normalize Allegro product aliases

### DIFF
--- a/magazyn/parsing.py
+++ b/magazyn/parsing.py
@@ -2,7 +2,12 @@ from __future__ import annotations
 
 import unicodedata
 
-from .constants import ALL_SIZES, KNOWN_COLORS, PRODUCT_ALIASES
+from .constants import (
+    ALL_SIZES,
+    KNOWN_COLORS,
+    normalize_product_title_fragment,
+    resolve_product_alias,
+)
 
 COLOR_ALIASES = {
     "czerwone": "czerwony",
@@ -84,8 +89,8 @@ def parse_product_info(item: dict) -> tuple[str, str, str]:
                     size = "Uniwersalny"
                     name = " ".join(words[:-1])
 
-    name = name.strip()
-    name = PRODUCT_ALIASES.get(name, name)
+    name = normalize_product_title_fragment(name.strip())
+    name = resolve_product_alias(name)
     color = normalize_color(color)
     return name, size, color
 
@@ -145,7 +150,8 @@ def parse_offer_title(title: str) -> tuple[str, str, str]:
                 remaining_words.pop(index)
 
     name = " ".join(remaining_words).strip()
-    name = PRODUCT_ALIASES.get(name, name)
+    name = normalize_product_title_fragment(name)
+    name = resolve_product_alias(name)
 
     if not size:
         size = "Uniwersalny"

--- a/magazyn/print_agent.py
+++ b/magazyn/print_agent.py
@@ -1,6 +1,6 @@
 from .notifications import send_report
 from .services import consume_order_stock, get_sales_summary
-from .constants import ALL_SIZES, KNOWN_COLORS, PRODUCT_ALIASES
+from .constants import ALL_SIZES, KNOWN_COLORS
 from .parsing import parse_product_info
 from magazyn import DB_PATH
 from .config import settings, load_config

--- a/magazyn/services.py
+++ b/magazyn/services.py
@@ -6,7 +6,7 @@ from decimal import Decimal, ROUND_HALF_UP
 from .db import get_session, record_purchase, consume_stock, record_sale
 from .models import Product, ProductSize, PurchaseBatch, Sale
 from sqlalchemy import func
-from .constants import ALL_SIZES, PRODUCT_ALIASES
+from .constants import ALL_SIZES, normalize_product_title_fragment, resolve_product_alias
 from .parsing import parse_product_info
 from datetime import datetime
 from .config import settings
@@ -474,8 +474,8 @@ def _parse_pdf(file) -> pd.DataFrame:
 def _import_invoice_df(df: pd.DataFrame):
     """Record purchases using rows from a DataFrame."""
     for _, row in df.iterrows():
-        name = row.get("Nazwa")
-        name = PRODUCT_ALIASES.get(name, name)
+        name = normalize_product_title_fragment(row.get("Nazwa", ""))
+        name = resolve_product_alias(name)
         color = row.get("Kolor", "")
         size = row.get("Rozmiar")
         quantity = _to_int(row.get("Ilość", 0))


### PR DESCRIPTION
## Summary
- extend the product alias map with normalized replacements for Front Line, Lumen, Blossom and related Truelove variants
- normalize offer titles before resolving aliases and reuse the same helper in invoice import code
- cover the new aliases with Allegro sync tests to confirm they match the correct products

## Testing
- PYTHONPATH=. pytest magazyn/tests/test_parsing.py magazyn/tests/test_allegro_refresh.py

------
https://chatgpt.com/codex/tasks/task_e_68cedec42e3c832aa8bc602d0e345051