### PR TITLE
Configure SQLite connections consistently

### DIFF
--- a/magazyn/agent/migrate.py
+++ b/magazyn/agent/migrate.py
@@ -5,10 +5,10 @@ from __future__ import annotations
 import argparse
 import json
 import logging
-import sqlite3
 from pathlib import Path
 from typing import Iterable, Optional
 
+from magazyn.db import sqlite_connect
 from magazyn.print_agent import AgentConfig, LabelAgent, load_config
 
 LOGGER = logging.getLogger(__name__)
@@ -18,7 +18,7 @@ def migrate_printed_file(db_path: str, printed_file: Path) -> None:
     if not printed_file.exists():
         LOGGER.info("Printed orders file %s not found, skipping", printed_file)
         return
-    conn = sqlite3.connect(db_path)
+    conn = sqlite_connect(db_path)
     cur = conn.cursor()
     cur.execute("SELECT COUNT(*) FROM printed_orders")
     if cur.fetchone()[0]:
@@ -44,7 +44,7 @@ def migrate_queue_file(db_path: str, queue_file: Path) -> None:
     if not queue_file.exists():
         LOGGER.info("Queued labels file %s not found, skipping", queue_file)
         return
-    conn = sqlite3.connect(db_path)
+    conn = sqlite_connect(db_path)
     cur = conn.cursor()
     cur.execute("SELECT COUNT(*) FROM label_queue")
     if cur.fetchone()[0]:
@@ -79,9 +79,9 @@ def migrate_from_legacy_db(db_path: str, legacy_db: Path) -> None:
     if not legacy_db.exists():
         LOGGER.info("Legacy database %s not found, skipping", legacy_db)
         return
-    conn = sqlite3.connect(db_path)
+    conn = sqlite_connect(db_path)
     cur = conn.cursor()
-    old_conn = sqlite3.connect(legacy_db)
+    old_conn = sqlite_connect(legacy_db)
     old_cur = old_conn.cursor()
     try:
         for table, columns in (("printed_orders", 3), ("label_queue", 4)):

--- a/magazyn/migrations/add_barcode_to_product_sizes.py
+++ b/magazyn/migrations/add_barcode_to_product_sizes.py
@@ -1,9 +1,9 @@
-import sqlite3
 from magazyn import DB_PATH
+from magazyn.db import sqlite_connect
 
 
 def migrate():
-    with sqlite3.connect(DB_PATH) as conn:
+    with sqlite_connect(DB_PATH) as conn:
         cur = conn.cursor()
         cur.execute("PRAGMA table_info(product_sizes)")
         cols = [row[1] for row in cur.fetchall()]

--- a/magazyn/migrations/add_sales_cost_columns.py
+++ b/magazyn/migrations/add_sales_cost_columns.py
@@ -1,6 +1,5 @@
-import sqlite3
-
 from magazyn import DB_PATH
