### PR TITLE
Refactor print agent to use LabelAgent configuration

### DIFF
--- a/magazyn/agent/__init__.py
+++ b/magazyn/agent/__init__.py
@@ -1,0 +1,5 @@
+"""Helpers for managing the legacy label printing agent."""
+
+from .migrate import main as migrate_main
+
+__all__ = ["migrate_main"]

--- a/magazyn/agent/migrate.py
+++ b/magazyn/agent/migrate.py
@@ -1,0 +1,177 @@
+"""CLI utilities for migrating legacy label agent data."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sqlite3
+from pathlib import Path
+from typing import Iterable, Optional
+
+from magazyn.print_agent import AgentConfig, LabelAgent, load_config
+
+LOGGER = logging.getLogger(__name__)
+
+
+def migrate_printed_file(db_path: str, printed_file: Path) -> None:
+    if not printed_file.exists():
+        LOGGER.info("Printed orders file %s not found, skipping", printed_file)
+        return
+    conn = sqlite3.connect(db_path)
+    cur = conn.cursor()
+    cur.execute("SELECT COUNT(*) FROM printed_orders")
+    if cur.fetchone()[0]:
+        LOGGER.info("printed_orders table already populated, skipping text file import")
+        conn.close()
+        return
+    with printed_file.open("r", encoding="utf-8") as handle:
+        for line in handle:
+            line = line.strip()
+            if not line or "," not in line:
+                continue
+            order_id, ts = line.split(",", 1)
+            cur.execute(
+                "INSERT OR IGNORE INTO printed_orders(order_id, printed_at) VALUES (?, ?)",
+                (order_id.strip(), ts.strip()),
+            )
+    conn.commit()
+    conn.close()
+    LOGGER.info("Imported printed orders from %s", printed_file)
+
+
+def migrate_queue_file(db_path: str, queue_file: Path) -> None:
+    if not queue_file.exists():
+        LOGGER.info("Queued labels file %s not found, skipping", queue_file)
+        return
+    conn = sqlite3.connect(db_path)
+    cur = conn.cursor()
+    cur.execute("SELECT COUNT(*) FROM label_queue")
+    if cur.fetchone()[0]:
+        LOGGER.info("label_queue table already populated, skipping jsonl import")
+        conn.close()
+        return
+    with queue_file.open("r", encoding="utf-8") as handle:
+        for line in handle:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                item = json.loads(line)
+            except json.JSONDecodeError:
+                LOGGER.error("Invalid JSON entry in %s: %s", queue_file, line)
+                continue
+            cur.execute(
+                "INSERT INTO label_queue(order_id, label_data, ext, last_order_data) VALUES (?, ?, ?, ?)",
+                (
+                    item.get("order_id"),
+                    item.get("label_data"),
+                    item.get("ext"),
+                    json.dumps(item.get("last_order_data", {})),
+                ),
+            )
+    conn.commit()
+    conn.close()
+    LOGGER.info("Imported queued labels from %s", queue_file)
+
+
+def migrate_from_legacy_db(db_path: str, legacy_db: Path) -> None:
+    if not legacy_db.exists():
+        LOGGER.info("Legacy database %s not found, skipping", legacy_db)
+        return
+    conn = sqlite3.connect(db_path)
+    cur = conn.cursor()
+    old_conn = sqlite3.connect(legacy_db)
+    old_cur = old_conn.cursor()
+    try:
+        for table, columns in (("printed_orders", 3), ("label_queue", 4)):
+            old_cur.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name=?",
+                (table,),
+            )
+            if not old_cur.fetchone():
+                continue
+            cur.execute(f"SELECT COUNT(*) FROM {table}")
+            if cur.fetchone()[0]:
+                continue
+            placeholders = ",".join(["?"] * columns)
+            for row in old_cur.execute(f"SELECT * FROM {table}"):
+                cur.execute(f"INSERT INTO {table} VALUES ({placeholders})", row)
+        conn.commit()
+    finally:
+        old_conn.close()
+        conn.close()
+    LOGGER.info("Imported data from legacy database %s", legacy_db)
+
+
+def run_migrations(agent: LabelAgent, *, printed_file: Optional[Path], queue_file: Optional[Path], legacy_db: Optional[Path]) -> None:
+    agent.ensure_db()
+    if printed_file:
+        migrate_printed_file(agent.config.db_file, printed_file)
+    if queue_file:
+        migrate_queue_file(agent.config.db_file, queue_file)
+    if legacy_db:
+        migrate_from_legacy_db(agent.config.db_file, legacy_db)
+
+
+def build_agent(args: argparse.Namespace) -> LabelAgent:
+    settings_obj = load_config()
+    config = AgentConfig.from_settings(settings_obj)
+    updates = {}
+    if args.db_file:
+        updates["db_file"] = str(args.db_file)
+    if args.printed_file:
+        updates["legacy_printed_file"] = str(args.printed_file)
+    if args.queue_file:
+        updates["legacy_queue_file"] = str(args.queue_file)
+    if args.legacy_db:
+        updates["legacy_db_file"] = str(args.legacy_db)
+    if updates:
+        config = config.with_updates(**updates)
+    agent = LabelAgent(config, settings_obj)
+    return agent
+
+
+def parse_args(argv: Optional[Iterable[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Migrate legacy label agent data")
+    parser.add_argument("--db-file", type=Path, help="Path to the SQLite database")
+    parser.add_argument(
+        "--printed-file",
+        type=Path,
+        help="Path to the legacy printed orders text file",
+    )
+    parser.add_argument(
+        "--queue-file",
+        type=Path,
+        help="Path to the legacy queued labels JSONL file",
+    )
+    parser.add_argument(
+        "--legacy-db",
+        type=Path,
+        help="Path to the legacy standalone SQLite database",
+    )
+    return parser.parse_args(list(argv) if argv is not None else None)
+
+
+def main(argv: Optional[Iterable[str]] = None) -> int:
+    args = parse_args(argv)
+    agent = build_agent(args)
+    printed_default = agent.config.legacy_printed_file
+    queue_default = agent.config.legacy_queue_file
+    legacy_db_default = agent.config.legacy_db_file
+
+    printed_file = Path(args.printed_file) if args.printed_file else (Path(printed_default) if printed_default else None)
+    queue_file = Path(args.queue_file) if args.queue_file else (Path(queue_default) if queue_default else None)
+    legacy_db = Path(args.legacy_db) if args.legacy_db else (Path(legacy_db_default) if legacy_db_default else None)
+
+    run_migrations(
+        agent,
+        printed_file=printed_file if printed_file and printed_file.exists() else None,
+        queue_file=queue_file if queue_file and queue_file.exists() else None,
+        legacy_db=legacy_db if legacy_db and legacy_db.exists() else None,
+    )
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())

--- a/magazyn/app.py
+++ b/magazyn/app.py
@@ -81,10 +81,11 @@ def start_print_agent(app_obj=None):
         return
     _print_agent_started = True
     app_ctx = app_obj or current_app
+    agent = print_agent.agent
     try:
-        print_agent.validate_env()
-        print_agent.ensure_db_init()
-        started = print_agent.start_agent_thread()
+        agent.validate_env()
+        agent.ensure_db_init()
+        started = agent.start_agent_thread()
         if not started:
             app_ctx.logger.info("Print agent already running")
             _print_agent_started = False

--- a/magazyn/print_agent.py
+++ b/magazyn/print_agent.py
@@ -1,20 +1,26 @@
-from .notifications import send_report
-from .services import consume_order_stock, get_sales_summary
-from .constants import ALL_SIZES, KNOWN_COLORS
-from .parsing import parse_product_info
-from magazyn import DB_PATH
-from .config import settings, load_config
-import os
+from __future__ import annotations
+
+import base64
 import fcntl
 import json
-import base64
-import subprocess
 import logging
+import os
 import sqlite3
+import subprocess
 import threading
+from dataclasses import dataclass, replace
 from datetime import datetime, timedelta, time as dt_time
+from typing import Any, Dict, Iterable, List, Optional, Tuple
 from zoneinfo import ZoneInfo
+
 import requests
+
+from magazyn import DB_PATH
+
+from .config import load_config, settings
+from .notifications import send_report
+from .parsing import parse_product_info
+from .services import consume_order_stock, get_sales_summary
 
 
 class ConfigError(Exception):
@@ -25,704 +31,643 @@ def parse_time_str(value: str) -> dt_time:
     """Return time from ``HH:MM`` or raise ``ValueError``."""
     try:
         return dt_time.fromisoformat(value)
-    except ValueError as e:
-        raise ValueError(f"Invalid time value: {value}") from e
+    except ValueError as exc:  # pragma: no cover - defensive
+        raise ValueError(f"Invalid time value: {value}") from exc
 
 
-API_TOKEN = settings.API_TOKEN
-PAGE_ACCESS_TOKEN = settings.PAGE_ACCESS_TOKEN
-RECIPIENT_ID = settings.RECIPIENT_ID
-STATUS_ID = settings.STATUS_ID
-PRINTER_NAME = settings.PRINTER_NAME
-CUPS_SERVER = settings.CUPS_SERVER
-CUPS_PORT = settings.CUPS_PORT
-POLL_INTERVAL = settings.POLL_INTERVAL
-QUIET_HOURS_START = parse_time_str(settings.QUIET_HOURS_START)
-QUIET_HOURS_END = parse_time_str(settings.QUIET_HOURS_END)
-TIMEZONE = settings.TIMEZONE
-BASE_URL = "https://api.baselinker.com/connector.php"
-PRINTED_FILE = os.path.join(os.path.dirname(__file__), "printed_orders.txt")
-PRINTED_EXPIRY_DAYS = settings.PRINTED_EXPIRY_DAYS
-LABEL_QUEUE = os.path.join(os.path.dirname(__file__), "queued_labels.jsonl")
-LOG_LEVEL = settings.LOG_LEVEL
-# Whether periodic summary reports should be sent
-ENABLE_WEEKLY_REPORTS = settings.ENABLE_WEEKLY_REPORTS
-ENABLE_MONTHLY_REPORTS = settings.ENABLE_MONTHLY_REPORTS
-# Use the same database file as the web application
-DB_FILE = DB_PATH
-# Location of the legacy database used by the standalone printer agent
-OLD_DB_FILE = os.path.abspath(
-    os.path.join(os.path.dirname(__file__), os.pardir, "printer", "data.db")
-)
-LOG_FILE = settings.LOG_FILE
-LOCK_FILE = os.getenv(
-    "AGENT_LOCK_FILE", os.path.join(os.path.dirname(LOG_FILE), "agent.lock")
-)
-_lock_handle = None
+@dataclass
+class AgentConfig:
+    api_token: str
+    page_access_token: str
+    recipient_id: str
+    status_id: str
+    printer_name: str
+    cups_server: Optional[str]
+    cups_port: Optional[int]
+    poll_interval: int
+    quiet_hours_start: dt_time
+    quiet_hours_end: dt_time
+    timezone: str
+    printed_expiry_days: int
+    enable_weekly_reports: bool
+    enable_monthly_reports: bool
+    log_level: str
+    log_file: str
+    db_file: str
+    lock_file: str
+    base_url: str = "https://api.baselinker.com/connector.php"
+    legacy_printed_file: Optional[str] = None
+    legacy_queue_file: Optional[str] = None
+    legacy_db_file: Optional[str] = None
 
-logging.basicConfig(
-    level=getattr(logging, LOG_LEVEL, logging.INFO),
-    format="%(asctime)s [%(levelname)s] %(message)s",
-    handlers=[
-        logging.FileHandler(LOG_FILE),
-        logging.StreamHandler(),
-    ],
-)
-logger = logging.getLogger(__name__)
-
-HEADERS = {
-    "X-BLToken": API_TOKEN,
-    "Content-Type": "application/x-www-form-urlencoded",
-}
-
-
-def reload_env():
-    """Reload environment variables and update globals."""
-    global settings
-    settings = load_config()
-    global API_TOKEN, PAGE_ACCESS_TOKEN, RECIPIENT_ID, STATUS_ID, PRINTER_NAME
-    global CUPS_SERVER, CUPS_PORT, POLL_INTERVAL, QUIET_HOURS_START
-    global QUIET_HOURS_END, TIMEZONE, PRINTED_EXPIRY_DAYS, LOG_LEVEL
-    global LOG_FILE, DB_FILE, ENABLE_WEEKLY_REPORTS, ENABLE_MONTHLY_REPORTS
-    API_TOKEN = settings.API_TOKEN
-    PAGE_ACCESS_TOKEN = settings.PAGE_ACCESS_TOKEN
-    RECIPIENT_ID = settings.RECIPIENT_ID
-    STATUS_ID = settings.STATUS_ID
-    PRINTER_NAME = settings.PRINTER_NAME
-    CUPS_SERVER = settings.CUPS_SERVER
-    CUPS_PORT = settings.CUPS_PORT
-    POLL_INTERVAL = settings.POLL_INTERVAL
-    QUIET_HOURS_START = parse_time_str(settings.QUIET_HOURS_START)
-    QUIET_HOURS_END = parse_time_str(settings.QUIET_HOURS_END)
-    TIMEZONE = settings.TIMEZONE
-    PRINTED_EXPIRY_DAYS = settings.PRINTED_EXPIRY_DAYS
-    old_log_file = LOG_FILE
-    LOG_LEVEL = settings.LOG_LEVEL
-    LOG_FILE = settings.LOG_FILE
-    DB_FILE = settings.DB_PATH
-    HEADERS["X-BLToken"] = API_TOKEN
-    ENABLE_WEEKLY_REPORTS = settings.ENABLE_WEEKLY_REPORTS
-    ENABLE_MONTHLY_REPORTS = settings.ENABLE_MONTHLY_REPORTS
-
-    from . import db
-
-    db.configure_engine(DB_FILE)
-
-    logger.setLevel(getattr(logging, LOG_LEVEL, logging.INFO))
-    if old_log_file != LOG_FILE:
-        root_logger = logging.getLogger()
-        formatter = logging.Formatter(
-            "%(asctime)s [%(levelname)s] %(message)s"
+    @classmethod
+    def from_settings(cls, cfg: Any) -> "AgentConfig":
+        base_dir = os.path.dirname(__file__)
+        log_file = cfg.LOG_FILE
+        lock_file = os.getenv(
+            "AGENT_LOCK_FILE",
+            os.path.join(os.path.dirname(log_file), "agent.lock"),
         )
-        for h in list(root_logger.handlers):
-            if isinstance(h, logging.FileHandler):
-                root_logger.removeHandler(h)
-                h.close()
-        file_handler = logging.FileHandler(LOG_FILE)
+        return cls(
+            api_token=cfg.API_TOKEN,
+            page_access_token=cfg.PAGE_ACCESS_TOKEN,
+            recipient_id=cfg.RECIPIENT_ID,
+            status_id=cfg.STATUS_ID,
+            printer_name=cfg.PRINTER_NAME,
+            cups_server=cfg.CUPS_SERVER,
+            cups_port=cfg.CUPS_PORT,
+            poll_interval=cfg.POLL_INTERVAL,
+            quiet_hours_start=parse_time_str(cfg.QUIET_HOURS_START),
+            quiet_hours_end=parse_time_str(cfg.QUIET_HOURS_END),
+            timezone=cfg.TIMEZONE,
+            printed_expiry_days=cfg.PRINTED_EXPIRY_DAYS,
+            enable_weekly_reports=cfg.ENABLE_WEEKLY_REPORTS,
+            enable_monthly_reports=cfg.ENABLE_MONTHLY_REPORTS,
+            log_level=cfg.LOG_LEVEL,
+            log_file=log_file,
+            db_file=getattr(cfg, "DB_PATH", DB_PATH),
+            lock_file=lock_file,
+            legacy_printed_file=os.path.join(base_dir, "printed_orders.txt"),
+            legacy_queue_file=os.path.join(base_dir, "queued_labels.jsonl"),
+            legacy_db_file=os.path.abspath(
+                os.path.join(base_dir, os.pardir, "printer", "data.db")
+            ),
+        )
+
+    def with_updates(self, **kwargs: Any) -> "AgentConfig":
+        return replace(self, **kwargs)
+
+
+class LabelAgent:
+    """Encapsulates the state and behaviour of the label printing agent."""
+
+    def __init__(self, config: AgentConfig, settings_obj: Any):
+        self.config = config
+        self.settings = settings_obj
+        self.logger = logging.getLogger(__name__)
+        self.last_order_data: Dict[str, Any] = {}
+        self._agent_thread: Optional[threading.Thread] = None
+        self._stop_event = threading.Event()
+        self._lock_handle = None
+        self._api_calls_total = 0
+        self._api_calls_success = 0
+        self._last_api_log = datetime.now()
+        self._headers = {
+            "X-BLToken": config.api_token,
+            "Content-Type": "application/x-www-form-urlencoded",
+        }
+        self._configure_logging(initial=True)
+        self._configure_db_engine()
+
+    # ------------------------------------------------------------------
+    # Configuration helpers
+    # ------------------------------------------------------------------
+    def _configure_logging(self, initial: bool = False) -> None:
+        formatter = logging.Formatter("%(asctime)s [%(levelname)s] %(message)s")
+        root_logger = logging.getLogger()
+        root_logger.setLevel(getattr(logging, self.config.log_level, logging.INFO))
+
+        # Ensure we have a stream handler for console output.
+        if not any(isinstance(h, logging.StreamHandler) for h in root_logger.handlers):
+            stream_handler = logging.StreamHandler()
+            stream_handler.setFormatter(formatter)
+            root_logger.addHandler(stream_handler)
+
+        # Replace existing file handlers so updates to LOG_FILE take effect.
+        file_handlers = [h for h in root_logger.handlers if isinstance(h, logging.FileHandler)]
+        for handler in file_handlers:
+            root_logger.removeHandler(handler)
+            handler.close()
+        file_handler = logging.FileHandler(self.config.log_file)
         file_handler.setFormatter(formatter)
         root_logger.addHandler(file_handler)
 
+        self.logger.setLevel(getattr(logging, self.config.log_level, logging.INFO))
+        if initial:
+            self.logger.debug("LabelAgent logging configured")
 
-def reload_config():
-    """Reload configuration from .env and update globals."""
-    reload_env()
+    def _configure_db_engine(self) -> None:
+        from . import db
 
+        db.configure_engine(self.config.db_file)
 
-last_order_data = {}
-_agent_thread = None
-# Timestamps for last periodic reports
-_last_weekly_report = None
-_last_monthly_report = None
-# Event used to signal the agent loop to exit
-_stop_event = threading.Event()
+    def reload_config(self) -> None:
+        """Reload configuration from ``.env`` and update the agent state."""
+        self.settings = load_config()
+        self.config = AgentConfig.from_settings(self.settings)
+        self._headers["X-BLToken"] = self.config.api_token
+        self._configure_logging()
+        self._configure_db_engine()
+        globals()["settings"] = self.settings
+        globals()["logger"] = self.logger
 
+    # Backwards-compatible alias
+    reload_env = reload_config
 
-def validate_env():
-    required = {
-        "API_TOKEN": API_TOKEN,
-        "PAGE_ACCESS_TOKEN": PAGE_ACCESS_TOKEN,
-        "RECIPIENT_ID": RECIPIENT_ID,
-    }
-    missing = [name for name, value in required.items() if not value]
-    if missing:
-        logger.error(
-            "Brak wymaganych zmiennych środowiskowych: %s", ", ".join(missing)
-        )
-        raise ConfigError(
-            "Missing environment variables: " + ", ".join(missing)
-        )
+    # ------------------------------------------------------------------
+    # Validation and persistence helpers
+    # ------------------------------------------------------------------
+    def validate_env(self) -> None:
+        required = {
+            "API_TOKEN": self.config.api_token,
+            "PAGE_ACCESS_TOKEN": self.config.page_access_token,
+            "RECIPIENT_ID": self.config.recipient_id,
+        }
+        missing = [name for name, value in required.items() if not value]
+        if missing:
+            self.logger.error(
+                "Brak wymaganych zmiennych środowiskowych: %s", ", ".join(missing)
+            )
+            raise ConfigError("Missing environment variables: " + ", ".join(missing))
 
-
-def ensure_db():
-    conn = sqlite3.connect(DB_FILE)
-    cur = conn.cursor()
-    cur.execute(
-        "CREATE TABLE IF NOT EXISTS printed_orders("
-        "order_id TEXT PRIMARY KEY, printed_at TEXT, last_order_data TEXT)"
-    )
-    cur.execute("PRAGMA table_info(printed_orders)")
-    cols = [row[1] for row in cur.fetchall()]
-    if "last_order_data" not in cols:
+    def ensure_db(self) -> None:
+        conn = sqlite3.connect(self.config.db_file)
+        cur = conn.cursor()
         cur.execute(
-            "ALTER TABLE printed_orders ADD COLUMN last_order_data TEXT"
+            "CREATE TABLE IF NOT EXISTS printed_orders("  # noqa: S608 - static SQL
+            "order_id TEXT PRIMARY KEY, printed_at TEXT, last_order_data TEXT)"
+        )
+        cur.execute("PRAGMA table_info(printed_orders)")
+        cols = [row[1] for row in cur.fetchall()]
+        if "last_order_data" not in cols:
+            cur.execute(
+                "ALTER TABLE printed_orders ADD COLUMN last_order_data TEXT"
+            )
+            conn.commit()
+        cur.execute(
+            "CREATE TABLE IF NOT EXISTS label_queue("  # noqa: S608 - static SQL
+            "order_id TEXT, label_data TEXT, ext TEXT, last_order_data TEXT)"
         )
         conn.commit()
-    cur.execute(
-        "CREATE TABLE IF NOT EXISTS label_queue("
-        "order_id TEXT, label_data TEXT, ext TEXT, last_order_data TEXT)"
-    )
-    conn.commit()
 
-    if os.path.exists(PRINTED_FILE):
-        cur.execute("SELECT COUNT(*) FROM printed_orders")
-        if cur.fetchone()[0] == 0:
-            with open(PRINTED_FILE, "r") as f:
-                for line in f:
-                    if "," in line:
-                        oid, ts = line.strip().split(",")
-                        cur.execute(
-                            "INSERT OR IGNORE INTO printed_orders("
-                            "order_id, printed_at) VALUES (?, ?)",
-                            (oid, ts),
-                        )
-            conn.commit()
-    if os.path.exists(LABEL_QUEUE):
-        cur.execute("SELECT COUNT(*) FROM label_queue")
-        if cur.fetchone()[0] == 0:
-            with open(LABEL_QUEUE, "r") as f:
-                for line in f:
-                    line = line.strip()
-                    if not line:
-                        continue
-                    try:
-                        item = json.loads(line)
-                        cur.execute(
-                            "INSERT INTO label_queue("
-                            "order_id, label_data, ext, last_order_data)"
-                            " VALUES (?, ?, ?, ?)",
-                            (
-                                item.get("order_id"),
-                                item.get("label_data"),
-                                item.get("ext"),
-                                json.dumps(item.get("last_order_data", {})),
-                            ),
-                        )
-                    except Exception as e:
-                        logger.error(f"Błąd migracji z {LABEL_QUEUE}: {e}")
-            conn.commit()
-
-    # migrate data from old standalone database if present and tables are empty
-    if os.path.exists(OLD_DB_FILE):
+        # clean entries where product name was replaced with customer name
         try:
-            old_conn = sqlite3.connect(OLD_DB_FILE)
-            old_cur = old_conn.cursor()
-            for table, cols in (
-                ("printed_orders", 3),
-                ("label_queue", 4),
-            ):
-                old_cur.execute(
-                    "SELECT name FROM sqlite_master WHERE type='table' AND name=?",
-                    (table,),
-                )
-                if not old_cur.fetchone():
+            cur.execute("SELECT order_id, last_order_data FROM printed_orders")
+            rows = cur.fetchall()
+            for oid, data_json in rows:
+                try:
+                    data = json.loads(data_json) if data_json else {}
+                except Exception:  # pragma: no cover - defensive
                     continue
-                cur.execute(f"SELECT COUNT(*) FROM {table}")
-                if cur.fetchone()[0] == 0:
-                    placeholders = ",".join(["?"] * cols)
-                    for row in old_cur.execute(f"SELECT * FROM {table}"):
-                        cur.execute(
-                            f"INSERT INTO {table} VALUES ({placeholders})",
-                            row,
-                        )
+                name = (data.get("name") or "").strip()
+                cust = (data.get("customer") or "").strip()
+                if name and cust and name == cust:
+                    prod_name, size, color = parse_product_info(
+                        (data.get("products") or [{}])[0]
+                    )
+                    data["name"] = prod_name
+                    data["size"] = size
+                    data["color"] = color
+                    cur.execute(
+                        "UPDATE printed_orders SET last_order_data=? WHERE order_id=?",
+                        (json.dumps(data), oid),
+                    )
             conn.commit()
-            old_conn.close()
-        except Exception as e:
-            logger.error(f"B\u0142\u0105d migracji z {OLD_DB_FILE}: {e}")
+        except Exception as exc:  # pragma: no cover - defensive
+            self.logger.error("Błąd migracji last_order_data: %s", exc)
+        finally:
+            conn.close()
 
-    # clean entries where product name was replaced with customer name
-    try:
-        cur.execute("SELECT order_id, last_order_data FROM printed_orders")
+    def ensure_db_init(self) -> None:
+        self.ensure_db()
+
+    def load_printed_orders(self) -> List[Dict[str, Any]]:
+        self.ensure_db()
+        conn = sqlite3.connect(self.config.db_file)
+        cur = conn.cursor()
+        cur.execute(
+            "SELECT order_id, printed_at, last_order_data FROM printed_orders ORDER BY printed_at DESC"
+        )
         rows = cur.fetchall()
-        for oid, data_json in rows:
+        conn.close()
+        items: List[Dict[str, Any]] = []
+        for oid, ts, data_json in rows:
             try:
                 data = json.loads(data_json) if data_json else {}
-            except Exception:
-                continue
-            name = (data.get("name") or "").strip()
-            cust = (data.get("customer") or "").strip()
-            if name and cust and name == cust:
-                prod_name, size, color = parse_product_info((data.get("products") or [{}])[0])
-                data["name"] = prod_name
-                data["size"] = size
-                data["color"] = color
-                cur.execute(
-                    "UPDATE printed_orders SET last_order_data=? WHERE order_id=?",
-                    (json.dumps(data), oid),
-                )
-        conn.commit()
-    except Exception as e:
-        logger.error(f"B\u0142\u0105d migracji last_order_data: {e}")
-    conn.close()
+            except Exception:  # pragma: no cover - defensive
+                data = {}
+            items.append(
+                {
+                    "order_id": oid,
+                    "printed_at": datetime.fromisoformat(ts),
+                    "last_order_data": data,
+                }
+            )
+        return items
 
-
-def ensure_db_init():
-    ensure_db()
-
-
-def load_printed_orders():
-    """Return printed orders sorted by newest first."""
-    ensure_db()
-    conn = sqlite3.connect(DB_FILE)
-    cur = conn.cursor()
-    cur.execute(
-        "SELECT order_id, printed_at, last_order_data FROM printed_orders ORDER BY printed_at DESC"
-    )
-    rows = cur.fetchall()
-    conn.close()
-    items = []
-    for oid, ts, data_json in rows:
-        try:
-            data = json.loads(data_json) if data_json else {}
-        except Exception:
-            data = {}
-        items.append(
-            {
-                "order_id": oid,
-                "printed_at": datetime.fromisoformat(ts),
-                "last_order_data": data,
-            }
-        )
-    return items
-
-
-def mark_as_printed(order_id, last_order_data=None):
-    """Record that an order's labels were printed."""
-    conn = sqlite3.connect(DB_FILE)
-    cur = conn.cursor()
-    data_json = json.dumps(last_order_data or {})
-    cur.execute(
-        "INSERT OR IGNORE INTO printed_orders(order_id, printed_at, last_order_data) VALUES (?, ?, ?)",
-        (order_id, datetime.now().isoformat(), data_json),
-    )
-    cur.execute(
-        "UPDATE printed_orders SET last_order_data=? WHERE order_id=?",
-        (data_json, order_id),
-    )
-    conn.commit()
-    conn.close()
-
-
-def clean_old_printed_orders():
-    threshold = datetime.now() - timedelta(days=PRINTED_EXPIRY_DAYS)
-    conn = sqlite3.connect(DB_FILE)
-    cur = conn.cursor()
-    cur.execute(
-        "DELETE FROM printed_orders WHERE printed_at < ?",
-        (threshold.isoformat(),),
-    )
-    conn.commit()
-    conn.close()
-
-
-def load_queue():
-    ensure_db()
-    conn = sqlite3.connect(DB_FILE)
-    cur = conn.cursor()
-    cur.execute(
-        "SELECT order_id, label_data, ext, last_order_data FROM label_queue"
-    )
-    rows = cur.fetchall()
-    conn.close()
-    items = []
-    for order_id, label_data, ext, last_order_json in rows:
-        try:
-            last_data = json.loads(last_order_json) if last_order_json else {}
-        except Exception:
-            last_data = {}
-        items.append(
-            {
-                "order_id": order_id,
-                "label_data": label_data,
-                "ext": ext,
-                "last_order_data": last_data,
-            }
-        )
-    return items
-
-
-def save_queue(items):
-    conn = sqlite3.connect(DB_FILE)
-    cur = conn.cursor()
-    cur.execute("DELETE FROM label_queue")
-    for item in items:
+    def mark_as_printed(
+        self, order_id: str, last_order_data: Optional[Dict[str, Any]] = None
+    ) -> None:
+        conn = sqlite3.connect(self.config.db_file)
+        cur = conn.cursor()
+        data_json = json.dumps(last_order_data or {})
         cur.execute(
-            "INSERT INTO label_queue(order_id, label_data, ext, last_order_data) VALUES (?, ?, ?, ?)",
-            (
-                item.get("order_id"),
-                item.get("label_data"),
-                item.get("ext"),
-                json.dumps(item.get("last_order_data", {})),
-            ),
+            "INSERT OR IGNORE INTO printed_orders(order_id, printed_at, last_order_data) VALUES (?, ?, ?)",
+            (order_id, datetime.now().isoformat(), data_json),
         )
