### PR TITLE
Initialize agent and db during app creation

### DIFF
--- a/magazyn/factory.py
+++ b/magazyn/factory.py
@@ -56,8 +56,8 @@ def create_app(config: Optional[Mapping[str, Any]] = None) -> Flask:
                 rule
             )
 
-    app.before_first_request(lambda: ensure_db_initialized(app))
-    app.before_first_request(lambda: start_print_agent(app))
+    ensure_db_initialized(app)
+    start_print_agent(app)
 
     _register_shutdown_hook()
 

--- a/magazyn/tests/test_factory.py
+++ b/magazyn/tests/test_factory.py
@@ -1,0 +1,40 @@
+from magazyn.config import settings
+from magazyn import db as db_mod
+from magazyn import factory
+
+
+def test_create_app_initializes_agent_and_migrations(tmp_path, monkeypatch, request):
+    original_db_path = settings.DB_PATH
+    tmp_db_path = tmp_path / "app.db"
+    monkeypatch.setattr(settings, "DB_PATH", str(tmp_db_path))
+
+    db_mod.configure_engine(settings.DB_PATH)
+    request.addfinalizer(lambda: db_mod.configure_engine(original_db_path))
+
+    migrations_called = []
+
+    def fake_apply_migrations():
+        migrations_called.append(True)
+
+    monkeypatch.setattr(db_mod, "apply_migrations", fake_apply_migrations)
+
+    call_order = []
+    original_ensure = factory.ensure_db_initialized
+
+    def tracking_ensure(app_obj=None):
+        call_order.append(("ensure", app_obj))
+        original_ensure(app_obj)
+
+    monkeypatch.setattr(factory, "ensure_db_initialized", tracking_ensure)
+
+    def fake_start_agent(app_obj=None):
+        call_order.append(("start", app_obj))
+
+    monkeypatch.setattr(factory, "start_print_agent", fake_start_agent)
+
+    app = factory.create_app({"TESTING": True, "WTF_CSRF_ENABLED": False})
+
+    assert migrations_called, "Migrations should run during app creation"
+    assert ("ensure", app) in call_order, "Database init should be triggered immediately"
+    assert ("start", app) in call_order, "Agent should start during app creation"
+    assert call_order.index(("ensure", app)) < call_order.index(("start", app))


### PR DESCRIPTION
## Summary
- initialize the database and print agent during application factory execution
- add an integration test ensuring migrations run and the agent starts when the app is created

## Testing
- PYTHONPATH=. pytest magazyn/tests/test_factory.py

------
https://chatgpt.com/codex/tasks/task_e_68cfebc9b250832ab678f4a6e725ac0c