### PR TITLE
Add link icon for Allegro price monitor offers

### DIFF
--- a/magazyn/templates/allegro/price_check.html
+++ b/magazyn/templates/allegro/price_check.html
@@ -16,7 +16,23 @@
         <tbody>
         {% for item in price_checks %}
             <tr>
-                <td>{{ item.title }}</td>
+                <td>
+                    {% if item.offer_id %}
+                        <a
+                            href="https://allegro.pl/oferta/{{ item.offer_id }}"
+                            class="link-dark"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            title="{{ item.title }}"
+                            aria-label="{{ item.title }}"
+                        >
+                            <i class="bi bi-link-45deg" aria-hidden="true"></i>
+                            <span class="visually-hidden">{{ item.title }}</span>
+                        </a>
+                    {% else %}
+                        {{ item.title }}
+                    {% endif %}
+                </td>
                 <td>{{ item.label }}</td>
                 <td>
                     {% if item.own_price %}

--- a/magazyn/tests/test_allegro_offers.py
+++ b/magazyn/tests/test_allegro_offers.py
@@ -297,15 +297,27 @@ def test_price_check_table_and_lowest_flag(client, login, monkeypatch):
 
     rows = re.findall(r"<tr>.*?</tr>", body, re.S)
     data_rows = [row for row in rows if "Oferta" in row and "th" not in row]
-    row_low = next(row for row in data_rows if "Oferta najtańsza" in row)
-    row_high = next(row for row in data_rows if "Oferta droższa" in row)
 
+    def row_by_offer(offer_id: str) -> str:
+        return next(
+            row
+            for row in data_rows
+            if f"href=\"https://allegro.pl/oferta/{offer_id}\"" in row
+        )
+
+    row_low = row_by_offer("offer-low")
+    row_high = row_by_offer("offer-high")
+
+    assert "bi-link-45deg" in row_low
+    assert 'visually-hidden">Oferta najtańsza</span>' in row_low
     assert "90.00 zł" in row_low
     assert "95.00 zł" in row_low
     assert "href=\"https://allegro.pl/oferta/competitor-a-offer\"" in row_low
     assert "aria-label=\"Zobacz ofertę konkurencji\"" in row_low
     assert "text-success" in row_low and "✓" in row_low
 
+    assert "bi-link-45deg" in row_high
+    assert 'visually-hidden">Oferta droższa</span>' in row_high
     assert "120.00 zł" in row_high
     assert "80.00 zł" in row_high
     assert "href=\"https://allegro.pl/oferta/competitor-c-offer\"" in row_high
@@ -371,12 +383,15 @@ def test_price_check_product_level_aggregates_barcodes(client, login, monkeypatc
     assert response.status_code == 200
 
     body = response.data.decode("utf-8")
+    rows = re.findall(r"<tr>.*?</tr>", body, re.S)
     row = next(
         row
-        for row in re.findall(r"<tr>.*?</tr>", body, re.S)
-        if "Oferta produktowa" in row
+        for row in rows
+        if "href=\"https://allegro.pl/oferta/offer-product\"" in row
     )
 
+    assert "bi-link-45deg" in row
+    assert 'visually-hidden">Oferta produktowa</span>' in row
     assert "Legowisko Szare" in row
     assert "85.00 zł" in row
     assert "href=\"https://allegro.pl/oferta/competitor-2-offer\"" in row


### PR DESCRIPTION
## Summary
- wrap price monitor offer cells with an icon link to the Allegro offer including accessibility text
- update price check tests to assert the new markup while continuing to validate price data

## Testing
- PYTHONPATH=. pytest magazyn/tests/test_allegro_offers.py -k price_check

------
https://chatgpt.com/codex/tasks/task_e_68cf43262f34832a8571020434743f5d