### PR TITLE
Fix typing compatibility for price check helpers

### DIFF
--- a/magazyn/allegro.py
+++ b/magazyn/allegro.py
@@ -1,4 +1,5 @@
 from decimal import Decimal, InvalidOperation
+from typing import Optional
 
 from flask import (
     Blueprint,
@@ -98,7 +99,7 @@ def offers():
     )
 
 
-def _format_decimal(value: Decimal | None) -> str | None:
+def _format_decimal(value: Optional[Decimal]) -> Optional[str]:
     if value is None:
         return None
     return f"{value:.2f}"
@@ -134,7 +135,7 @@ def price_check():
     price_checks = []
     for offer in offers:
         competitor_prices: list[Decimal] = []
-        error: str | None = None
+        error: Optional[str] = None
         barcode = offer["barcode"]
         if barcode:
             try:


### PR DESCRIPTION
## Summary
- import `Optional` and switch helper annotations to typing-compatible syntax
- avoid Python 3.10-only union syntax in allegro price checking helpers

## Testing
- `PYTHONPATH=. pytest magazyn/tests -q` *(fails: baseline test_sync_offers_matches_alias_variants already fails, matched 3 vs 4)*

------
https://chatgpt.com/codex/tasks/task_e_68cecf78bda0832a9642ea405a295cf1