### PR TITLE
Load Allegro price checks via JSON endpoint

### DIFF
--- a/magazyn/static/price_check.js
+++ b/magazyn/static/price_check.js
@@ -1,0 +1,153 @@
+(function () {
+    function createLink(url, label, visuallyHiddenText, extraClasses) {
+        if (!url) {
+            return label || '';
+        }
+        const link = document.createElement('a');
+        link.href = url;
+        link.target = '_blank';
+        link.rel = 'noopener noreferrer';
+        link.className = extraClasses || 'link-dark';
+        if (label) {
+            link.textContent = label;
+        } else {
+            const icon = document.createElement('i');
+            icon.className = 'bi bi-link-45deg';
+            icon.setAttribute('aria-hidden', 'true');
+            link.appendChild(icon);
+            if (visuallyHiddenText) {
+                const span = document.createElement('span');
+                span.className = 'visually-hidden';
+                span.textContent = visuallyHiddenText;
+                link.appendChild(span);
+            }
+        }
+        return link;
+    }
+
+    function renderPriceChecks(data) {
+        const loading = document.getElementById('price-check-loading');
+        const tableContainer = document.getElementById('price-check-table-container');
+        const tableBody = document.getElementById('price-check-table-body');
+        const errorContainer = document.getElementById('price-check-error');
+
+        if (!loading || !tableContainer || !tableBody || !errorContainer) {
+            return;
+        }
+
+        loading.classList.add('d-none');
+
+        if (data.auth_error) {
+            errorContainer.className = 'alert alert-warning';
+            errorContainer.textContent = data.auth_error;
+            return;
+        }
+
+        tableContainer.classList.remove('d-none');
+        tableBody.innerHTML = '';
+
+        const priceChecks = Array.isArray(data.price_checks) ? data.price_checks : [];
+        if (priceChecks.length === 0) {
+            const row = document.createElement('tr');
+            const cell = document.createElement('td');
+            cell.colSpan = 5;
+            cell.className = 'text-center text-muted';
+            cell.textContent = 'Brak powiązanych ofert Allegro.';
+            row.appendChild(cell);
+            tableBody.appendChild(row);
+            return;
+        }
+
+        priceChecks.forEach((item) => {
+            const row = document.createElement('tr');
+
+            const offerCell = document.createElement('td');
+            if (item.offer_id) {
+                const offerLink = createLink(
+                    'https://allegro.pl/oferta/' + item.offer_id,
+                    '',
+                    item.title || 'Oferta Allegro'
+                );
+                offerCell.appendChild(offerLink);
+            } else {
+                offerCell.textContent = item.title || '';
+            }
+            row.appendChild(offerCell);
+
+            const labelCell = document.createElement('td');
+            labelCell.textContent = item.label || '';
+            row.appendChild(labelCell);
+
+            const ownPriceCell = document.createElement('td');
+            ownPriceCell.textContent = item.own_price ? item.own_price + ' zł' : '–';
+            if (!item.own_price) {
+                ownPriceCell.classList.add('text-muted');
+            }
+            row.appendChild(ownPriceCell);
+
+            const competitorCell = document.createElement('td');
+            if (item.error) {
+                const badge = document.createElement('span');
+                badge.className = 'badge bg-secondary';
+                badge.textContent = item.error;
+                competitorCell.appendChild(badge);
+            } else if (item.competitor_price) {
+                const wrapper = document.createElement('div');
+                wrapper.className = 'd-flex align-items-center gap-2';
+                const priceSpan = document.createElement('span');
+                priceSpan.textContent = item.competitor_price + ' zł';
+                wrapper.appendChild(priceSpan);
+                if (item.competitor_offer_url) {
+                    const competitorLink = createLink(
+                        item.competitor_offer_url,
+                        null,
+                        'Zobacz ofertę konkurencji',
+                        'btn btn-outline-secondary btn-sm'
+                    );
+                    const icon = competitorLink.querySelector('i');
+                    if (!icon) {
+                        const iconEl = document.createElement('i');
+                        iconEl.className = 'bi bi-diagram-3';
+                        competitorLink.prepend(iconEl);
+                    } else {
+                        icon.className = 'bi bi-diagram-3';
+                    }
+                    wrapper.appendChild(competitorLink);
+                }
+                competitorCell.appendChild(wrapper);
+            } else {
+                competitorCell.className = 'text-muted';
+                competitorCell.textContent = 'Brak danych';
+            }
+            row.appendChild(competitorCell);
+
+            const lowestCell = document.createElement('td');
+            lowestCell.className = 'text-center';
+            if (item.is_lowest === null || item.is_lowest === undefined) {
+                lowestCell.innerHTML = '<span class="text-muted">–</span>';
+            } else if (item.is_lowest) {
+                lowestCell.innerHTML = '<span class="text-success" title="Nasza oferta jest najtańsza">✓</span>';
+            } else {
+                lowestCell.innerHTML = '<span class="text-danger" title="Konkurencja ma niższą cenę">✗</span>';
+            }
+            row.appendChild(lowestCell);
+
+            tableBody.appendChild(row);
+        });
+    }
+
+    function fetchPriceChecks() {
+        const url = window.location.pathname + '?format=json';
+        fetch(url, { headers: { Accept: 'application/json' } })
+            .then((response) => response.json())
+            .then(renderPriceChecks)
+            .catch(() => {
+                renderPriceChecks({
+                    price_checks: [],
+                    auth_error: 'Nie udało się pobrać danych cenowych. Odśwież stronę i spróbuj ponownie.',
+                });
+            });
+    }
+
+    document.addEventListener('DOMContentLoaded', fetchPriceChecks);
+})();

