### PR TITLE
Persist Allegro tokens to env file

### DIFF
--- a/magazyn/allegro_api.py
+++ b/magazyn/allegro_api.py
@@ -4,6 +4,8 @@ from typing import Optional
 import requests
 from requests.exceptions import HTTPError
 
+from .env_tokens import update_allegro_tokens
+
 AUTH_URL = "https://allegro.pl/auth/oauth/token"
 API_BASE_URL = "https://api.allegro.pl"
 DEFAULT_TIMEOUT = 10
@@ -146,11 +148,10 @@ def fetch_product_listing(ean: str, page: int = 1) -> list:
                     if not new_token:
                         raise RuntimeError(friendly_message)
                     token = new_token
-                    os.environ["ALLEGRO_ACCESS_TOKEN"] = new_token
                     new_refresh = token_data.get("refresh_token")
                     if new_refresh:
                         refresh = new_refresh
-                        os.environ["ALLEGRO_REFRESH_TOKEN"] = new_refresh
+                    update_allegro_tokens(token, refresh)
                     continue
                 raise RuntimeError(friendly_message) from exc
             raise

--- a/magazyn/env_tokens.py
+++ b/magazyn/env_tokens.py
@@ -1,0 +1,42 @@
+"""Utilities for keeping Allegro OAuth tokens in sync."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import MutableMapping
+from typing import Optional
+
+
+def update_allegro_tokens(
+    access_token: Optional[str] = None, refresh_token: Optional[str] = None
+) -> None:
+    """Persist new Allegro OAuth tokens and update ``os.environ``.
+
+    Parameters
+    ----------
+    access_token:
+        The freshly obtained access token. If ``None`` the persisted value is not
+        modified.
+    refresh_token:
+        The accompanying refresh token. If ``None`` the previous value is kept.
+    """
+
+    if access_token is None and refresh_token is None:
+        return
+
+    if access_token is not None:
+        os.environ["ALLEGRO_ACCESS_TOKEN"] = access_token
+    if refresh_token is not None:
+        os.environ["ALLEGRO_REFRESH_TOKEN"] = refresh_token
+
+    # Import lazily to avoid circular imports with ``magazyn.app``.
+    from .app import load_settings, write_env  # pylint: disable=import-outside-toplevel
+
+    values: MutableMapping[str, str] = load_settings()
+    if access_token is not None:
+        values["ALLEGRO_ACCESS_TOKEN"] = access_token
+    if refresh_token is not None:
+        values["ALLEGRO_REFRESH_TOKEN"] = refresh_token
+
+    write_env(values)
+


### PR DESCRIPTION
## Summary
- add a helper that syncs Allegro OAuth tokens to os.environ and the .env file
- invoke the helper after token refreshes in the Allegro API client and sync logic
- extend Allegro token refresh tests to assert that persisted values are updated

## Testing
- PYTHONPATH=/workspace/retrievershop-suite pytest magazyn/tests/test_allegro_offers.py::test_fetch_product_listing_refreshes_token_on_unauthorized magazyn/tests/test_allegro_refresh.py::test_refresh_on_unauthorized_fetch

------
https://chatgpt.com/codex/tasks/task_e_68cf3b63b0ec832abc555d950c283783