-    conn.commit()
-    conn.close()
-
-
-_api_calls_total = 0
-_api_calls_success = 0
-_last_api_log = datetime.now()
-
-
-def _maybe_log_api_summary():
-    """Log hourly summary of successful API calls."""
-    global _api_calls_total, _api_calls_success, _last_api_log
-    now = datetime.now()
-    if now - _last_api_log >= timedelta(hours=1) and _api_calls_total:
-        logger.info(
-            "Udane połączenia: [%s/%s]",
-            _api_calls_success,
-            _api_calls_total,
+        cur.execute(
+            "UPDATE printed_orders SET last_order_data=? WHERE order_id=?",
+            (data_json, order_id),
         )
-        _api_calls_total = 0
-        _api_calls_success = 0
-        _last_api_log = now
+        conn.commit()
+        conn.close()
 
-
-def call_api(method, parameters=None):
-    global _api_calls_total, _api_calls_success
-    parameters = parameters or {}
-    success = False
-    try:
-        payload = {"method": method, "parameters": json.dumps(parameters)}
-        response = requests.post(
-            BASE_URL, headers=HEADERS, data=payload, timeout=10
+    def clean_old_printed_orders(self) -> None:
+        threshold = datetime.now() - timedelta(days=self.config.printed_expiry_days)
+        conn = sqlite3.connect(self.config.db_file)
+        cur = conn.cursor()
+        cur.execute(
+            "DELETE FROM printed_orders WHERE printed_at < ?",
+            (threshold.isoformat(),),
         )
-        response.raise_for_status()
-        success = True
-        return response.json()
-    except requests.exceptions.HTTPError as e:
-        logger.error(f"HTTP error in call_api({method}): {e}")
-    except requests.exceptions.RequestException as e:
-        logger.error(f"Request error in call_api({method}): {e}")
-    except Exception as e:
-        logger.error(f"Błąd w call_api({method}): {e}")
-    finally:
-        _api_calls_total += 1
-        if success:
-            _api_calls_success += 1
-        _maybe_log_api_summary()
-    return {}
+        conn.commit()
+        conn.close()
 
-
-def get_orders():
-    response = call_api(
-        "getOrders",
-        {"status_id": STATUS_ID, "include_products": 1},
-    )
-    return response.get("orders", [])
-
-
-def get_order_packages(order_id):
-    response = call_api("getOrderPackages", {"order_id": order_id})
-    return response.get("packages", [])
-
-
-def get_label(courier_code, package_id):
-    response = call_api(
-        "getLabel", {"courier_code": courier_code, "package_id": package_id}
-    )
-    return response.get("label"), response.get("extension", "pdf")
-
-
-def print_label(base64_data, extension, order_id):
-    try:
-        file_path = f"/tmp/label_{order_id}.{extension}"
-        pdf_data = base64.b64decode(base64_data)
-        with open(file_path, "wb") as f:
-            f.write(pdf_data)
-        cmd = ["lp"]
-        host = None
-        if CUPS_SERVER or CUPS_PORT:
-            server = CUPS_SERVER or "localhost"
-            host = f"{server}:{CUPS_PORT}" if CUPS_PORT else server
-        if host:
-            cmd.extend(["-h", host])
-        cmd.extend(["-d", PRINTER_NAME, file_path])
-        result = subprocess.run(cmd, capture_output=True)
-        os.remove(file_path)
-        if result.returncode != 0:
-            logger.error(
-                "Błąd drukowania (kod %s): %s",
-                result.returncode,
-                result.stderr.decode().strip(),
+    def load_queue(self) -> List[Dict[str, Any]]:
+        self.ensure_db()
+        conn = sqlite3.connect(self.config.db_file)
+        cur = conn.cursor()
+        cur.execute(
+            "SELECT order_id, label_data, ext, last_order_data FROM label_queue"
+        )
+        rows = cur.fetchall()
+        conn.close()
+        items: List[Dict[str, Any]] = []
+        for order_id, label_data, ext, last_order_json in rows:
+            try:
+                last_data = json.loads(last_order_json) if last_order_json else {}
+            except Exception:  # pragma: no cover - defensive
+                last_data = {}
+            items.append(
+                {
+                    "order_id": order_id,
+                    "label_data": label_data,
+                    "ext": ext,
+                    "last_order_data": last_data,
+                }
             )
-        else:
-            logger.info("📨 Label printed")
-    except Exception as e:
-        logger.error(f"Błąd drukowania: {e}")
+        return items
 
-
-def print_test_page():
-    try:
-        file_path = "/tmp/print_test.txt"
-        with open(file_path, "w") as f:
-            f.write("=== TEST PRINT ===\n")
-        result = subprocess.run(
-            ["lp", "-d", PRINTER_NAME, file_path], capture_output=True
-        )
-        os.remove(file_path)
-        if result.returncode != 0:
-            logger.error(
-                "Błąd testowego druku (kod %s): %s",
-                result.returncode,
-                result.stderr.decode().strip(),
+    def save_queue(self, items: Iterable[Dict[str, Any]]) -> None:
+        conn = sqlite3.connect(self.config.db_file)
+        cur = conn.cursor()
+        cur.execute("DELETE FROM label_queue")
+        for item in items:
+            cur.execute(
+                "INSERT INTO label_queue(order_id, label_data, ext, last_order_data) VALUES (?, ?, ?, ?)",
+                (
+                    item.get("order_id"),
+                    item.get("label_data"),
+                    item.get("ext"),
+                    json.dumps(item.get("last_order_data", {})),
+                ),
             )
+        conn.commit()
+        conn.close()
+
+    # ------------------------------------------------------------------
+    # External integrations
+    # ------------------------------------------------------------------
+    def _maybe_log_api_summary(self) -> None:
+        now = datetime.now()
+        if now - self._last_api_log >= timedelta(hours=1) and self._api_calls_total:
+            self.logger.info(
+                "Udane połączenia: [%s/%s]",
+                self._api_calls_success,
+                self._api_calls_total,
+            )
+            self._api_calls_total = 0
+            self._api_calls_success = 0
+            self._last_api_log = now
+
+    def call_api(self, method: str, parameters: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+        parameters = parameters or {}
+        success = False
+        try:
+            payload = {"method": method, "parameters": json.dumps(parameters)}
+            response = requests.post(
+                self.config.base_url, headers=self._headers, data=payload, timeout=10
+            )
+            response.raise_for_status()
+            success = True
+            return response.json()
+        except requests.exceptions.HTTPError as exc:
+            self.logger.error("HTTP error in call_api(%s): %s", method, exc)
+        except requests.exceptions.RequestException as exc:
+            self.logger.error("Request error in call_api(%s): %s", method, exc)
+        except Exception as exc:  # pragma: no cover - defensive
+            self.logger.error("Błąd w call_api(%s): %s", method, exc)
+        finally:
+            self._api_calls_total += 1
+            if success:
+                self._api_calls_success += 1
+            self._maybe_log_api_summary()
+        return {}
+
+    def get_orders(self) -> List[Dict[str, Any]]:
+        response = self.call_api(
+            "getOrders", {"status_id": self.config.status_id, "include_products": 1}
+        )
+        return response.get("orders", [])
+
+    def get_order_packages(self, order_id: str) -> List[Dict[str, Any]]:
+        response = self.call_api("getOrderPackages", {"order_id": order_id})
+        return response.get("packages", [])
+
+    def get_label(self, courier_code: str, package_id: str) -> Tuple[str, str]:
+        response = self.call_api(
+            "getLabel", {"courier_code": courier_code, "package_id": package_id}
+        )
+        return response.get("label"), response.get("extension", "pdf")
+
+    def print_label(self, base64_data: str, extension: str, order_id: str) -> None:
+        try:
+            file_path = f"/tmp/label_{order_id}.{extension}"
+            pdf_data = base64.b64decode(base64_data)
+            with open(file_path, "wb") as handle:
+                handle.write(pdf_data)
+            cmd = ["lp"]
+            host = None
+            if self.config.cups_server or self.config.cups_port:
+                server = self.config.cups_server or "localhost"
+                host = (
+                    f"{server}:{self.config.cups_port}"
+                    if self.config.cups_port
+                    else server
+                )
+            if host:
+                cmd.extend(["-h", host])
+            cmd.extend(["-d", self.config.printer_name, file_path])
+            result = subprocess.run(cmd, capture_output=True, check=False)
+            os.remove(file_path)
+            if result.returncode != 0:
+                self.logger.error(
+                    "Błąd drukowania (kod %s): %s",
+                    result.returncode,
+                    result.stderr.decode().strip(),
+                )
+            else:
+                self.logger.info("📨 Label printed")
+        except Exception as exc:
+            self.logger.error("Błąd drukowania: %s", exc)
+
+    def print_test_page(self) -> bool:
+        try:
+            file_path = "/tmp/print_test.txt"
+            with open(file_path, "w", encoding="utf-8") as handle:
+                handle.write("=== TEST PRINT ===\n")
+            result = subprocess.run(
+                ["lp", "-d", self.config.printer_name, file_path],
+                capture_output=True,
+                check=False,
+            )
+            os.remove(file_path)
+            if result.returncode != 0:
+                self.logger.error(
+                    "Błąd testowego druku (kod %s): %s",
+                    result.returncode,
+                    result.stderr.decode().strip(),
+                )
+                return False
+            self.logger.info("🔧 Testowa strona została wysłana do drukarki.")
+            return True
+        except Exception as exc:
+            self.logger.error("Błąd testowego druku: %s", exc)
             return False
-        logger.info("🔧 Testowa strona została wysłana do drukarki.")
+
+    def send_messenger_message(self, data: Dict[str, Any]) -> None:
+        try:
+            message = (
+                f"📦 Nowe zamówienie od: {data.get('customer', '-')}\n"
+                f"🛒 Produkty:\n"
+                + "".join(
+                    f"- {shorten_product_name(p['name'])} (x{p['quantity']})\n"
+                    for p in data.get("products", [])
+                )
+                + f"🚚 Wysyłka: {data.get('shipping', '-')}\n"
+                f"🚛 Kurier: {data.get('courier_code', '-')}\n"
+                f"🌐 Platforma: {data.get('platform', '-')}\n"
+                f"📎 ID: {data.get('order_id', '-')}"
+            )
+
+            response = requests.post(
+                "https://graph.facebook.com/v17.0/me/messages",
+                headers={
+                    "Authorization": f"Bearer {self.config.page_access_token}",
+                    "Content-Type": "application/json",
+                },
+                data=json.dumps(
+                    {
+                        "recipient": {"id": self.config.recipient_id},
+                        "message": {"text": message},
+                    }
+                ),
+                timeout=10,
+            )
+            response.raise_for_status()
+        except Exception as exc:
+            self.logger.error("Błąd wysyłania wiadomości: %s", exc)
+
+    # ------------------------------------------------------------------
+    # Agent loop
+    # ------------------------------------------------------------------
+    def is_quiet_time(self) -> bool:
+        now = datetime.now(ZoneInfo(self.config.timezone)).time()
+        start = self.config.quiet_hours_start
+        end = self.config.quiet_hours_end
+        if start <= end:
+            return start <= now < end
+        return now >= start or now < end
+
+    def _send_periodic_reports(self) -> None:
+        now = datetime.now()
+        if self.config.enable_weekly_reports and (
+            not hasattr(self, "_last_weekly_report")
+            or not self._last_weekly_report
+            or now - self._last_weekly_report >= timedelta(days=7)
+        ):
+            report = get_sales_summary(7)
+            lines = [
+                f"- {r['name']} {r['size']}: sprzedano {r['sold']}, zostalo {r['remaining']}"
+                for r in report
+            ]
+            send_report("Raport tygodniowy", lines)
+            self._last_weekly_report = now
+        if self.config.enable_monthly_reports and (
+            not hasattr(self, "_last_monthly_report")
+            or not self._last_monthly_report
+            or now - self._last_monthly_report >= timedelta(days=30)
+        ):
+            report = get_sales_summary(30)
+            lines = [
+                f"- {r['name']} {r['size']}: sprzedano {r['sold']}, zostalo {r['remaining']}"
+                for r in report
+            ]
+            send_report("Raport miesieczny", lines)
+            self._last_monthly_report = now
+
+    def _process_queue(self, queue: List[Dict[str, Any]], printed: Dict[str, Any]) -> List[Dict[str, Any]]:
+        if self.is_quiet_time():
+            return queue
+        grouped: Dict[str, List[Dict[str, Any]]] = {}
+        for item in queue:
+            grouped.setdefault(item["order_id"], []).append(item)
+
+        new_queue: List[Dict[str, Any]] = []
+        for oid, items in grouped.items():
+            try:
+                for it in items:
+                    self.print_label(it["label_data"], it.get("ext", "pdf"), it["order_id"])
+                consume_order_stock(items[0].get("last_order_data", {}).get("products", []))
+                self.mark_as_printed(oid, items[0].get("last_order_data"))
+                printed[oid] = datetime.now()
+            except Exception as exc:
+                self.logger.error("Błąd przetwarzania z kolejki: %s", exc)
+                new_queue.extend(items)
+        return new_queue
+
+    def _agent_loop(self) -> None:
+        while not self._stop_event.is_set():
+            self._send_periodic_reports()
+            self.clean_old_printed_orders()
+            printed_entries = self.load_printed_orders()
+            printed = {entry["order_id"]: entry["printed_at"] for entry in printed_entries}
+            queue = self.load_queue()
+
+            queue = self._process_queue(queue, printed)
+            self.save_queue(queue)
+
+            try:
+                orders = self.get_orders()
+                for order in orders:
+                    order_id = str(order["order_id"])
+                    prod_name, size, color = parse_product_info(
+                        (order.get("products") or [{}])[0]
+                    )
+                    self.last_order_data = {
+                        "order_id": order_id,
+                        "name": prod_name,
+                        "size": size,
+                        "color": color,
+                        "customer": order.get("delivery_fullname", "Nieznany klient"),
+                        "platform": order.get("order_source", "brak"),
+                        "shipping": order.get("delivery_method", "brak"),
+                        "products": order.get("products", []),
+                        "courier_code": "",
+                    }
+
+                    if order_id in printed:
+                        continue
+
+                    packages = self.get_order_packages(order_id)
+                    labels: List[Tuple[str, str]] = []
+                    courier_code = ""
+
+                    for package in packages:
+                        package_id = package.get("package_id")
+                        code = package.get("courier_code")
+                        if code and not courier_code:
+                            courier_code = code
+                        if not package_id or not code:
+                            self.logger.warning("  Brak danych: package_id lub courier_code")
+                            continue
+                        label_data, ext = self.get_label(courier_code, package_id)
+                        if label_data:
+                            labels.append((label_data, ext))
+
+                    if courier_code:
+                        self.last_order_data["courier_code"] = courier_code
+
+                    if labels:
+                        if self.is_quiet_time():
+                            for label_data, ext in labels:
+                                queue.append(
+                                    {
+                                        "order_id": order_id,
+                                        "label_data": label_data,
+                                        "ext": ext,
+                                        "last_order_data": self.last_order_data,
+                                    }
+                                )
+                            self.send_messenger_message(self.last_order_data)
+                            self.mark_as_printed(order_id, self.last_order_data)
+                            printed[order_id] = datetime.now()
+                        else:
+                            for label_data, ext in labels:
+                                self.print_label(label_data, ext, order_id)
+                            consume_order_stock(self.last_order_data.get("products", []))
+                            self.send_messenger_message(self.last_order_data)
+                            self.mark_as_printed(order_id, self.last_order_data)
+                            printed[order_id] = datetime.now()
+            except Exception as exc:
+                self.logger.error("[BŁĄD GŁÓWNY] %s", exc)
+
+            self.save_queue(queue)
+            self._stop_event.wait(self.config.poll_interval)
+
+    def start_agent_thread(self) -> bool:
+        if self._agent_thread and self._agent_thread.is_alive():
+            return False
+        if self._lock_handle is None:
+            try:
+                self._lock_handle = open(self.config.lock_file, "w")
+                fcntl.flock(self._lock_handle, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            except OSError:
+                if self._lock_handle:
+                    self._lock_handle.close()
+                    self._lock_handle = None
+                self.logger.info("Print agent already running, skipping startup")
+                return False
+        self._stop_event = threading.Event()
+        self._agent_thread = threading.Thread(target=self._agent_loop, daemon=True)
+        self._agent_thread.start()
         return True
-    except Exception as e:
-        logger.error(f"Błąd testowego druku: {e}")
-        return False
+
+    def stop_agent_thread(self) -> None:
+        if self._agent_thread and self._agent_thread.is_alive():
+            self._stop_event.set()
+            self._agent_thread.join()
+            self._agent_thread = None
+        if self._lock_handle:
+            try:
+                fcntl.flock(self._lock_handle, fcntl.LOCK_UN)
+            except OSError:  # pragma: no cover - defensive
+                pass
+            self._lock_handle.close()
+            self._lock_handle = None
+            try:
+                os.remove(self.config.lock_file)
+            except OSError:
+                pass
 
 
-def shorten_product_name(full_name):
+def shorten_product_name(full_name: str) -> str:
     words = full_name.strip().split()
     if len(words) >= 3:
         return f"{words[0]} {' '.join(words[-2:])}"
     return full_name
 
 
+# Instantiate default agent used throughout the application.
+agent = LabelAgent(AgentConfig.from_settings(settings), settings)
+logger = agent.logger
 
 
-def send_messenger_message(data):
-    try:
-        message = (
-            f"📦 Nowe zamówienie od: {data.get('customer', '-')}\n"
-            f"🛒 Produkty:\n"
-            + "".join(
-                f"- {shorten_product_name(p['name'])} (x{p['quantity']})\n"
-                for p in data.get("products", [])
-            )
-            + f"🚚 Wysyłka: {data.get('shipping', '-')}\n"
-            f"🚛 Kurier: {data.get('courier_code', '-')}\n"
-            f"🌐 Platforma: {data.get('platform', '-')}\n"
-            f"📎 ID: {data.get('order_id', '-')}"
-        )
-
-        response = requests.post(
-            "https://graph.facebook.com/v17.0/me/messages",
-            headers={
-                "Authorization": f"Bearer {PAGE_ACCESS_TOKEN}",
-                "Content-Type": "application/json",
-            },
-            data=json.dumps(
-                {
-                    "recipient": {"id": RECIPIENT_ID},
-                    "message": {"text": message},
-                }
-            ),
-        )
-        logger.info(
-            "📬 Messenger response: %s %s", response.status_code, response.text
-        )
-        response.raise_for_status()
-        logger.info("✅ Wiadomość została wysłana przez Messengera.")
-    except Exception as e:
-        logger.error(f"Błąd wysyłania wiadomości: {e}")
+def __getattr__(name: str) -> Any:
+    if hasattr(agent, name):
+        return getattr(agent, name)
+    lower_name = name.lower()
+    if hasattr(agent.config, lower_name):
+        return getattr(agent.config, lower_name)
+    raise AttributeError(name)
 
 
-def is_quiet_time():
-    now = datetime.now(ZoneInfo(TIMEZONE)).time()
-    start = QUIET_HOURS_START
-    end = QUIET_HOURS_END
-    if start <= end:
-        return start <= now < end
-    else:
-        return now >= start or now < end
-
-
-def _send_periodic_reports():
-    global _last_weekly_report, _last_monthly_report
-    now = datetime.now()
-    if ENABLE_WEEKLY_REPORTS and (
-        not _last_weekly_report or now - _last_weekly_report >= timedelta(days=7)
-    ):
-        report = get_sales_summary(7)
-        lines = [
-            f"- {r['name']} {r['size']}: sprzedano {r['sold']}, zostalo {r['remaining']}"
-            for r in report
-        ]
-        send_report("Raport tygodniowy", lines)
-        _last_weekly_report = now
-    if ENABLE_MONTHLY_REPORTS and (
-        not _last_monthly_report or now - _last_monthly_report >= timedelta(days=30)
-    ):
-        report = get_sales_summary(30)
-        lines = [
-            f"- {r['name']} {r['size']}: sprzedano {r['sold']}, zostalo {r['remaining']}"
-            for r in report
-        ]
-        send_report("Raport miesieczny", lines)
-        _last_monthly_report = now
-
-
-def _agent_loop():
-    while not _stop_event.is_set():
-        _send_periodic_reports()
-        clean_old_printed_orders()
-        printed_entries = load_printed_orders()
-        printed = {e["order_id"]: e["printed_at"] for e in printed_entries}
-        queue = load_queue()
-
-        if not is_quiet_time():
-            grouped = {}
-            for item in queue:
-                grouped.setdefault(item["order_id"], []).append(item)
-
-            new_queue = []
-            for oid, items in grouped.items():
-                try:
-                    for it in items:
-                        print_label(
-                            it["label_data"],
-                            it.get("ext", "pdf"),
-                            it["order_id"],
-                        )
-                    consume_order_stock(
-                        items[0].get("last_order_data", {}).get("products", [])
-                    )
-                    mark_as_printed(oid, items[0].get("last_order_data"))
-                    printed[oid] = datetime.now()
-                except Exception as e:
-                    logger.error(f"Błąd przetwarzania z kolejki: {e}")
-                    new_queue.extend(items)
-
-            queue = new_queue
-            save_queue(queue)
-
-        try:
-            orders = get_orders()
-            for order in orders:
-                order_id = str(order["order_id"])
-
-                global last_order_data
-                prod_name, size, color = parse_product_info(
-                    (order.get("products") or [{}])[0]
-                )
-                last_order_data = {
-                    "order_id": order_id,
-                    "name": prod_name,
-                    "size": size,
-                    "color": color,
-                    "customer": order.get("delivery_fullname", "Nieznany klient"),
-                    "platform": order.get("order_source", "brak"),
-                    "shipping": order.get("delivery_method", "brak"),
-                    "products": order.get("products", []),
-                    "courier_code": "",
-                }
-
-                if order_id in printed:
-                    continue
-
-                # Skip logging order details to avoid sensitive data in logs
-                packages = get_order_packages(order_id)
-                labels = []
-                courier_code = ""
-
-                for p in packages:
-                    package_id = p.get("package_id")
-                    code = p.get("courier_code")
-                    if code and not courier_code:
-                        courier_code = code
-                    if not package_id or not code:
-                        logger.warning(
-                            "  Brak danych: package_id lub courier_code"
-                        )
-                        continue
-
-                    # Avoid logging package identifiers
-
-                    label_data, ext = get_label(courier_code, package_id)
-                    if label_data:
-                        labels.append((label_data, ext))
-                    else:
-                        # Missing label data
-                        pass
-
-                if courier_code:
-                    last_order_data["courier_code"] = courier_code
-
-                if labels:
-                    if is_quiet_time():
-                        # Quiet hours: postpone printing
-                        for label_data, ext in labels:
-                            queue.append(
-                                {
-                                    "order_id": order_id,
-                                    "label_data": label_data,
-                                    "ext": ext,
-                                    "last_order_data": last_order_data,
-                                }
-                            )
-                        send_messenger_message(last_order_data)
-                        mark_as_printed(order_id, last_order_data)
-                        printed[order_id] = datetime.now()
-                    else:
-                        for label_data, ext in labels:
-                            print_label(label_data, ext, order_id)
-                        consume_order_stock(
-                            last_order_data.get("products", [])
-                        )
-                        send_messenger_message(last_order_data)
-                        mark_as_printed(order_id, last_order_data)
-                        printed[order_id] = datetime.now()
-
-        except Exception as e:
-            logger.error(f"[BŁĄD GŁÓWNY] {e}")
-
-        save_queue(queue)
-        _stop_event.wait(POLL_INTERVAL)
-
-
-def start_agent_thread():
-    """Start the background agent if not already running.
-
-    Returns ``True`` when a new thread was started and ``False`` otherwise.
-    """
-    global _agent_thread, _stop_event, _lock_handle
-    if _agent_thread and _agent_thread.is_alive():
-        return False
-    if _lock_handle is None:
-        try:
-            _lock_handle = open(LOCK_FILE, "w")
-            fcntl.flock(_lock_handle, fcntl.LOCK_EX | fcntl.LOCK_NB)
-        except OSError:
-            if _lock_handle:
-                _lock_handle.close()
-                _lock_handle = None
-            logger.info("Print agent already running, skipping startup")
-            return False
-    _stop_event = threading.Event()
-    _agent_thread = threading.Thread(target=_agent_loop, daemon=True)
-    _agent_thread.start()
-    return True
-
-
-def stop_agent_thread():
-    """Signal the agent loop to stop and release the lock."""
-    global _agent_thread, _lock_handle
-    if _agent_thread and _agent_thread.is_alive():
-        _stop_event.set()
-        _agent_thread.join()
-        _agent_thread = None
-    if _lock_handle:
-        try:
-            fcntl.flock(_lock_handle, fcntl.LOCK_UN)
-        except OSError:
-            pass
-        _lock_handle.close()
-        _lock_handle = None
-        try:
-            os.remove(LOCK_FILE)
-        except OSError:
-            pass
+__all__ = [
+    "AgentConfig",
+    "LabelAgent",
+    "ConfigError",
+    "agent",
+    "logger",
+    "parse_time_str",
+    "shorten_product_name",
+]

--- a/magazyn/services.py
+++ b/magazyn/services.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 """Backward compatibility layer for legacy service imports."""
 
+from pypdf import PdfReader
+
 from .db import consume_stock, get_session, record_purchase, record_sale
 from .models import Product, ProductSize, PurchaseBatch, Sale
 from .domain.inventory import (
@@ -59,6 +61,7 @@ __all__ = [
     "_parse_pdf",
     "_parse_simple_pdf",
     "_parse_tiptop_invoice",
+    "PdfReader",
     "_to_decimal",
     "_to_int",
     "Product",

--- a/magazyn/tests/test_agent_thread.py
+++ b/magazyn/tests/test_agent_thread.py
@@ -5,16 +5,17 @@ import magazyn.print_agent as pa
 
 
 def test_stop_agent_thread_stops(monkeypatch):
+    agent = pa.agent
     started = threading.Event()
 
     def loop():
         started.set()
-        while not pa._stop_event.is_set():
+        while not agent._stop_event.is_set():
             time.sleep(0.01)
 
-    monkeypatch.setattr(pa, "_agent_loop", loop)
-    pa.start_agent_thread()
+    monkeypatch.setattr(agent, "_agent_loop", loop)
+    agent.start_agent_thread()
     assert started.wait(1)
-    assert pa._agent_thread.is_alive()
-    pa.stop_agent_thread()
-    assert pa._agent_thread is None or not pa._agent_thread.is_alive()
+    assert agent._agent_thread.is_alive()
+    agent.stop_agent_thread()
+    assert agent._agent_thread is None or not agent._agent_thread.is_alive()

--- a/magazyn/tests/test_courier_code.py
+++ b/magazyn/tests/test_courier_code.py
@@ -4,27 +4,28 @@ import magazyn.print_agent as pa
 
 def test_agent_loop_stores_courier_code(monkeypatch):
     mod = importlib.reload(pa)
+    agent = mod.agent
 
-    monkeypatch.setattr(mod, "_send_periodic_reports", lambda: None)
-    monkeypatch.setattr(mod, "clean_old_printed_orders", lambda: None)
-    monkeypatch.setattr(mod, "load_printed_orders", lambda: [])
-    monkeypatch.setattr(mod, "load_queue", lambda: [])
-    monkeypatch.setattr(mod, "save_queue", lambda q: None)
-    monkeypatch.setattr(mod, "is_quiet_time", lambda: False)
+    monkeypatch.setattr(agent, "_send_periodic_reports", lambda: None)
+    monkeypatch.setattr(agent, "clean_old_printed_orders", lambda: None)
+    monkeypatch.setattr(agent, "load_printed_orders", lambda: [])
+    monkeypatch.setattr(agent, "load_queue", lambda: [])
+    monkeypatch.setattr(agent, "save_queue", lambda q: None)
+    monkeypatch.setattr(agent, "is_quiet_time", lambda: False)
     monkeypatch.setattr(mod, "consume_order_stock", lambda p: None)
     monkeypatch.setattr(
-        mod,
+        agent,
         "print_label",
         lambda d, e, o: None,
     )
 
     captured = {}
-    monkeypatch.setattr(mod, "mark_as_printed", lambda oid, data=None: captured.setdefault("marked", data))
-    monkeypatch.setattr(mod, "send_messenger_message", lambda data: captured.setdefault("mess", data))
+    monkeypatch.setattr(agent, "mark_as_printed", lambda oid, data=None: captured.setdefault("marked", data))
+    monkeypatch.setattr(agent, "send_messenger_message", lambda data: captured.setdefault("mess", data))
 
-    monkeypatch.setattr(mod, "get_orders", lambda: [{"order_id": 1, "products": [{"name": "Prod", "quantity": 1}]}])
-    monkeypatch.setattr(mod, "get_order_packages", lambda oid: [{"package_id": "p1", "courier_code": "DHL"}])
-    monkeypatch.setattr(mod, "get_label", lambda code, pid: ("data", "pdf"))
+    monkeypatch.setattr(agent, "get_orders", lambda: [{"order_id": 1, "products": [{"name": "Prod", "quantity": 1}]}])
+    monkeypatch.setattr(agent, "get_order_packages", lambda oid: [{"package_id": "p1", "courier_code": "DHL"}])
+    monkeypatch.setattr(agent, "get_label", lambda code, pid: ("data", "pdf"))
 
     class Stopper:
         def __init__(self):
@@ -35,11 +36,11 @@ def test_agent_loop_stores_courier_code(monkeypatch):
 
         def wait(self, t):
             self.calls += 1
-    mod._stop_event = Stopper()
-    mod.POLL_INTERVAL = 0
+    agent._stop_event = Stopper()
+    agent.config = agent.config.with_updates(poll_interval=0)
 
-    mod._agent_loop()
+    agent._agent_loop()
 
-    assert mod.last_order_data.get("courier_code") == "DHL"
+    assert agent.last_order_data.get("courier_code") == "DHL"
     assert captured["mess"].get("courier_code") == "DHL"
     assert captured["marked"].get("courier_code") == "DHL"

--- a/magazyn/tests/test_pdf_tiptop.py
+++ b/magazyn/tests/test_pdf_tiptop.py
@@ -42,7 +42,9 @@ def _run_fake_pdf(texts, monkeypatch):
         def __init__(self, *_args, **_kwargs):
             self.pages = [FakePage(t) for t in texts]
 
-    monkeypatch.setattr(services, "PdfReader", FakePdfReader)
+    from magazyn.domain import invoice_import
+
+    monkeypatch.setattr(invoice_import, "PdfReader", FakePdfReader)
     return _parse_pdf(io.BytesIO(b"dummy"))
 
 

--- a/magazyn/tests/test_weekly_reports.py
+++ b/magazyn/tests/test_weekly_reports.py
@@ -2,11 +2,14 @@ import magazyn.print_agent as pa
 
 
 def test_weekly_report_not_sent_when_disabled(monkeypatch):
-    monkeypatch.setattr(pa, "ENABLE_WEEKLY_REPORTS", False)
-    monkeypatch.setattr(pa, "ENABLE_MONTHLY_REPORTS", False)
+    agent = pa.agent
+    agent.config = agent.config.with_updates(
+        enable_weekly_reports=False,
+        enable_monthly_reports=False,
+    )
     monkeypatch.setattr(pa, "get_sales_summary", lambda *a, **k: [])
     calls = []
     monkeypatch.setattr(pa, "send_report", lambda *a, **k: calls.append(a))
-    pa._last_weekly_report = None
-    pa._send_periodic_reports()
+    agent._last_weekly_report = None
+    agent._send_periodic_reports()
     assert calls == []


### PR DESCRIPTION
## Summary
- replace global print agent state with an AgentConfig dataclass and LabelAgent instance while keeping backwards compatible helpers
- add a magazyn.agent.migrate CLI to migrate legacy printed order and label data on demand
- update the Flask app and agent-focused tests to work with the class-based agent implementation

## Testing
- PYTHONPATH=. pytest magazyn/tests

------
https://chatgpt.com/codex/tasks/task_e_68cfddf6d5e8832a9c608ca0a8edf8bd