--- a/magazyn/templates/allegro/price_check.html
+++ b/magazyn/templates/allegro/price_check.html
@@ -7,8 +7,13 @@
     {{ auth_error }}
 </div>
 {% else %}
-<div class="table-responsive">
-    <table class="table table-striped align-middle">
+<div id="price-check-loading" class="d-flex align-items-center gap-3">
+    <div class="spinner-border" role="status" aria-hidden="true"></div>
+    <span>Pobieramy aktualne ceny konkurencji…</span>
+</div>
+<div id="price-check-error" class="d-none"></div>
+<div id="price-check-table-container" class="table-responsive d-none">
+    <table class="table table-striped align-middle" aria-live="polite">
         <thead class="table-dark">
             <tr>
                 <th scope="col">Oferta</th>
@@ -18,73 +23,9 @@
                 <th scope="col" class="text-center">Najtańsza?</th>
             </tr>
         </thead>
-        <tbody>
-        {% for item in price_checks %}
-            <tr>
-                <td>
-                    {% if item.offer_id %}
-                        <a
-                            href="https://allegro.pl/oferta/{{ item.offer_id }}"
-                            class="link-dark"
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            title="{{ item.title }}"
-                            aria-label="{{ item.title }}"
-                        >
-                            <i class="bi bi-link-45deg" aria-hidden="true"></i>
-                            <span class="visually-hidden">{{ item.title }}</span>
-                        </a>
-                    {% else %}
-                        {{ item.title }}
-                    {% endif %}
-                </td>
-                <td>{{ item.label }}</td>
-                <td>
-                    {% if item.own_price %}
-                        {{ item.own_price }} zł
-                    {% else %}
-                        <span class="text-muted">–</span>
-                    {% endif %}
-                </td>
-                <td>
-                    {% if item.error %}
-                        <span class="text-muted">{{ item.error }}</span>
-                    {% elif item.competitor_price %}
-                        <div class="d-flex align-items-center gap-2">
-                            <span>{{ item.competitor_price }} zł</span>
-                            {% if item.competitor_offer_url %}
-                                <a
-                                    class="btn btn-outline-secondary btn-sm"
-                                    href="{{ item.competitor_offer_url }}"
-                                    target="_blank"
-                                    rel="noopener noreferrer"
-                                    aria-label="Zobacz ofertę konkurencji"
-                                >
-                                    <i class="bi bi-diagram-3"></i>
-                                </a>
-                            {% endif %}
-                        </div>
-                    {% else %}
-                        <span class="text-muted">Brak danych</span>
-                    {% endif %}
-                </td>
-                <td class="text-center">
-                    {% if item.is_lowest is none %}
-                        <span class="text-muted">–</span>
-                    {% elif item.is_lowest %}
-                        <span class="text-success" title="Nasza oferta jest najtańsza">✓</span>
-                    {% else %}
-                        <span class="text-danger" title="Konkurencja ma niższą cenę">✗</span>
-                    {% endif %}
-                </td>
-            </tr>
-        {% else %}
-            <tr>
-                <td colspan="5" class="text-center text-muted">Brak powiązanych ofert Allegro.</td>
-            </tr>
-        {% endfor %}
-        </tbody>
+        <tbody id="price-check-table-body"></tbody>
     </table>
 </div>
+<script src="{{ url_for('static', filename='price_check.js') }}" defer></script>
 {% endif %}
 {% endblock %}


### PR DESCRIPTION
## Summary
- extract the Allegro price comparison logic into a reusable `build_price_checks` helper
- add JSON responses for `/allegro/price-check` requests and lazy-load data on the HTML page
- render a loading spinner and populate the table via new client-side script
- refresh the price check tests to validate the JSON API and new HTML placeholders

## Testing
- PYTHONPATH=. pytest magazyn/tests/test_allegro_offers.py

------
https://chatgpt.com/codex/tasks/task_e_68cfd03f32d0832aaa718b12c40d0f45