### PR TITLE
Refactor Flask app initialization into factory

### DIFF
--- a/magazyn/factory.py
+++ b/magazyn/factory.py
@@ -1,0 +1,70 @@
+"""Application factory for the magazyn package."""
+
+from __future__ import annotations
+
+import atexit
+from typing import Optional, Mapping, Any
+
+from flask import Flask
+from flask_wtf import CSRFProtect
+
+from .config import settings
+from .constants import ALL_SIZES
+from .products import bp as products_bp
+from .history import bp as history_bp
+from .sales import bp as sales_bp
+from .shipping import bp as shipping_bp
+from .allegro import bp as allegro_bp
+from . import print_agent
+from .app import bp as main_bp, start_print_agent, ensure_db_initialized
+
+_shutdown_registered = False
+
+
+def _register_shutdown_hook() -> None:
+    global _shutdown_registered
+    if _shutdown_registered:
+        return
+    atexit.register(print_agent.stop_agent_thread)
+    _shutdown_registered = True
+
+
+def create_app(config: Optional[Mapping[str, Any]] = None) -> Flask:
+    """Create and configure a :class:`Flask` application instance."""
+
+    app = Flask(__name__)
+    app.secret_key = settings.SECRET_KEY
+
+    if config:
+        app.config.update(config)
+
+    CSRFProtect(app)
+    app.jinja_env.globals["ALL_SIZES"] = ALL_SIZES
+
+    app.register_blueprint(main_bp)
+    app.register_blueprint(products_bp)
+    app.register_blueprint(history_bp)
+    app.register_blueprint(sales_bp)
+    app.register_blueprint(shipping_bp)
+    app.register_blueprint(allegro_bp)
+
+    for rule in list(app.url_map.iter_rules()):
+        if rule.endpoint.startswith("main."):
+            simple_endpoint = rule.endpoint.split(".", 1)[1]
+            app.view_functions[simple_endpoint] = app.view_functions[rule.endpoint]
+            app.url_map._rules_by_endpoint.setdefault(simple_endpoint, []).append(
+                rule
+            )
+
+    app.before_first_request(lambda: ensure_db_initialized(app))
+    app.before_first_request(lambda: start_print_agent(app))
+
+    _register_shutdown_hook()
+
+    @app.cli.command("init-db")
+    def init_db_command() -> None:
+        """Initialize the application database."""
+        with app.app_context():
+            ensure_db_initialized(app)
+
+    return app

--- a/magazyn/tests/conftest.py
+++ b/magazyn/tests/conftest.py
@@ -7,7 +7,8 @@ import magazyn.config as cfg
 
 @pytest.fixture
 def app_mod(tmp_path, monkeypatch):
-    monkeypatch.setattr(cfg.settings, "DB_PATH", ":memory:")
+    db_path = tmp_path / "test.db"
+    monkeypatch.setattr(cfg.settings, "DB_PATH", str(db_path))
     monkeypatch.setattr(cfg.settings, "COMMISSION_ALLEGRO", 10.0)
     import magazyn.sales as sales_mod
 
@@ -26,15 +27,20 @@ def app_mod(tmp_path, monkeypatch):
     import magazyn.app as app_mod
 
     importlib.reload(app_mod)
+    from magazyn.factory import create_app
     import magazyn.db as db_mod
 
+    importlib.reload(db_mod)
+    monkeypatch.setattr(db_mod, "apply_migrations", lambda: None)
     db_mod.configure_engine(cfg.settings.DB_PATH)
     from sqlalchemy.orm import sessionmaker
 
     db_mod.SessionLocal = sessionmaker(
         bind=db_mod.engine, autoflush=False, expire_on_commit=False
     )
-    app_mod.app.config["WTF_CSRF_ENABLED"] = False
+
+    app = create_app({"TESTING": True, "WTF_CSRF_ENABLED": False})
+    app_mod.app = app
     app_mod.reset_db()
     return app_mod
 

--- a/magazyn/tests/test_db_config.py
+++ b/magazyn/tests/test_db_config.py
@@ -9,6 +9,7 @@ from magazyn.models import User
 
 def test_reload_env_reconfigures_engine(tmp_path, monkeypatch):
     first = tmp_path / "first.db"
+    monkeypatch.setattr(db, "apply_migrations", lambda: None)
     db.configure_engine(str(first))
     db.init_db()
     with db.get_session() as session:

--- a/magazyn/tests/test_sales.py
+++ b/magazyn/tests/test_sales.py
@@ -1,4 +1,3 @@
-from magazyn.app import app
 from magazyn.models import Product, ProductSize, Sale, ShippingThreshold
 
 from decimal import Decimal


### PR DESCRIPTION
## Summary
- add a `create_app` factory that configures blueprints, globals, hooks, and shutdown handling
- update `magazyn.app` to expose a blueprint, defer initialization side-effects, and reuse the factory when run as a script
- switch integration tests and helpers to build isolated app instances via the factory and file-backed temporary databases while stubbing migrations

## Testing
- PYTHONPATH=. pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68cfd7fdfa18832aac52a9170278bc4c