### PR TITLE
Ensure .env permissions are tightened

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,12 @@ This repository contains the code for the RetrieverShop warehouse application an
    ```bash
    cp .env.example .env
    ```
-2. Edit `.env` and provide your API credentials. The printing agents require values such as `API_TOKEN`, `PAGE_ACCESS_TOKEN` and `RECIPIENT_ID`.
-3. Configure CUPS access. When mounting the host's CUPS socket you should leave
+2. On POSIX systems restrict the file permissions so the contents stay private:
+   ```bash
+   chmod 600 .env
+   ```
+3. Edit `.env` and provide your API credentials. The printing agents require values such as `API_TOKEN`, `PAGE_ACCESS_TOKEN` and `RECIPIENT_ID`.
+4. Configure CUPS access. When mounting the host's CUPS socket you should leave
    the variables empty:
    ```env
    CUPS_SERVER=

--- a/magazyn/app.py
+++ b/magazyn/app.py
@@ -150,6 +150,14 @@ def write_env(values):
         current_app.logger.exception("Failed to write .env file: %s", e)
         if has_request_context():
             flash(f"Błąd zapisu pliku .env: {e}")
+        return
+
+    try:
+        os.chmod(ENV_PATH, 0o600)
+    except (AttributeError, NotImplementedError, OSError, PermissionError) as e:
+        current_app.logger.error(
+            "Failed to set permissions on %s: %s", ENV_PATH, e
+        )
 
 
 def ensure_db_initialized(app_obj=None):

--- a/magazyn/tests/test_env_permissions.py
+++ b/magazyn/tests/test_env_permissions.py
@@ -1,0 +1,21 @@
+import os
+import stat
+
+import pytest
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX-only permission semantics")
+def test_write_env_sets_strict_permissions(app_mod, tmp_path, monkeypatch):
+    env_path = tmp_path / ".env"
+    example_path = tmp_path / ".env.example"
+    example_path.write_text("FOO=bar\n", encoding="utf-8")
+
+    monkeypatch.setattr(app_mod, "ENV_PATH", env_path)
+    monkeypatch.setattr(app_mod, "EXAMPLE_PATH", example_path)
+
+    with app_mod.app.app_context():
+        app_mod.write_env({"FOO": "baz"})
+
+    assert env_path.exists(), ".env should be created by write_env"
+    mode = stat.S_IMODE(env_path.stat().st_mode)
+    assert mode == 0o600


### PR DESCRIPTION
## Summary
- set the generated `.env` file to 0o600 in `write_env` and log failures to adjust permissions
- cover the behaviour with a POSIX-only pytest that checks the file mode of new `.env` files
- document the required permissions in the setup instructions for `.env`

## Testing
- ./run-tests.sh magazyn/tests/test_env_permissions.py

------
https://chatgpt.com/codex/tasks/task_e_68cff616e1ec832aabc93d2ef1db4ce7