### PR TITLE
Update magazyn container to Python 3.12 and Gunicorn

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Additional arguments are passed directly to `pytest`, for example:
 ./run-tests.sh magazyn/tests/test_agent_thread.py
 ```
 
-The project is developed and tested using **Python 3.9**.
+The project is developed and tested using **Python 3.12**.
 
 ## Running with Docker Compose
 
@@ -176,6 +176,16 @@ the application persist on the host:
 
 The compose configuration mounts the host's `/var/run/cups/cups.sock` so the
 printing agent can communicate with the host CUPS server.
+
+The container image now starts the application with Gunicorn using the
+`magazyn.wsgi:app` entrypoint bound to `0.0.0.0:8000`. Traefik and any reverse
+proxy configuration should therefore forward traffic to port `8000` inside the
+container. If you run the image manually, you can use the same command:
+
+```bash
+docker run --env-file=.env retrievershop/magazyn \
+  gunicorn magazyn.wsgi:app --bind 0.0.0.0:8000
+```
 
 The application uses a SQLite database stored in `magazyn/database.db`. This
 file is created automatically on first startup if it does not already exist.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       - ./.env.example:/app/.env.example:ro
       - /var/run/cups/cups.sock:/var/run/cups/cups.sock
     env_file: .env
-    command: ["python", "-m", "magazyn.app"]
+    command: ["gunicorn", "magazyn.wsgi:app", "--bind", "0.0.0.0:8000"]
     restart: always
     networks:
       - proxy
@@ -18,7 +18,7 @@ services:
       - "traefik.http.routers.magazyn2.rule=Host(`magazyn2.retrievershop.pl`)"
       - "traefik.http.routers.magazyn2.entrypoints=https"
       - "traefik.http.routers.magazyn2.tls=true"
-      - "traefik.http.services.magazyn2.loadbalancer.server.port=80"
+      - "traefik.http.services.magazyn2.loadbalancer.server.port=8000"
       - "traefik.http.services.magazyn2.loadbalancer.server.scheme=http"
 
 

--- a/magazyn/Dockerfile
+++ b/magazyn/Dockerfile
@@ -1,24 +1,46 @@
-# Używamy obrazu Python jako bazy
-FROM python:3.9-slim
+# syntax=docker/dockerfile:1
 
-# Ustawiamy katalog roboczy
+FROM python:3.12-slim AS builder
+
+ENV VIRTUAL_ENV=/opt/venv
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+
 WORKDIR /app
 
-# Instalujemy zależności systemowe
-RUN apt-get update && apt-get install -y \
+RUN python -m venv "$VIRTUAL_ENV"
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
     libsqlite3-dev \
     cups-client \
     && rm -rf /var/lib/apt/lists/*
 
-# Kopiujemy pliki aplikacji do kontenera w podkatalogu
-COPY . /app/magazyn
+COPY magazyn/requirements.txt /tmp/requirements.txt
+RUN pip install --no-cache-dir -r /tmp/requirements.txt
 
-# Instalujemy wymagane pakiety z requirements.txt
-RUN pip install --no-cache-dir -r /app/magazyn/requirements.txt
+COPY . /app
 
-# Ustawiamy port, na którym aplikacja będzie dostępna
-EXPOSE 80
 
-# Uruchamiamy aplikację
-CMD ["python", "-m", "magazyn.app"]
+FROM python:3.12-slim AS runtime
+
+ENV VIRTUAL_ENV=/opt/venv
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+
+WORKDIR /app
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    cups-client \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder $VIRTUAL_ENV $VIRTUAL_ENV
+COPY --from=builder /app /app
+
+RUN groupadd --system magazyn && \
+    useradd --system --gid magazyn --home /app magazyn && \
+    chown -R magazyn:magazyn /app "$VIRTUAL_ENV"
+
+USER magazyn
+
+EXPOSE 8000
+
+CMD ["gunicorn", "magazyn.wsgi:app", "--bind", "0.0.0.0:8000"]

--- a/magazyn/requirements.txt
+++ b/magazyn/requirements.txt
@@ -7,3 +7,4 @@ python-dotenv==1.1.1
 SQLAlchemy==2.0.41
 Flask-WTF==1.2.2
 pypdf==3.17.4
+gunicorn==23.0.0

--- a/magazyn/wsgi.py
+++ b/magazyn/wsgi.py
@@ -1,0 +1,5 @@
+"""WSGI entrypoint for running the magazyn application with Gunicorn."""
+
+from magazyn.factory import create_app
+
+app = create_app()


### PR DESCRIPTION
## Summary
- migrate the magazyn Dockerfile to a Python 3.12 multi-stage build with a runtime user and Gunicorn entrypoint
- add a dedicated WSGI module and include Gunicorn in the application requirements
- update docker-compose labels and README to document the new Gunicorn startup on port 8000

## Testing
- ./run-tests.sh magazyn/tests/test_factory.py

------
https://chatgpt.com/codex/tasks/task_e_68cfef619220832a95977fae7efa3a3d