### PR TITLE
Add security headers and CDN integrity protection

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,18 @@ file (`agent.lock` next to the log file) to ensure additional processes skip
 starting the agent. When multiple workers load the application, only the first
 one obtains the lock and launches the background thread.
 
+## Front-end security
+
+The base HTML template loads Bootstrap and Bootstrap Icons exclusively from
+jsDelivr using Subresource Integrity (SRI) hashes with the `crossorigin`
+attribute, ensuring the assets cannot be tampered with in transit. Responses
+are additionally protected with a Content Security Policy limiting scripts and
+styles to application assets and jsDelivr, locking frames to the application
+itself, and restricting image sources to the Retriever Shop domain. The
+application also emits the `Strict-Transport-Security` and
+`X-Content-Type-Options` headers so browsers enforce HTTPS transport and avoid
+MIME type sniffing.
+
 ## Modifying settings via the web interface
 
 After starting the application you can modify the values stored in your `.env` file without touching the filesystem. Log in to the web interface and open the **Ustawienia** tab from the navigation bar.

--- a/magazyn/factory.py
+++ b/magazyn/factory.py
@@ -63,6 +63,28 @@ def create_app(config: Optional[Mapping[str, Any]] = None) -> Flask:
 
     _register_shutdown_hook()
 
+    @app.after_request
+    def apply_security_headers(response):
+        """Attach security headers to every response."""
+
+        csp = (
+            "default-src 'self'; "
+            "img-src 'self' https://retrievershop.pl data:; "
+            "script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; "
+            "style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; "
+            "font-src 'self' https://cdn.jsdelivr.net data:; "
+            "connect-src 'self'; "
+            "object-src 'none'; "
+            "base-uri 'self'; "
+            "frame-ancestors 'self'"
+        )
+        response.headers.setdefault("Content-Security-Policy", csp)
+        response.headers.setdefault(
+            "Strict-Transport-Security", "max-age=31536000; includeSubDomains"
+        )
+        response.headers.setdefault("X-Content-Type-Options", "nosniff")
+        return response
+
     @app.cli.command("init-db")
     def init_db_command() -> None:
         """Initialize the application database."""

--- a/magazyn/templates/base.html
+++ b/magazyn/templates/base.html
@@ -4,8 +4,14 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Retriever Shop - Magazyn</title>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
+    <link rel="stylesheet"
+          href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
+          integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH"
+          crossorigin="anonymous">
+    <link rel="stylesheet"
+          href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css"
+          integrity="sha384-XGjxtQfXaH2tnPFa9x+ruJTuLE3Aa6LhHSWRr1XeTyhezb4abCG4ccI5AkVDxqC+"
+          crossorigin="anonymous">
     <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
 </head>
 <body>
@@ -148,7 +154,9 @@
     </div>
     <input type="hidden" id="barcode-csrf-token" value="{{ csrf_token() }}">
 
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"
+            integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz"
+            crossorigin="anonymous"></script>
     <script src="{{ url_for('static', filename='barcode-scanner.js') }}"></script>
     <script>
         const btn = document.getElementById('mobileMenuBtn');

--- a/magazyn/tests/test_security_headers.py
+++ b/magazyn/tests/test_security_headers.py
@@ -1,0 +1,24 @@
+import pytest
+
+
+@pytest.mark.usefixtures("login")
+def test_security_headers_are_applied(client):
+    response = client.get("/")
+
+    assert response.status_code == 200
+    assert response.headers["Content-Security-Policy"] == (
+        "default-src 'self'; "
+        "img-src 'self' https://retrievershop.pl data:; "
+        "script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; "
+        "style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; "
+        "font-src 'self' https://cdn.jsdelivr.net data:; "
+        "connect-src 'self'; "
+        "object-src 'none'; "
+        "base-uri 'self'; "
+        "frame-ancestors 'self'"
+    )
+    assert (
+        response.headers["Strict-Transport-Security"]
+        == "max-age=31536000; includeSubDomains"
+    )
+    assert response.headers["X-Content-Type-Options"] == "nosniff"


### PR DESCRIPTION
## Summary
- update Bootstrap CDN includes to supported versions secured with SRI
- apply a security middleware that sets CSP, HSTS, and X-Content-Type-Options headers
- cover the headers with a regression test and document the new frontend policy

## Testing
- PYTHONPATH=. pytest magazyn/tests/test_security_headers.py

------
https://chatgpt.com/codex/tasks/task_e_68d026e8a2fc832a9216ff7074e20288