### PR TITLE
Fix requirements path in magazyn Dockerfile

### DIFF
--- a/magazyn/Dockerfile
+++ b/magazyn/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
     && rm -rf /var/lib/apt/lists/*
 
-COPY magazyn/requirements.txt /tmp/requirements.txt
+COPY requirements.txt /tmp/requirements.txt
 RUN pip install --no-cache-dir -r /tmp/requirements.txt
 
 COPY . /app


### PR DESCRIPTION
## Summary
- update the magazyn Dockerfile to copy the requirements file directly from the build context

## Testing
- not run (docker not available in environment)


------
https://chatgpt.com/codex/tasks/task_e_68d0313b415c832a8899a9cff01ee653