### PR TITLE
Handle SQLite WAL configuration failures gracefully

### DIFF
--- a/magazyn/tests/test_db.py
+++ b/magazyn/tests/test_db.py
@@ -1,3 +1,6 @@
+import logging
+import sqlite3
+
 import magazyn.db as db
 from magazyn.db import sqlite_connect
 
@@ -24,3 +27,30 @@ def test_configure_engine_enables_wal_mode(tmp_path, monkeypatch):
             db.engine.dispose()
         db.engine = original_engine
         db.SessionLocal = original_session_local
+
+
+def test_configure_sqlite_connection_readonly(tmp_path, caplog):
+    db_file = tmp_path / "readonly.db"
+
+    # create the database so SQLite can open it in read-only mode later
+    with sqlite3.connect(str(db_file)) as conn:
+        conn.execute("CREATE TABLE IF NOT EXISTS t (id INTEGER PRIMARY KEY)")
+
+    readonly_uri = f"file:{db_file}?mode=ro"
+    caplog.set_level(logging.WARNING, logger="magazyn.db")
+
+    with sqlite3.connect(
+        readonly_uri,
+        uri=True,
+        check_same_thread=False,
+    ) as readonly_conn:
+        db._configure_sqlite_connection(readonly_conn)
+
+        busy_timeout = readonly_conn.execute("PRAGMA busy_timeout").fetchone()[0]
+        foreign_keys = readonly_conn.execute("PRAGMA foreign_keys").fetchone()[0]
+
+    warning_messages = [record.getMessage() for record in caplog.records]
+
+    assert any("journal_mode" in message for message in warning_messages)
+    assert busy_timeout == db.SQLITE_BUSY_TIMEOUT_MS
+    assert foreign_keys == 1


### PR DESCRIPTION
## Summary
- guard WAL journal configuration against sqlite3.OperationalError and log degraded mode
- continue applying busy_timeout and foreign_keys pragmas even when WAL setup fails
- add regression test covering read-only SQLite connections to ensure graceful handling

## Testing
- PYTHONPATH=. pytest magazyn/tests/test_db.py


------
https://chatgpt.com/codex/tasks/task_e_68d039974728832a83335a81e8295094