### PR TITLE
Fix sales summary session handling

### DIFF
--- a/magazyn/tests/test_reports.py
+++ b/magazyn/tests/test_reports.py
@@ -21,9 +21,18 @@ def test_sales_summary(app_mod, monkeypatch):
     monkeypatch.setattr(cfg.settings, "LOW_STOCK_THRESHOLD", 1)
     services = importlib.import_module("magazyn.services")
     importlib.reload(services)
-    prod = services.create_product("Prod", "Red", {"M": 0}, {"M": "111"})
+    prod = services.create_product(
+        "Prod", "Red", {"M": 0, "L": 0}, {"M": "111", "L": "222"}
+    )
     app_mod.record_purchase(prod.id, "M", 5, 1.0)
+    app_mod.record_purchase(prod.id, "L", 4, 1.0)
     app_mod.consume_stock(prod.id, "M", 2, sale_price=0)
+    app_mod.consume_stock(prod.id, "L", 1, sale_price=0)
+
     summary = services.get_sales_summary(7)
-    assert summary[0]["sold"] == 2
-    assert summary[0]["remaining"] == 3
+    summary_map = {(row["name"], row["size"]): row for row in summary}
+
+    assert summary_map[("Prod", "M")]["sold"] == 2
+    assert summary_map[("Prod", "M")]["remaining"] == 3
+    assert summary_map[("Prod", "L")]["sold"] == 1
+    assert summary_map[("Prod", "L")]["remaining"] == 3


### PR DESCRIPTION
## Summary
- build the sales summary stock lookup using product and size identifiers inside the session context
- materialize sales aggregates together with product metadata before leaving the database session
- extend the sales summary test to cover multiple sizes and validate sold and remaining quantities

## Testing
- `PYTHONPATH=. pytest magazyn/tests/test_reports.py magazyn/tests/test_weekly_reports.py`


------
https://chatgpt.com/codex/tasks/task_e_68cfd6464ae8832a98740506d00fc532