### PR TITLE
Handle multi-part product color matching for Allegro sync

### DIFF
--- a/magazyn/parsing.py
+++ b/magazyn/parsing.py
@@ -42,6 +42,30 @@ def normalize_color(color: str) -> str:
             if len(normalized_alias) > len(base_match):
                 base_match = normalized_alias
                 base_color = canonical
+    if base_match:
+        return base_color.capitalize()
+
+    normalized_known_colors = {
+        _strip_diacritics(known): known for known in KNOWN_COLORS
+    }
+
+    def _match_known(normalized: str) -> str | None:
+        if not normalized:
+            return None
+        return normalized_known_colors.get(normalized)
+
+    matched_color = _match_known(normalized_color)
+    if matched_color:
+        base_color = matched_color
+    else:
+        for suffix, replacement in (("o", "y"), ("a", "y"), ("e", "y")):
+            if normalized_color.endswith(suffix) and len(normalized_color) > 1:
+                candidate = normalized_color[:-1] + replacement
+                matched_color = _match_known(candidate)
+                if matched_color:
+                    base_color = matched_color
+                    break
+
     return base_color.capitalize()
 
 


### PR DESCRIPTION
## Summary
- normalize product colors by splitting multi-part values and reusing the color normalizer used for offers
- extend normalize_color with heuristics so adjective endings map to the canonical base color
- cover the new colour matching logic with a sync_offers test for multi-colour products

## Testing
- PYTHONPATH=. pytest magazyn/tests/test_allegro_refresh.py

------
https://chatgpt.com/codex/tasks/task_e_68cee1cfd2a4832ab9a0b3b07572947e