### PR TITLE
Update Flask dependency and adjust alias matching

### DIFF
--- a/magazyn/parsing.py
+++ b/magazyn/parsing.py
@@ -35,7 +35,7 @@ PRODUCT_KEYWORDS: list[tuple[str, str, int]] = [
     ("tropical", "Szelki dla psa Truelove Tropical", 2),
     ("adventure dog", "Szelki dla psa Truelove Adventure Dog", 2),
     ("lumen", "Szelki dla psa Truelove Lumen", 1),
-    ("blossom", "Szelki dla psa Truelove Blossom", 1),
+    ("blossom", "Szelki dla psa Truelove Blossom", 2),
     ("front line premium", "Szelki dla psa Truelove Front Line Premium", 1),
     ("front line", "Szelki dla psa Truelove Front Line", 0),
 ]

--- a/magazyn/requirements.txt
+++ b/magazyn/requirements.txt
@@ -1,4 +1,4 @@
-flask==2.2.5
+flask==3.0.3
 werkzeug==3.1.3
 pandas==2.3.0
 openpyxl==3.1.5


### PR DESCRIPTION
## Summary
- bump Flask to 3.0.3 so it is compatible with Werkzeug 3.1 in the warehouse service
- tweak product keyword priorities so Blossom variants resolve to the correct canonical product during Allegro offer sync

## Testing
- `pip install -r magazyn/requirements.txt`
- `PYTHONPATH=. pytest magazyn/tests`


------
https://chatgpt.com/codex/tasks/task_e_68cfd6cafe80832a9e85d9fcd051fcc6