### PR TITLE
Add diagnostics endpoints and Prometheus metrics

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,12 @@ services:
     env_file: .env
     command: ["gunicorn", "magazyn.wsgi:app", "--bind", "0.0.0.0:8000"]
     restart: always
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/healthz"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
     networks:
       - proxy
     labels:

--- a/magazyn/Dockerfile
+++ b/magazyn/Dockerfile
@@ -13,6 +13,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
     libsqlite3-dev \
     cups-client \
+    curl \
     && rm -rf /var/lib/apt/lists/*
 
 COPY magazyn/requirements.txt /tmp/requirements.txt
@@ -30,6 +31,7 @@ WORKDIR /app
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     cups-client \
+    curl \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder $VIRTUAL_ENV $VIRTUAL_ENV

--- a/magazyn/diagnostics.py
+++ b/magazyn/diagnostics.py
@@ -1,0 +1,89 @@
+"""Blueprint exposing diagnostics and metrics endpoints."""
+
+from __future__ import annotations
+
+import subprocess
+from typing import Dict, Tuple
+
+from flask import Blueprint, Response, current_app, jsonify
+from prometheus_client import CONTENT_TYPE_LATEST, generate_latest
+from sqlalchemy import text
+
+from .config import settings
+from .db import get_session
+
+
+bp = Blueprint("diagnostics", __name__)
+
+
+def _check_database() -> Tuple[str, str]:
+    """Run a simple query to ensure the database is reachable."""
+
+    try:
+        with get_session() as session:
+            session.execute(text("SELECT 1"))
+        return "ok", ""
+    except Exception as exc:  # pragma: no cover - defensive
+        current_app.logger.exception("Database health check failed: %s", exc)
+        return "error", str(exc)
+
+
+def _check_cups() -> Tuple[str, str]:
+    """Verify that the configured CUPS server is reachable."""
+
+    host = None
+    if settings.CUPS_SERVER or settings.CUPS_PORT:
+        host = settings.CUPS_SERVER or "localhost"
+        if settings.CUPS_PORT:
+            host = f"{host}:{settings.CUPS_PORT}"
+
+    cmd = ["lpstat", "-r"] if not host else ["lpstat", "-h", host, "-r"]
+
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            check=False,
+            timeout=5,
+        )
+    except Exception as exc:  # pragma: no cover - defensive
+        current_app.logger.exception("CUPS health check failed: %s", exc)
+        return "error", str(exc)
+
+    if result.returncode != 0:
+        stderr = result.stderr.decode() if result.stderr else ""
+        stdout = result.stdout.decode() if result.stdout else ""
+        message = stderr or stdout or "Unknown error"
+        current_app.logger.error("CUPS health check returned %s", message)
+        return "error", message
+
+    return "ok", ""
+
+
+@bp.route("/healthz")
+def healthz():
+    """Return status of dependent services."""
+
+    checks: Dict[str, Tuple[str, str]] = {
+        "database": _check_database(),
+        "cups": _check_cups(),
+    }
+
+    overall = "ok" if all(status == "ok" for status, _ in checks.values()) else "error"
+    response = {
+        "status": overall,
+        "checks": {
+            name: {"status": status, "details": detail}
+            for name, (status, detail) in checks.items()
+        },
+    }
+    http_status = 200 if overall == "ok" else 503
+    return jsonify(response), http_status
+
+
+@bp.route("/metrics")
+def metrics() -> Response:
+    """Expose Prometheus metrics."""
+
+    return Response(generate_latest(), mimetype=CONTENT_TYPE_LATEST)
+

--- a/magazyn/factory.py
+++ b/magazyn/factory.py
@@ -17,6 +17,7 @@ from .shipping import bp as shipping_bp
 from .allegro import bp as allegro_bp
 from . import print_agent
 from .app import bp as main_bp, start_print_agent, ensure_db_initialized
+from .diagnostics import bp as diagnostics_bp
 
 _shutdown_registered = False
 
@@ -47,6 +48,7 @@ def create_app(config: Optional[Mapping[str, Any]] = None) -> Flask:
     app.register_blueprint(sales_bp)
     app.register_blueprint(shipping_bp)
     app.register_blueprint(allegro_bp)
+    app.register_blueprint(diagnostics_bp)
 
     for rule in list(app.url_map.iter_rules()):
         if rule.endpoint.startswith("main."):

--- a/magazyn/metrics.py
+++ b/magazyn/metrics.py
@@ -1,0 +1,33 @@
+"""Shared Prometheus metrics used across the application."""
+
+from prometheus_client import Counter, Gauge, Histogram
+
+
+PRINT_LABELS_TOTAL = Counter(
+    "magazyn_print_labels_total",
+    "Total number of labels successfully submitted to the printer.",
+)
+PRINT_LABEL_ERRORS_TOTAL = Counter(
+    "magazyn_print_errors_total",
+    "Total number of errors encountered by the print agent.",
+    ["stage"],
+)
+PRINT_QUEUE_SIZE = Gauge(
+    "magazyn_print_queue_size",
+    "Current number of labels waiting in the queue.",
+)
+PRINT_QUEUE_OLDEST_AGE_SECONDS = Gauge(
+    "magazyn_print_queue_oldest_age_seconds",
+    "Age in seconds of the oldest queued label.",
+)
+PRINT_AGENT_ITERATION_SECONDS = Histogram(
+    "magazyn_print_iteration_duration_seconds",
+    "Duration of a single agent processing loop in seconds.",
+)
+
+PRINT_QUEUE_SIZE.set(0)
+PRINT_QUEUE_OLDEST_AGE_SECONDS.set(0)
+PRINT_LABEL_ERRORS_TOTAL.labels(stage="print")
+PRINT_LABEL_ERRORS_TOTAL.labels(stage="queue")
+PRINT_LABEL_ERRORS_TOTAL.labels(stage="loop")
+

--- a/magazyn/requirements.txt
+++ b/magazyn/requirements.txt
@@ -8,3 +8,4 @@ SQLAlchemy==2.0.41
 Flask-WTF==1.2.2
 pypdf==3.17.4
 gunicorn==23.0.0
+prometheus-client==0.20.0

--- a/magazyn/tests/test_diagnostics.py
+++ b/magazyn/tests/test_diagnostics.py
@@ -1,0 +1,33 @@
+import types
+
+from magazyn import print_agent
+
+
+def test_healthz_returns_ok(client, monkeypatch):
+    dummy = types.SimpleNamespace(returncode=0, stdout=b"", stderr=b"")
+
+    monkeypatch.setattr(
+        "magazyn.diagnostics.subprocess.run", lambda *args, **kwargs: dummy
+    )
+
+    response = client.get("/healthz")
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["status"] == "ok"
+    assert payload["checks"]["cups"]["status"] == "ok"
+    assert payload["checks"]["database"]["status"] == "ok"
+
+
+def test_metrics_endpoint(client):
+    print_agent.PRINT_QUEUE_SIZE.set(3)
+
+    try:
+        response = client.get("/metrics")
+
+        assert response.status_code == 200
+        body = response.data.decode()
+        assert "magazyn_print_queue_size" in body
+        assert "3.0" in body
+    finally:
+        print_agent.PRINT_QUEUE_SIZE.set(0)


### PR DESCRIPTION
## Summary
- add a diagnostics blueprint that provides /healthz and /metrics endpoints and register it with the factory
- instrument the print agent with Prometheus counters and gauges while persisting queue timestamps via a new metrics module
- add the prometheus client dependency, install curl for container health checks, configure docker-compose healthcheck, and cover the endpoints with integration tests

## Testing
- PYTHONPATH=. pytest magazyn/tests/test_diagnostics.py magazyn/tests/test_utils.py

------
https://chatgpt.com/codex/tasks/task_e_68cff893b1c0832abc95059922900ca6