### PR TITLE
Improve print agent reliability

### DIFF
--- a/magazyn/metrics.py
+++ b/magazyn/metrics.py
@@ -24,10 +24,20 @@ PRINT_AGENT_ITERATION_SECONDS = Histogram(
     "magazyn_print_iteration_duration_seconds",
     "Duration of a single agent processing loop in seconds.",
 )
+PRINT_AGENT_RETRIES_TOTAL = Counter(
+    "magazyn_print_retries_total",
+    "Total number of retry attempts performed by the print agent.",
+)
+PRINT_AGENT_DOWNTIME_SECONDS = Counter(
+    "magazyn_print_downtime_seconds",
+    "Total duration in seconds spent waiting before retries.",
+)
 
 PRINT_QUEUE_SIZE.set(0)
 PRINT_QUEUE_OLDEST_AGE_SECONDS.set(0)
 PRINT_LABEL_ERRORS_TOTAL.labels(stage="print")
 PRINT_LABEL_ERRORS_TOTAL.labels(stage="queue")
 PRINT_LABEL_ERRORS_TOTAL.labels(stage="loop")
+PRINT_AGENT_RETRIES_TOTAL.inc(0)
+PRINT_AGENT_DOWNTIME_SECONDS.inc(0)
 

--- a/magazyn/tests/test_agent_thread.py
+++ b/magazyn/tests/test_agent_thread.py
@@ -1,7 +1,19 @@
 import time
 import threading
-import importlib
+from datetime import datetime, timedelta
+from pathlib import Path
+
 import magazyn.print_agent as pa
+
+
+def _make_agent(tmp_path):
+    config = pa.agent.config.with_updates(
+        db_file=str(tmp_path / "agent.db"),
+        lock_file=str(tmp_path / "agent.lock"),
+        log_file=str(tmp_path / "agent.log"),
+        poll_interval=1,
+    )
+    return pa.LabelAgent(config, pa.settings)
 
 
 def test_stop_agent_thread_stops(monkeypatch):
@@ -19,3 +31,69 @@ def test_stop_agent_thread_stops(monkeypatch):
     assert agent._agent_thread.is_alive()
     agent.stop_agent_thread()
     assert agent._agent_thread is None or not agent._agent_thread.is_alive()
+
+
+def test_start_agent_thread_cleans_orphaned_lock(tmp_path, monkeypatch):
+    agent = _make_agent(tmp_path)
+    agent.ensure_db()
+    lock_path = Path(agent.config.lock_file)
+    heartbeat_path = Path(agent._heartbeat_path)
+    lock_path.write_text("")
+    stale = datetime.now() - timedelta(minutes=10)
+    heartbeat_path.write_text(stale.isoformat())
+    started = threading.Event()
+
+    def loop():
+        started.set()
+        agent._stop_event.wait(0.05)
+
+    monkeypatch.setattr(agent, "_agent_loop", loop)
+    try:
+        assert agent.start_agent_thread()
+        assert started.wait(1)
+        assert heartbeat_path.exists()
+        refreshed = datetime.fromisoformat(heartbeat_path.read_text().strip())
+        assert refreshed > stale
+    finally:
+        agent.stop_agent_thread()
+        assert not heartbeat_path.exists()
+        if lock_path.exists():
+            lock_path.unlink()
+
+
+def test_retry_updates_metrics(tmp_path):
+    agent = _make_agent(tmp_path)
+    waits = []
+
+    class DummyEvent:
+        def wait(self, timeout):
+            waits.append(timeout)
+            return False
+
+        def is_set(self):
+            return False
+
+    agent._stop_event = DummyEvent()
+    attempts = []
+    start_retries = pa.PRINT_AGENT_RETRIES_TOTAL._value.get()
+    start_downtime = pa.PRINT_AGENT_DOWNTIME_SECONDS._value.get()
+
+    def flaky():
+        attempts.append(object())
+        if len(attempts) < 3:
+            raise pa.PrintError("fail")
+        return "ok"
+
+    result = agent._retry(
+        flaky,
+        stage="test",
+        retry_exceptions=(pa.PrintError,),
+        max_attempts=3,
+        base_delay=0.5,
+    )
+
+    assert result == "ok"
+    assert len(attempts) == 3
+    assert waits == [0.5, 1.0]
+    assert pa.PRINT_AGENT_RETRIES_TOTAL._value.get() == start_retries + 2
+    assert pa.PRINT_AGENT_DOWNTIME_SECONDS._value.get() == start_downtime + 1.5

--- a/magazyn/tests/test_utils.py
+++ b/magazyn/tests/test_utils.py
@@ -154,6 +154,7 @@ def test_queue_roundtrip(tmp_path, monkeypatch):
     assert loaded[0]["label_data"] == item["label_data"]
     assert loaded[0]["ext"] == item["ext"]
     assert loaded[0]["last_order_data"] == item["last_order_data"]
+    assert loaded[0]["status"] == "queued"
 
 
 def test_validate_env_missing_api_token(monkeypatch):
@@ -185,6 +186,7 @@ def test_load_queue_handles_corrupted_json(tmp_path, monkeypatch):
     conn.close()
     items = agent.load_queue()
     assert items[0]["last_order_data"] == {}
+    assert items[0]["status"] == "queued"
 
 
 def test_call_api_handles_http_error(monkeypatch):


### PR DESCRIPTION
## Summary
- add heartbeat tracking, orphaned lock cleanup, and resilient thread start/stop logic
- persist queue item statuses, add retry/backoff handling for API and printing errors, and expand metrics
- extend unit tests to cover heartbeat cleanup, retry accounting, and updated queue persistence

## Testing
- PYTHONPATH=. pytest magazyn/tests/test_agent_thread.py magazyn/tests/test_utils.py

------
https://chatgpt.com/codex/tasks/task_e_68cffb9d6e80832ab32c856e1507e391