### PR TITLE
Clear Allegro tokens from env file when refresh fails

### DIFF
--- a/magazyn/allegro_api.py
+++ b/magazyn/allegro_api.py
@@ -4,7 +4,7 @@ from typing import Optional
 import requests
 from requests.exceptions import HTTPError
 
-from .env_tokens import update_allegro_tokens
+from .env_tokens import clear_allegro_tokens, update_allegro_tokens
 
 AUTH_URL = "https://allegro.pl/auth/oauth/token"
 API_BASE_URL = "https://api.allegro.pl"
@@ -143,9 +143,11 @@ def fetch_product_listing(ean: str, page: int = 1) -> list:
                     try:
                         token_data = refresh_token(refresh)
                     except Exception as refresh_exc:
+                        clear_allegro_tokens()
                         raise RuntimeError(friendly_message) from refresh_exc
                     new_token = token_data.get("access_token")
                     if not new_token:
+                        clear_allegro_tokens()
                         raise RuntimeError(friendly_message)
                     token = new_token
                     new_refresh = token_data.get("refresh_token")

--- a/magazyn/allegro_sync.py
+++ b/magazyn/allegro_sync.py
@@ -14,7 +14,7 @@ from . import allegro_api
 from .models import AllegroOffer, Product, ProductSize
 from .db import get_session
 from .parsing import parse_offer_title, normalize_color
-from .env_tokens import update_allegro_tokens
+from .env_tokens import clear_allegro_tokens, update_allegro_tokens
 
 logger = logging.getLogger(__name__)
 
@@ -42,8 +42,7 @@ def _normalized_product_color_components(value: str) -> set[str]:
 
 
 def _clear_cached_tokens():
-    os.environ.pop("ALLEGRO_ACCESS_TOKEN", None)
-    os.environ.pop("ALLEGRO_REFRESH_TOKEN", None)
+    clear_allegro_tokens()
 
 
 def sync_offers():

--- a/magazyn/env_tokens.py
+++ b/magazyn/env_tokens.py
@@ -40,3 +40,20 @@ def update_allegro_tokens(
 
     write_env(values)
 
+
+def clear_allegro_tokens() -> None:
+    """Remove Allegro OAuth tokens from the environment and persisted settings."""
+
+    os.environ.pop("ALLEGRO_ACCESS_TOKEN", None)
+    os.environ.pop("ALLEGRO_REFRESH_TOKEN", None)
+
+    # Import lazily to avoid circular imports with ``magazyn.app``.
+    from .app import load_settings, write_env  # pylint: disable=import-outside-toplevel
+
+    values: MutableMapping[str, str] = load_settings()
+
+    values.pop("ALLEGRO_ACCESS_TOKEN", None)
+    values.pop("ALLEGRO_REFRESH_TOKEN", None)
+
+    write_env(values)
+


### PR DESCRIPTION
## Summary
- add a helper that clears Allegro OAuth tokens from os.environ and the persisted .env settings
- ensure Allegro sync and product listing refresh paths invoke the helper when refresh attempts fail or return no access token
- extend refresh and listing tests to verify that the clear helper is called when refreshes fail

## Testing
- `PYTHONPATH=. pytest magazyn/tests/test_allegro_refresh.py magazyn/tests/test_allegro_offers.py` *(fails: `test_sync_offers_matches_alias_variants` also fails on main branch in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cf40e96488832a954398a621466c47