### PR TITLE
Add schema migration registry and tests

### DIFF
--- a/magazyn/app.py
+++ b/magazyn/app.py
@@ -24,7 +24,6 @@ from .db import (
     get_session,
     init_db,
     reset_db,
-    ensure_schema,
     register_default_user,
     record_purchase,
     consume_stock,
@@ -175,7 +174,6 @@ def ensure_db_initialized(app_obj=None):
 
         # Always run table creation so new tables appear automatically.
         init_db()
-        ensure_schema()
         register_default_user()
     except Exception as e:
         logger = (app_obj or current_app).logger

--- a/magazyn/migrations/add_barcode_to_product_sizes.py
+++ b/magazyn/migrations/add_barcode_to_product_sizes.py
@@ -14,6 +14,12 @@ def migrate():
         else:
             print("barcode column already exists")
 
+        cur.execute(
+            "CREATE UNIQUE INDEX IF NOT EXISTS idx_product_sizes_barcode "
+            "ON product_sizes(barcode)"
+        )
+        conn.commit()
+
 
 if __name__ == "__main__":
     migrate()

--- a/magazyn/migrations/add_sales_cost_columns.py
+++ b/magazyn/migrations/add_sales_cost_columns.py
@@ -1,0 +1,34 @@
+import sqlite3
+
+from magazyn import DB_PATH
+
+
+COLUMNS = {
+    "purchase_cost": "NUMERIC(10,2) DEFAULT 0.0 NOT NULL",
+    "sale_price": "NUMERIC(10,2) DEFAULT 0.0 NOT NULL",
+    "shipping_cost": "NUMERIC(10,2) DEFAULT 0.0 NOT NULL",
+    "commission_fee": "NUMERIC(10,2) DEFAULT 0.0 NOT NULL",
+}
+
+
+def migrate():
+    with sqlite3.connect(DB_PATH) as conn:
+        cur = conn.cursor()
+        cur.execute("PRAGMA table_info(sales)")
+        existing = {row[1] for row in cur.fetchall()}
+        changed = False
+
+        for column, definition in COLUMNS.items():
+            if column not in existing:
+                cur.execute(f"ALTER TABLE sales ADD COLUMN {column} {definition}")
+                changed = True
+
+        if changed:
+            conn.commit()
+            print("Added missing financial columns to sales")
+        else:
+            print("Sales table already contains financial columns")
+
+
+if __name__ == "__main__":
+    migrate()

--- a/magazyn/migrations/create_shipping_thresholds_table.py
+++ b/magazyn/migrations/create_shipping_thresholds_table.py
@@ -1,0 +1,30 @@
+import sqlite3
+
+from magazyn import DB_PATH
+
+
+def migrate():
+    with sqlite3.connect(DB_PATH) as conn:
+        cur = conn.cursor()
+        cur.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='shipping_thresholds'"
+        )
+        if cur.fetchone():
+            print("shipping_thresholds table already exists")
+            return
+
+        cur.execute(
+            """
+            CREATE TABLE shipping_thresholds (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                min_order_value REAL NOT NULL,
+                shipping_cost NUMERIC(10,2) NOT NULL
+            )
+            """
+        )
+        conn.commit()
+        print("Created shipping_thresholds table")
+
+
+if __name__ == "__main__":
+    migrate()

--- a/magazyn/tests/test_migrations.py
+++ b/magazyn/tests/test_migrations.py
@@ -1,0 +1,115 @@
+import importlib
+import sqlite3
+
+import magazyn.config as cfg
+
+
+def _prepare_db(tmp_path, monkeypatch):
+    db_path = tmp_path / "test.db"
+    monkeypatch.setattr(cfg.settings, "DB_PATH", str(db_path))
+
+    pkg = importlib.import_module("magazyn")
+    importlib.reload(pkg)
+
+    db_mod = importlib.import_module("magazyn.db")
+    db = importlib.reload(db_mod)
+    db.configure_engine(cfg.settings.DB_PATH)
+    return db, db_path
+
+
+def test_apply_migrations_records_executions(tmp_path, monkeypatch):
+    db, db_path = _prepare_db(tmp_path, monkeypatch)
+
+    migrations_dir = tmp_path / "migrations"
+    migrations_dir.mkdir()
+
+    first = migrations_dir / "001_create_demo.py"
+    first.write_text(
+        """
+import sqlite3
+from magazyn import DB_PATH
+
+
+def migrate():
+    with sqlite3.connect(DB_PATH) as conn:
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS demo_entries (id INTEGER PRIMARY KEY, note TEXT)"
+        )
+        conn.execute("INSERT INTO demo_entries (note) VALUES ('first')")
+        conn.commit()
+"""
+    )
+
+    second = migrations_dir / "002_append_demo.py"
+    second.write_text(
+        """
+import sqlite3
+from magazyn import DB_PATH
+
+
+def migrate():
+    with sqlite3.connect(DB_PATH) as conn:
+        conn.execute("INSERT INTO demo_entries (note) VALUES ('second')")
+        conn.commit()
+"""
+    )
+
+    monkeypatch.setattr(db, "MIGRATIONS_DIR", migrations_dir)
+
+    db.init_db()
+
+    with sqlite3.connect(db_path) as conn:
+        cur = conn.execute(
+            "SELECT filename FROM schema_migrations ORDER BY filename"
+        )
+        applied = [row[0] for row in cur.fetchall()]
+        demo_entries = conn.execute(
+            "SELECT note FROM demo_entries ORDER BY id"
+        ).fetchall()
+
+    assert applied == ["001_create_demo.py", "002_append_demo.py"]
+    assert [row[0] for row in demo_entries] == ["first", "second"]
+
+
+def test_apply_migrations_skip_already_applied(tmp_path, monkeypatch):
+    db, db_path = _prepare_db(tmp_path, monkeypatch)
+
+    migrations_dir = tmp_path / "migrations"
+    migrations_dir.mkdir()
+
+    (migrations_dir / "001_single_run.py").write_text(
+        """
+import sqlite3
+from magazyn import DB_PATH
+
+
+def migrate():
+    with sqlite3.connect(DB_PATH) as conn:
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS run_guard (id INTEGER PRIMARY KEY)"
+        )
+        cur = conn.execute("SELECT COUNT(*) FROM run_guard")
+        if cur.fetchone()[0]:
+            raise RuntimeError("migration executed twice")
+        conn.execute("INSERT INTO run_guard DEFAULT VALUES")
+        conn.commit()
+"""
+    )
+
+    monkeypatch.setattr(db, "MIGRATIONS_DIR", migrations_dir)
+
+    db.init_db()
+
+    with sqlite3.connect(db_path) as conn:
+        initial = conn.execute(
+            "SELECT filename, applied_at FROM schema_migrations"
+        ).fetchall()
+
+    db.init_db()
+
+    with sqlite3.connect(db_path) as conn:
+        final = conn.execute(
+            "SELECT filename, applied_at FROM schema_migrations"
+        ).fetchall()
+
+    assert final == initial


### PR DESCRIPTION
## Summary
- add a schema_migrations registry that prevents rerunning applied migration scripts
- migrate legacy ensure_schema logic into dedicated migration files
- cover migration tracking with unit tests that exercise new and repeated runs

## Testing
- PYTHONPATH=. pytest magazyn/tests/test_migrations.py

------
https://chatgpt.com/codex/tasks/task_e_68cfe6e99d58832abf97ee9aa6e18ebb