### PR TITLE
Add Allegro price check view and tests

### DIFF
--- a/magazyn/templates/allegro/price_check.html
+++ b/magazyn/templates/allegro/price_check.html
@@ -1,0 +1,55 @@
+{% extends "base.html" %}
+
+{% block content %}
+<h1 class="mb-4">Monitor cen Allegro</h1>
+<div class="table-responsive">
+    <table class="table table-striped align-middle">
+        <thead class="table-dark">
+            <tr>
+                <th scope="col">Oferta</th>
+                <th scope="col">Produkt</th>
+                <th scope="col">Nasza cena</th>
+                <th scope="col">Najniższa cena konkurencji</th>
+                <th scope="col" class="text-center">Najtańsza?</th>
+            </tr>
+        </thead>
+        <tbody>
+        {% for item in price_checks %}
+            <tr>
+                <td>{{ item.title }}</td>
+                <td>{{ item.label }}</td>
+                <td>
+                    {% if item.own_price %}
+                        {{ item.own_price }} zł
+                    {% else %}
+                        <span class="text-muted">–</span>
+                    {% endif %}
+                </td>
+                <td>
+                    {% if item.error %}
+                        <span class="text-muted">{{ item.error }}</span>
+                    {% elif item.competitor_price %}
+                        {{ item.competitor_price }} zł
+                    {% else %}
+                        <span class="text-muted">Brak danych</span>
+                    {% endif %}
+                </td>
+                <td class="text-center">
+                    {% if item.is_lowest is none %}
+                        <span class="text-muted">–</span>
+                    {% elif item.is_lowest %}
+                        <span class="text-success" title="Nasza oferta jest najtańsza">✓</span>
+                    {% else %}
+                        <span class="text-danger" title="Konkurencja ma niższą cenę">✗</span>
+                    {% endif %}
+                </td>
+            </tr>
+        {% else %}
+            <tr>
+                <td colspan="5" class="text-center text-muted">Brak powiązanych ofert Allegro.</td>
+            </tr>
+        {% endfor %}
+        </tbody>
+    </table>
+</div>
+{% endblock %}

--- a/magazyn/templates/base.html
+++ b/magazyn/templates/base.html
@@ -43,6 +43,7 @@
                     <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('sales.list_sales') }}">Sprzedaż</a></li>
                     <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('history.print_history') }}">Historia drukowania</a></li>
                     <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('allegro.offers') }}">Oferty Allegro</a></li>
+                    <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('allegro.price_check') }}">Monitor cen Allegro</a></li>
                     {#
                     <li class="nav-item dropdown">
                         <a class="nav-link dropdown-toggle text-white" href="#" id="navbarAllegro" role="button" data-bs-toggle="dropdown" aria-expanded="false">
@@ -85,6 +86,7 @@
             <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('sales.list_sales') }}">Sprzedaż</a></li>
             <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('history.print_history') }}">Historia drukowania</a></li>
             <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('allegro.offers') }}">Oferty Allegro</a></li>
+            <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('allegro.price_check') }}">Monitor cen Allegro</a></li>
             {#
             <li class="nav-item dropdown">
                 <a class="nav-link dropdown-toggle text-white" href="#" id="mobileAllegro" role="button" data-bs-toggle="dropdown" aria-expanded="false">


### PR DESCRIPTION
## Summary
- add a price check view for Allegro offers that fetches competitor listings and flags the lowest price
- introduce a dedicated template and navigation links for the new price monitor page
- cover the view with an integration test that validates table rendering and lowest price calculation

## Testing
- PYTHONPATH=. pytest magazyn/tests/test_allegro_offers.py

------
https://chatgpt.com/codex/tasks/task_e_68cf0d8f54cc832ab2736c2ffd1b621b