### PR TITLE
Split Allegro offers into linked and unlinked sections

### DIFF
--- a/magazyn/allegro.py
+++ b/magazyn/allegro.py
@@ -35,7 +35,8 @@ def offers():
             )
             .all()
         )
-        offers = []
+        linked_offers: list[dict] = []
+        unlinked_offers: list[dict] = []
         for offer, size, product in rows:
             label = None
             if product and size:
@@ -43,16 +44,18 @@ def offers():
                 if product.color:
                     parts.append(product.color)
                 label = " – ".join([" ".join(parts), size.size])
-            offers.append(
-                {
-                    "offer_id": offer.offer_id,
-                    "title": offer.title,
-                    "price": offer.price,
-                    "product_size_id": offer.product_size_id,
-                    "selected_label": label,
-                    "barcode": size.barcode if size else None,
-                }
-            )
+            offer_data = {
+                "offer_id": offer.offer_id,
+                "title": offer.title,
+                "price": offer.price,
+                "product_size_id": offer.product_size_id,
+                "selected_label": label,
+                "barcode": size.barcode if size else None,
+            }
+            if offer.product_size_id:
+                linked_offers.append(offer_data)
+            else:
+                unlinked_offers.append(offer_data)
 
         inventory_rows = (
             db.query(ProductSize, Product)
@@ -87,7 +90,12 @@ def offers():
                     "filter": filter_text,
                 }
             )
-    return render_template("allegro/offers.html", offers=offers, inventory=inventory)
+    return render_template(
+        "allegro/offers.html",
+        unlinked_offers=unlinked_offers,
+        linked_offers=linked_offers,
+        inventory=inventory,
+    )
 
 
 def _format_decimal(value: Decimal | None) -> str | None:

--- a/magazyn/templates/allegro/offers.html
+++ b/magazyn/templates/allegro/offers.html
@@ -5,6 +5,7 @@
     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
     <button type="submit" class="btn btn-primary">Odśwież</button>
     </form>
+{% macro render_offers_table(offers) -%}
 <div class="table-responsive">
     <table class="table table-striped align-middle">
         <thead>
@@ -49,10 +50,31 @@
                     </form>
                 </td>
             </tr>
+        {% else %}
+            <tr>
+                <td colspan="4" class="text-center text-muted">Brak ofert w tej sekcji.</td>
+            </tr>
         {% endfor %}
         </tbody>
     </table>
 </div>
+{%- endmacro %}
+
+<section id="unlinked-offers" class="mb-5">
+    <div class="d-flex align-items-center gap-2 mb-3">
+        <h2 class="h4 mb-0">Oferty wymagające przypięcia</h2>
+        <span class="badge bg-secondary" data-offers-count>{{ unlinked_offers|length }}</span>
+    </div>
+    {{ render_offers_table(unlinked_offers) }}
+</section>
+
+<section id="linked-offers">
+    <div class="d-flex align-items-center gap-2 mb-3">
+        <h2 class="h4 mb-0">Oferty powiązane z magazynem</h2>
+        <span class="badge bg-secondary" data-offers-count>{{ linked_offers|length }}</span>
+    </div>
+    {{ render_offers_table(linked_offers) }}
+</section>
 
 <script>
 document.addEventListener('DOMContentLoaded', () => {


### PR DESCRIPTION
## Summary
- split Allegro offers into separate unlinked and linked collections and pass them to the template
- render two offer tables with counters for pending and linked offers
- update tests to cover the new sections and ensure manual linking moves an offer to the linked table

## Testing
- PYTHONPATH=. pytest magazyn/tests/test_allegro_offers.py

------
https://chatgpt.com/codex/tasks/task_e_68cf0efe9ef8832ab1a45d5027c5c990