### PR TITLE
Add indexes and ON DELETE constraints

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,23 @@ Additional arguments are passed directly to `pytest`, for example:
 
 The project is developed and tested using **Python 3.12**.
 
+## Database migrations
+
+### Index and foreign key improvements
+
+The `add_indexes_and_foreign_keys` migration rebuilds several tables to add
+database-level `ON DELETE` behaviour and supporting indexes used by Allegro
+synchronisation and sales reports. During the upgrade SQLite recreates the
+`product_sizes`, `purchase_batches`, `sales`, `allegro_offers` and
+`allegro_price_history` tables in place and copies existing data. Depending on
+the size of these tables the migration can momentarily lock the database file.
+
+The `sales.product_id` and `allegro_offers.product_id` columns now allow `NULL`
+values. Existing rows retain their identifiers, but when the related product is
+deleted future rows automatically clear the relationship instead of raising a
+foreign-key error. Historical price samples and offers remain accessible even if
+the referenced product size disappears.
+
 ## Running with Docker Compose
 
 Start the stack using the `docker-compose.yml` file in the repository root:

--- a/magazyn/migrations/add_indexes_and_foreign_keys.py
+++ b/magazyn/migrations/add_indexes_and_foreign_keys.py
@@ -1,0 +1,258 @@
+"""Add supporting indexes and explicit ON DELETE actions."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+
+from magazyn import DB_PATH
+from magazyn.db import sqlite_connect
+
+
+INDEX_STATEMENTS: tuple[tuple[str, str], ...] = (
+    (
+        "idx_product_sizes_product_id_size",
+        "CREATE INDEX IF NOT EXISTS idx_product_sizes_product_id_size "
+        "ON product_sizes(product_id, size)",
+    ),
+    (
+        "idx_sales_sale_date",
+        "CREATE INDEX IF NOT EXISTS idx_sales_sale_date ON sales(sale_date)",
+    ),
+    (
+        "idx_allegro_price_history_recorded_at",
+        "CREATE INDEX IF NOT EXISTS idx_allegro_price_history_recorded_at "
+        "ON allegro_price_history(recorded_at)",
+    ),
+    (
+        "idx_allegro_price_history_offer_recorded_at",
+        "CREATE INDEX IF NOT EXISTS idx_allegro_price_history_offer_recorded_at "
+        "ON allegro_price_history(offer_id, recorded_at)",
+    ),
+    (
+        "idx_allegro_price_history_product_size",
+        "CREATE INDEX IF NOT EXISTS idx_allegro_price_history_product_size "
+        "ON allegro_price_history(product_size_id)",
+    ),
+)
+
+
+@contextmanager
+def _foreign_keys_disabled(conn):
+    cur = conn.cursor()
+    try:
+        cur.execute("PRAGMA foreign_keys=OFF")
+        yield
+    finally:
+        cur.execute("PRAGMA foreign_keys=ON")
+        cur.close()
+
+
+def _foreign_key_actions(conn, table: str) -> dict[str, str]:
+    cur = conn.cursor()
+    try:
+        cur.execute(f"PRAGMA foreign_key_list({table})")
+        result: dict[str, str] = {}
+        for row in cur.fetchall():
+            # row[3] -> column name, row[6] -> on_delete
+            result[row[3]] = (row[6] or "").upper()
+        return result
+    finally:
+        cur.close()
+
+
+def _column_allows_null(conn, table: str, column: str) -> bool:
+    cur = conn.cursor()
+    try:
+        cur.execute(f"PRAGMA table_info({table})")
+        for cid, name, _type, notnull, *_ in cur.fetchall():
+            if name == column:
+                return not notnull
+        raise ValueError(f"Column {column} not found in table {table}")
+    finally:
+        cur.close()
+
+
+def _rebuild_table(conn, table: str, create_sql: str, columns: tuple[str, ...]):
+    with _foreign_keys_disabled(conn):
+        cur = conn.cursor()
+        try:
+            conn.execute("BEGIN")
+            cur.execute(f"ALTER TABLE {table} RENAME TO {table}_old")
+            cur.execute(create_sql)
+            column_list = ", ".join(columns)
+            cur.execute(
+                f"INSERT INTO {table} ({column_list}) SELECT {column_list} FROM {table}_old"
+            )
+            cur.execute(f"DROP TABLE {table}_old")
+            conn.commit()
+        except Exception:
+            conn.rollback()
+            raise
+        finally:
+            cur.close()
+
+
+def _ensure_product_sizes(conn):
+    actions = _foreign_key_actions(conn, "product_sizes")
+    if actions.get("product_id") == "CASCADE":
+        return
+
+    _rebuild_table(
+        conn,
+        "product_sizes",
+        """
+        CREATE TABLE product_sizes (
+            id INTEGER PRIMARY KEY,
+            product_id INTEGER NOT NULL REFERENCES products(id) ON DELETE CASCADE,
+            size TEXT NOT NULL,
+            quantity INTEGER NOT NULL DEFAULT 0,
+            barcode TEXT UNIQUE
+        )
+        """,
+        ("id", "product_id", "size", "quantity", "barcode"),
+    )
+
+
+def _ensure_purchase_batches(conn):
+    actions = _foreign_key_actions(conn, "purchase_batches")
+    if actions.get("product_id") == "CASCADE":
+        return
+
+    _rebuild_table(
+        conn,
+        "purchase_batches",
+        """
+        CREATE TABLE purchase_batches (
+            id INTEGER PRIMARY KEY,
+            product_id INTEGER NOT NULL REFERENCES products(id) ON DELETE CASCADE,
+            size TEXT NOT NULL,
+            quantity INTEGER NOT NULL,
+            price NUMERIC(10,2) NOT NULL,
+            purchase_date TEXT NOT NULL
+        )
+        """,
+        ("id", "product_id", "size", "quantity", "price", "purchase_date"),
+    )
+
+
+def _ensure_sales(conn):
+    actions = _foreign_key_actions(conn, "sales")
+    allows_null = _column_allows_null(conn, "sales", "product_id")
+    if actions.get("product_id") == "SET NULL" and allows_null:
+        return
+
+    _rebuild_table(
+        conn,
+        "sales",
+        """
+        CREATE TABLE sales (
+            id INTEGER PRIMARY KEY,
+            product_id INTEGER REFERENCES products(id) ON DELETE SET NULL,
+            size TEXT NOT NULL,
+            quantity INTEGER NOT NULL,
+            sale_date TEXT NOT NULL,
+            purchase_cost NUMERIC(10,2) NOT NULL DEFAULT 0.0,
+            sale_price NUMERIC(10,2) NOT NULL DEFAULT 0.0,
+            shipping_cost NUMERIC(10,2) NOT NULL DEFAULT 0.0,
+            commission_fee NUMERIC(10,2) NOT NULL DEFAULT 0.0
+        )
+        """,
+        (
+            "id",
+            "product_id",
+            "size",
+            "quantity",
+            "sale_date",
+            "purchase_cost",
+            "sale_price",
+            "shipping_cost",
+            "commission_fee",
+        ),
+    )
+
+
+def _ensure_allegro_offers(conn):
+    actions = _foreign_key_actions(conn, "allegro_offers")
+    allows_null = _column_allows_null(conn, "allegro_offers", "product_id")
+    if (
+        actions.get("product_id") == "SET NULL"
+        and actions.get("product_size_id") == "SET NULL"
+        and allows_null
+    ):
+        return
+
+    _rebuild_table(
+        conn,
+        "allegro_offers",
+        """
+        CREATE TABLE allegro_offers (
+            id INTEGER PRIMARY KEY,
+            offer_id TEXT UNIQUE,
+            title TEXT NOT NULL,
+            price NUMERIC(10,2) NOT NULL,
+            product_id INTEGER REFERENCES products(id) ON DELETE SET NULL,
+            product_size_id INTEGER REFERENCES product_sizes(id) ON DELETE SET NULL,
+            synced_at TEXT
+        )
+        """,
+        (
+            "id",
+            "offer_id",
+            "title",
+            "price",
+            "product_id",
+            "product_size_id",
+            "synced_at",
+        ),
+    )
+
+
+def _ensure_price_history(conn):
+    actions = _foreign_key_actions(conn, "allegro_price_history")
+    if actions.get("product_size_id") == "SET NULL":
+        return
+
+    _rebuild_table(
+        conn,
+        "allegro_price_history",
+        """
+        CREATE TABLE allegro_price_history (
+            id INTEGER PRIMARY KEY,
+            offer_id TEXT,
+            product_size_id INTEGER REFERENCES product_sizes(id) ON DELETE SET NULL,
+            price NUMERIC(10,2) NOT NULL,
+            recorded_at TEXT NOT NULL
+        )
+        """,
+        ("id", "offer_id", "product_size_id", "price", "recorded_at"),
+    )
+
+
+def _ensure_indexes(conn):
+    cur = conn.cursor()
+    try:
+        for name, statement in INDEX_STATEMENTS:
+            cur.execute(
+                "SELECT name FROM sqlite_master WHERE type='index' AND name=?",
+                (name,),
+            )
+            if cur.fetchone():
+                continue
+            cur.execute(statement)
+    finally:
+        cur.close()
+
+
+def migrate():
+    with sqlite_connect(DB_PATH) as conn:
+        _ensure_product_sizes(conn)
+        _ensure_purchase_batches(conn)
+        _ensure_sales(conn)
+        _ensure_allegro_offers(conn)
+        _ensure_price_history(conn)
+        _ensure_indexes(conn)
+        conn.commit()
+
+
+if __name__ == "__main__":
+    migrate()

--- a/magazyn/models.py
+++ b/magazyn/models.py
@@ -1,4 +1,13 @@
-from sqlalchemy import Column, Integer, String, Float, ForeignKey, Text, Numeric
+from sqlalchemy import (
+    Column,
+    Integer,
+    String,
+    Float,
+    ForeignKey,
+    Text,
+    Numeric,
+    Index,
+)
 from sqlalchemy.orm import declarative_base, relationship
 
 Base = declarative_base()
@@ -23,8 +32,15 @@ class Product(Base):
 
 class ProductSize(Base):
     __tablename__ = "product_sizes"
+    __table_args__ = (
+        Index("idx_product_sizes_product_id_size", "product_id", "size"),
+    )
     id = Column(Integer, primary_key=True)
-    product_id = Column(Integer, ForeignKey("products.id"))
+    product_id = Column(
+        Integer,
+        ForeignKey("products.id", ondelete="CASCADE"),
+        nullable=False,
+    )
     size = Column(String, nullable=False)
     quantity = Column(Integer, nullable=False, default=0)
     barcode = Column(String, unique=True)
@@ -54,7 +70,11 @@ class LabelQueue(Base):
 class PurchaseBatch(Base):
     __tablename__ = "purchase_batches"
     id = Column(Integer, primary_key=True)
-    product_id = Column(Integer, ForeignKey("products.id"), nullable=False)
+    product_id = Column(
+        Integer,
+        ForeignKey("products.id", ondelete="CASCADE"),
+        nullable=False,
+    )
     size = Column(String, nullable=False)
     quantity = Column(Integer, nullable=False)
     price = Column(Numeric(10, 2), nullable=False)
@@ -63,8 +83,13 @@ class PurchaseBatch(Base):
 
 class Sale(Base):
     __tablename__ = "sales"
+    __table_args__ = (Index("idx_sales_sale_date", "sale_date"),)
     id = Column(Integer, primary_key=True)
-    product_id = Column(Integer, ForeignKey("products.id"), nullable=False)
+    product_id = Column(
+        Integer,
+        ForeignKey("products.id", ondelete="SET NULL"),
+        nullable=True,
+    )
     size = Column(String, nullable=False)
     quantity = Column(Integer, nullable=False)
     sale_date = Column(String, nullable=False)
@@ -87,8 +112,16 @@ class AllegroOffer(Base):
     offer_id = Column(String, unique=True)
     title = Column(String, nullable=False)
     price = Column(Numeric(10, 2), nullable=False)
-    product_id = Column(Integer, ForeignKey("products.id"))
-    product_size_id = Column(Integer, ForeignKey("product_sizes.id"))
+    product_id = Column(
+        Integer,
+        ForeignKey("products.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    product_size_id = Column(
+        Integer,
+        ForeignKey("product_sizes.id", ondelete="SET NULL"),
+        nullable=True,
+    )
     synced_at = Column(String)
 
     product = relationship("Product")
@@ -97,9 +130,22 @@ class AllegroOffer(Base):
 
 class AllegroPriceHistory(Base):
     __tablename__ = "allegro_price_history"
+    __table_args__ = (
+        Index("idx_allegro_price_history_recorded_at", "recorded_at"),
+        Index(
+            "idx_allegro_price_history_offer_recorded_at",
+            "offer_id",
+            "recorded_at",
+        ),
+        Index("idx_allegro_price_history_product_size", "product_size_id"),
+    )
     id = Column(Integer, primary_key=True)
     offer_id = Column(String, index=True)
-    product_size_id = Column(Integer, ForeignKey("product_sizes.id"))
+    product_size_id = Column(
+        Integer,
+        ForeignKey("product_sizes.id", ondelete="SET NULL"),
+        nullable=True,
+    )
     price = Column(Numeric(10, 2), nullable=False)
     recorded_at = Column(String, nullable=False)
 

--- a/magazyn/tests/test_query_plans.py
+++ b/magazyn/tests/test_query_plans.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import magazyn.config as cfg
+from magazyn.db import sqlite_connect
+from magazyn.models import Product, ProductSize, Sale, AllegroPriceHistory
+
+
+def _explain(sql: str, *params: object) -> list[str]:
+    with sqlite_connect(cfg.settings.DB_PATH) as conn:
+        rows = conn.execute(f"EXPLAIN QUERY PLAN {sql}", params).fetchall()
+    return [row[-1] for row in rows]
+
+
+def test_allegro_sync_query_uses_product_size_index(app_mod):
+    with app_mod.get_session() as db:
+        product = Product(name="Speedy", color="Blue")
+        db.add(product)
+        db.flush()
+        db.add_all(
+            [
+                ProductSize(product_id=product.id, size="M", quantity=3),
+                ProductSize(product_id=product.id, size="L", quantity=1),
+            ]
+        )
+
+    plan = _explain(
+        """
+        SELECT ps.id
+        FROM product_sizes AS ps
+        JOIN products AS p ON p.id = ps.product_id
+        WHERE p.name = ? AND ps.size = ?
+        """,
+        "Speedy",
+        "M",
+    )
+
+    assert any("idx_product_sizes_product_id_size" in line for line in plan)
+
+
+def test_sales_summary_filters_use_sale_date_index(app_mod):
+    now = datetime.now(timezone.utc)
+    with app_mod.get_session() as db:
+        product = Product(name="Widget", color="Red")
+        db.add(product)
+        db.flush()
+        db.add_all(
+            [
+                Sale(
+                    product_id=product.id,
+                    size="M",
+                    quantity=1,
+                    sale_date=(now - timedelta(days=1)).isoformat(),
+                ),
+                Sale(
+                    product_id=product.id,
+                    size="L",
+                    quantity=2,
+                    sale_date=(now - timedelta(days=2)).isoformat(),
+                ),
+            ]
+        )
+
+    plan = _explain(
+        """
+        SELECT s.product_id, s.size, SUM(s.quantity)
+        FROM sales AS s
+        WHERE s.sale_date >= ?
+        GROUP BY s.product_id, s.size
+        """,
+        (now - timedelta(days=7)).isoformat(),
+    )
+
+    assert any("idx_sales_sale_date" in line for line in plan)
+
+
+def test_price_history_window_uses_recorded_at_index(app_mod):
+    now = datetime.now(timezone.utc)
+    earlier = (now - timedelta(hours=1)).isoformat()
+    with app_mod.get_session() as db:
+        db.add_all(
+            [
+                AllegroPriceHistory(
+                    offer_id="A1",
+                    product_size_id=None,
+                    price=10,
+                    recorded_at=earlier,
+                ),
+                AllegroPriceHistory(
+                    offer_id="A1",
+                    product_size_id=None,
+                    price=11,
+                    recorded_at=now.isoformat(),
+                ),
+            ]
+        )
+
+    plan = _explain(
+        """
+        SELECT offer_id, MIN(price), MAX(price)
+        FROM allegro_price_history
+        WHERE recorded_at >= ?
+        GROUP BY offer_id
+        """,
+        (now - timedelta(hours=2)).isoformat(),
+    )
+
+    assert any(
+        "idx_allegro_price_history_recorded_at" in line
+        or "idx_allegro_price_history_offer_recorded_at" in line
+        for line in plan
+    )


### PR DESCRIPTION
## Summary
- add a migration that rebuilds the main warehouse tables with foreign-key `ON DELETE` actions and supporting indexes
- keep the ORM metadata in sync by defining composite indexes and updated foreign keys
- cover the critical queries with regression tests and document the impact of the migration

## Testing
- ./run-tests.sh

------
https://chatgpt.com/codex/tasks/task_e_68d01e7d0d38832a8485d4cbc6d6a93e