### PR TITLE
Clear product association when unlinking offers

### DIFF
--- a/magazyn/allegro.py
+++ b/magazyn/allegro.py
@@ -319,6 +319,7 @@ def link_offer(offer_id):
                     flash("Nie znaleziono produktu o podanym ID")
             else:
                 offer.product_size_id = None
+                offer.product_id = None
                 flash("Usunięto powiązanie z magazynem")
             return redirect(url_for("allegro.offers"))
 


### PR DESCRIPTION
## Summary
- ensure unlinking an Allegro offer clears both product and size associations to fully detach it

## Testing
- PYTHONPATH=. pytest magazyn/tests/test_allegro_offers.py

------
https://chatgpt.com/codex/tasks/task_e_68cf34dbb544832a8280bb327f77010b