### PR TITLE
Handle model keywords in offer parsing

### DIFF
--- a/magazyn/tests/test_parsing.py
+++ b/magazyn/tests/test_parsing.py
@@ -33,3 +33,36 @@ def test_parse_offer_title_detects_pink_variants(title, expected_size):
 )
 def test_normalize_color_returns_canonical_form(value):
     assert normalize_color(value) == "Różowy"
+
+
+@pytest.mark.parametrize(
+    "title, expected_name, expected_color, expected_size",
+    [
+        (
+            "Mega okazja! Truelove Lumen dla aktywnych psów czerwone M",
+            "Szelki dla psa Truelove Lumen",
+            "Czerwony",
+            "M",
+        ),
+        (
+            "Wyprzedaż FRONT LINE PREMIUM Tropical turkusowy komplet",
+            "Szelki dla psa Truelove Tropical",
+            "Turkusowy",
+            "Uniwersalny",
+        ),
+        (
+            "Nowe Adventure Dog szelki blossom różowe L",
+            "Szelki dla psa Truelove Adventure Dog",
+            "Różowy",
+            "L",
+        ),
+    ],
+)
+def test_parse_offer_title_prefers_known_model_keywords(
+    title, expected_name, expected_color, expected_size
+):
+    name, color, size = parse_offer_title(title)
+
+    assert name == expected_name
+    assert color == expected_color
+    assert size == expected_size


### PR DESCRIPTION
## Summary
- detect well-known model keywords in offer titles and resolve them to canonical product names
- prioritise keyword matches over remaining title content so extra wording does not affect matching
- extend parsing and Allegro sync tests to cover noisy titles while still matching products by model, colour and size

## Testing
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_e_68cf141eb3ec832a9ee7a14a89c7d524