+from magazyn.db import sqlite_connect
 
 
 COLUMNS = {
@@ -12,7 +11,7 @@ COLUMNS = {
 
 
 def migrate():
-    with sqlite3.connect(DB_PATH) as conn:
+    with sqlite_connect(DB_PATH) as conn:
         cur = conn.cursor()
         cur.execute("PRAGMA table_info(sales)")
         existing = {row[1] for row in cur.fetchall()}

--- a/magazyn/migrations/allow_null_product_in_allegro_offers.py
+++ b/magazyn/migrations/allow_null_product_in_allegro_offers.py
@@ -1,10 +1,9 @@
-import sqlite3
-
 from magazyn import DB_PATH
+from magazyn.db import sqlite_connect
 
 
 def migrate():
-    with sqlite3.connect(DB_PATH) as conn:
+    with sqlite_connect(DB_PATH) as conn:
         cur = conn.cursor()
         cur.execute(
             "SELECT name FROM sqlite_master WHERE type='table' AND name='allegro_offers'"

--- a/magazyn/migrations/create_allegro_offers_table.py
+++ b/magazyn/migrations/create_allegro_offers_table.py
@@ -1,9 +1,9 @@
-import sqlite3
 from magazyn import DB_PATH
+from magazyn.db import sqlite_connect
 
 
 def migrate():
-    with sqlite3.connect(DB_PATH) as conn:
+    with sqlite_connect(DB_PATH) as conn:
         cur = conn.cursor()
         cur.execute(
             "SELECT name FROM sqlite_master WHERE type='table' AND name='allegro_offers'"

--- a/magazyn/migrations/create_shipping_thresholds_table.py
+++ b/magazyn/migrations/create_shipping_thresholds_table.py
@@ -1,10 +1,9 @@
-import sqlite3
-
 from magazyn import DB_PATH
+from magazyn.db import sqlite_connect
 
 
 def migrate():
-    with sqlite3.connect(DB_PATH) as conn:
+    with sqlite_connect(DB_PATH) as conn:
         cur = conn.cursor()
         cur.execute(
             "SELECT name FROM sqlite_master WHERE type='table' AND name='shipping_thresholds'"

--- a/magazyn/migrations/price_to_numeric.py
+++ b/magazyn/migrations/price_to_numeric.py
@@ -1,5 +1,5 @@
-import sqlite3
 from magazyn import DB_PATH
+from magazyn.db import sqlite_connect
 
 
 def _needs_numeric(cur, table, column):
@@ -10,7 +10,7 @@ def _needs_numeric(cur, table, column):
 
 
 def migrate():
-    with sqlite3.connect(DB_PATH) as conn:
+    with sqlite_connect(DB_PATH) as conn:
         cur = conn.cursor()
 
         if _needs_numeric(cur, "purchase_batches", "price"):

--- a/magazyn/migrations/remove_barcode_from_products.py
+++ b/magazyn/migrations/remove_barcode_from_products.py
@@ -1,9 +1,9 @@
-import sqlite3
 from magazyn import DB_PATH
+from magazyn.db import sqlite_connect
 
 
 def migrate():
-    with sqlite3.connect(DB_PATH) as conn:
+    with sqlite_connect(DB_PATH) as conn:
         cur = conn.cursor()
         cur.execute("PRAGMA table_info(products)")
         cols = [row[1] for row in cur.fetchall()]

--- a/magazyn/tests/test_db.py
+++ b/magazyn/tests/test_db.py
@@ -1,0 +1,26 @@
+import magazyn.db as db
+from magazyn.db import sqlite_connect
+
+
+def test_configure_engine_enables_wal_mode(tmp_path, monkeypatch):
+    original_engine = db.engine
+    original_session_local = db.SessionLocal
+    test_db = tmp_path / "wal.db"
+
+    try:
+        monkeypatch.setattr(db, "apply_migrations", lambda: None)
+        db.configure_engine(str(test_db))
+        db.init_db()
+
+        with db.engine.connect() as conn:
+            journal_mode = conn.exec_driver_sql("PRAGMA journal_mode").scalar_one()
+        assert journal_mode.lower() == "wal"
+
+        with sqlite_connect(test_db) as raw_conn:
+            raw_mode = raw_conn.execute("PRAGMA journal_mode").fetchone()[0]
+        assert raw_mode.lower() == "wal"
+    finally:
+        if db.engine is not None and db.engine is not original_engine:
+            db.engine.dispose()
+        db.engine = original_engine
+        db.SessionLocal = original_session_local

--- a/magazyn/tests/test_db_config.py
+++ b/magazyn/tests/test_db_config.py
@@ -1,10 +1,10 @@
-import sqlite3
 from types import SimpleNamespace
 from werkzeug.security import generate_password_hash
 
 import magazyn.db as db
 import magazyn.print_agent as pa
 from magazyn.models import User
+from magazyn.db import sqlite_connect
 
 
 def test_reload_env_reconfigures_engine(tmp_path, monkeypatch):
@@ -26,8 +26,8 @@ def test_reload_env_reconfigures_engine(tmp_path, monkeypatch):
     with db.get_session() as session:
         session.add(User(username="u2", password=generate_password_hash("p")))
 
-    conn1 = sqlite3.connect(first)
-    conn2 = sqlite3.connect(second)
+    conn1 = sqlite_connect(first)
+    conn2 = sqlite_connect(second)
     assert conn1.execute("SELECT username FROM users").fetchall() == [("u1",)]
     assert conn2.execute("SELECT username FROM users").fetchall() == [("u2",)]
     conn1.close()

--- a/magazyn/tests/test_migrations.py
+++ b/magazyn/tests/test_migrations.py
@@ -1,7 +1,7 @@
 import importlib
-import sqlite3
 
 import magazyn.config as cfg
+from magazyn.db import sqlite_connect
 
 
 def _prepare_db(tmp_path, monkeypatch):
@@ -26,12 +26,12 @@ def test_apply_migrations_records_executions(tmp_path, monkeypatch):
     first = migrations_dir / "001_create_demo.py"
     first.write_text(
         """
-import sqlite3
 from magazyn import DB_PATH
+from magazyn.db import sqlite_connect
 
 
 def migrate():
-    with sqlite3.connect(DB_PATH) as conn:
+    with sqlite_connect(DB_PATH) as conn:
         conn.execute(
             "CREATE TABLE IF NOT EXISTS demo_entries (id INTEGER PRIMARY KEY, note TEXT)"
         )
@@ -43,12 +43,12 @@ def migrate():
     second = migrations_dir / "002_append_demo.py"
     second.write_text(
         """
-import sqlite3
 from magazyn import DB_PATH
+from magazyn.db import sqlite_connect
 
 
 def migrate():
-    with sqlite3.connect(DB_PATH) as conn:
+    with sqlite_connect(DB_PATH) as conn:
         conn.execute("INSERT INTO demo_entries (note) VALUES ('second')")
         conn.commit()
 """
@@ -58,7 +58,7 @@ def migrate():
 
     db.init_db()
 
-    with sqlite3.connect(db_path) as conn:
+    with sqlite_connect(db_path) as conn:
         cur = conn.execute(
             "SELECT filename FROM schema_migrations ORDER BY filename"
         )
@@ -79,12 +79,12 @@ def test_apply_migrations_skip_already_applied(tmp_path, monkeypatch):
 
     (migrations_dir / "001_single_run.py").write_text(
         """
-import sqlite3
 from magazyn import DB_PATH
+from magazyn.db import sqlite_connect
 
 
 def migrate():
-    with sqlite3.connect(DB_PATH) as conn:
+    with sqlite_connect(DB_PATH) as conn:
         conn.execute(
             "CREATE TABLE IF NOT EXISTS run_guard (id INTEGER PRIMARY KEY)"
         )
@@ -100,14 +100,14 @@ def migrate():
 
     db.init_db()
 
-    with sqlite3.connect(db_path) as conn:
+    with sqlite_connect(db_path) as conn:
         initial = conn.execute(
             "SELECT filename, applied_at FROM schema_migrations"
         ).fetchall()
 
     db.init_db()
 
-    with sqlite3.connect(db_path) as conn:
+    with sqlite_connect(db_path) as conn:
         final = conn.execute(
             "SELECT filename, applied_at FROM schema_migrations"
         ).fetchall()

--- a/magazyn/tests/test_utils.py
+++ b/magazyn/tests/test_utils.py
@@ -1,6 +1,7 @@
 import json
-import sqlite3
 import pytest
+
+from magazyn.db import sqlite_connect
 
 
 def get_bl():
@@ -174,7 +175,7 @@ def test_load_queue_handles_corrupted_json(tmp_path, monkeypatch):
     agent.config = agent.config.with_updates(db_file=str(db))
     agent._configure_db_engine()
     agent.ensure_db()
-    conn = sqlite3.connect(db)
+    conn = sqlite_connect(db)
     cur = conn.cursor()
     cur.execute(
         "INSERT INTO label_queue(order_id, label_data, ext, last_order_data) VALUES (?,?,?,?)",
@@ -212,7 +213,7 @@ def test_ensure_db_migrates_wrong_name(tmp_path, monkeypatch):
     agent.config = agent.config.with_updates(db_file=str(db))
     agent._configure_db_engine()
     agent.ensure_db()
-    conn = sqlite3.connect(db)
+    conn = sqlite_connect(db)
     cur = conn.cursor()
     bad = {
         "name": "John Doe",


### PR DESCRIPTION
## Summary
- add a shared SQLite connection helper that applies WAL, busy timeout and foreign key pragmas
- update the SQLAlchemy engine, label agent utilities and migration scripts to reuse the new helper
- add regression coverage ensuring the database runs in WAL mode

## Testing
- PYTHONPATH=. pytest magazyn/tests

------
https://chatgpt.com/codex/tasks/task_e_68cfe93cbcb8832aa3e1a1a6c70ecdb8