### PR TITLE
Add database-backed settings store

### DIFF
--- a/magazyn/config.py
+++ b/magazyn/config.py
@@ -1,58 +1,27 @@
-import os
-from types import SimpleNamespace
-from dotenv import load_dotenv
+from .settings_store import settings_store
 
 
 def load_config():
-    """Load settings from .env and environment variables."""
-    load_dotenv()
-    excluded = {
-        seller.strip()
-        for seller in os.getenv("ALLEGRO_EXCLUDED_SELLERS", "").split(",")
-        if seller.strip()
-    }
-    return SimpleNamespace(
-        API_TOKEN=os.getenv("API_TOKEN"),
-        PAGE_ACCESS_TOKEN=os.getenv("PAGE_ACCESS_TOKEN"),
-        RECIPIENT_ID=os.getenv("RECIPIENT_ID"),
-        STATUS_ID=int(os.getenv("STATUS_ID", "91618")),
-        PRINTER_NAME=os.getenv("PRINTER_NAME", "Xprinter"),
-        CUPS_SERVER=os.getenv("CUPS_SERVER"),
-        CUPS_PORT=os.getenv("CUPS_PORT"),
-        POLL_INTERVAL=int(os.getenv("POLL_INTERVAL", "60")),
-        QUIET_HOURS_START=os.getenv("QUIET_HOURS_START", "10:00"),
-        QUIET_HOURS_END=os.getenv("QUIET_HOURS_END", "22:00"),
-        TIMEZONE=os.getenv("TIMEZONE", "Europe/Warsaw"),
-        PRINTED_EXPIRY_DAYS=int(os.getenv("PRINTED_EXPIRY_DAYS", "5")),
-        LOG_LEVEL=os.getenv("LOG_LEVEL", "INFO").upper(),
-        LOG_FILE=os.getenv(
-            "LOG_FILE", os.path.join(os.path.dirname(__file__), "agent.log")
-        ),
-        DB_PATH=os.getenv(
-            "DB_PATH", os.path.join(os.path.dirname(__file__), "database.db")
-        ),
-        SECRET_KEY=os.getenv("SECRET_KEY", "default_secret_key"),
-        FLASK_DEBUG=os.getenv("FLASK_DEBUG") == "1",
-        FLASK_ENV=os.getenv("FLASK_ENV", "production"),
-        COMMISSION_ALLEGRO=float(os.getenv("COMMISSION_ALLEGRO", "0")),
-        ALLEGRO_SELLER_ID=os.getenv("ALLEGRO_SELLER_ID"),
-        ALLEGRO_EXCLUDED_SELLERS=excluded,
-        LOW_STOCK_THRESHOLD=int(os.getenv("LOW_STOCK_THRESHOLD", "1")),
-        ALERT_EMAIL=os.getenv("ALERT_EMAIL"),
-        SMTP_SERVER=os.getenv("SMTP_SERVER"),
-        SMTP_PORT=os.getenv("SMTP_PORT", "25"),
-        SMTP_USERNAME=os.getenv("SMTP_USERNAME"),
-        SMTP_PASSWORD=os.getenv("SMTP_PASSWORD"),
-        ENABLE_MONTHLY_REPORTS=os.getenv("ENABLE_MONTHLY_REPORTS", "1") == "1",
-        ENABLE_WEEKLY_REPORTS=os.getenv("ENABLE_WEEKLY_REPORTS", "1") == "1",
-        API_RATE_LIMIT_CALLS=int(os.getenv("API_RATE_LIMIT_CALLS", "60")),
-        API_RATE_LIMIT_PERIOD=float(os.getenv("API_RATE_LIMIT_PERIOD", "60")),
-        API_RETRY_ATTEMPTS=int(os.getenv("API_RETRY_ATTEMPTS", "3")),
-        API_RETRY_BACKOFF_INITIAL=float(
-            os.getenv("API_RETRY_BACKOFF_INITIAL", "1.0")
-        ),
-        API_RETRY_BACKOFF_MAX=float(os.getenv("API_RETRY_BACKOFF_MAX", "30.0")),
-    )
+    """Return the cached configuration namespace."""
+
+    return settings_store.settings
 
 
-settings = load_config()
+class _SettingsProxy:
+    """Dynamic proxy exposing the latest configuration values."""
+
+    def __getattribute__(self, item):
+        if item == "__dict__":
+            return vars(settings_store.settings)
+        return super().__getattribute__(item)
+
+    def __getattr__(self, item):
+        return getattr(settings_store.settings, item)
+
+    def __setattr__(self, key, value):
+        if key.startswith("_"):
+            return super().__setattr__(key, value)
+        settings_store.update({key: value})
+
+
+settings = _SettingsProxy()

--- a/magazyn/env_tokens.py
+++ b/magazyn/env_tokens.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 import os
-from collections.abc import MutableMapping
 from typing import Optional
+
+from .settings_store import settings_store
 
 
 def update_allegro_tokens(
@@ -29,16 +30,13 @@ def update_allegro_tokens(
     if refresh_token is not None:
         os.environ["ALLEGRO_REFRESH_TOKEN"] = refresh_token
 
-    # Import lazily to avoid circular imports with ``magazyn.app``.
-    from .app import load_settings, write_env  # pylint: disable=import-outside-toplevel
-
-    values: MutableMapping[str, str] = load_settings()
+    updates = {}
     if access_token is not None:
-        values["ALLEGRO_ACCESS_TOKEN"] = access_token
+        updates["ALLEGRO_ACCESS_TOKEN"] = access_token
     if refresh_token is not None:
-        values["ALLEGRO_REFRESH_TOKEN"] = refresh_token
-
-    write_env(values)
+        updates["ALLEGRO_REFRESH_TOKEN"] = refresh_token
+    if updates:
+        settings_store.update(updates)
 
 
 def clear_allegro_tokens() -> None:
@@ -47,13 +45,10 @@ def clear_allegro_tokens() -> None:
     os.environ.pop("ALLEGRO_ACCESS_TOKEN", None)
     os.environ.pop("ALLEGRO_REFRESH_TOKEN", None)
 
-    # Import lazily to avoid circular imports with ``magazyn.app``.
-    from .app import load_settings, write_env  # pylint: disable=import-outside-toplevel
-
-    values: MutableMapping[str, str] = load_settings()
-
-    values.pop("ALLEGRO_ACCESS_TOKEN", None)
-    values.pop("ALLEGRO_REFRESH_TOKEN", None)
-
-    write_env(values)
+    settings_store.update(
+        {
+            "ALLEGRO_ACCESS_TOKEN": None,
+            "ALLEGRO_REFRESH_TOKEN": None,
+        }
+    )
 

--- a/magazyn/migrations/create_app_settings_table.py
+++ b/magazyn/migrations/create_app_settings_table.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from magazyn import DB_PATH
+from magazyn.db import sqlite_connect
+
+
+SCHEMA = """
+CREATE TABLE IF NOT EXISTS app_settings (
+    key TEXT PRIMARY KEY,
+    value TEXT,
+    updated_at TEXT NOT NULL DEFAULT (CURRENT_TIMESTAMP)
+)
+"""
+
+
+def migrate() -> None:
+    db_path = Path(DB_PATH)
+    with sqlite_connect(db_path) as conn:
+        cursor = conn.cursor()
+        cursor.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='app_settings'"
+        )
+        if cursor.fetchone():
+            print("app_settings table already exists")
+            return
+
+        cursor.execute(SCHEMA)
+        conn.commit()
+        print("Created app_settings table")
+
+
+if __name__ == "__main__":
+    migrate()
+

--- a/magazyn/models.py
+++ b/magazyn/models.py
@@ -7,6 +7,8 @@ from sqlalchemy import (
     Text,
     Numeric,
     Index,
+    DateTime,
+    func,
 )
 from sqlalchemy.orm import declarative_base, relationship
 
@@ -150,3 +152,12 @@ class AllegroPriceHistory(Base):
     recorded_at = Column(String, nullable=False)
 
     product_size = relationship("ProductSize", back_populates="price_history")
+
+
+class AppSetting(Base):
+    __tablename__ = "app_settings"
+    key = Column(String, primary_key=True)
+    value = Column(Text, nullable=True)
+    updated_at = Column(
+        DateTime, nullable=False, server_default=func.now(), onupdate=func.now()
+    )

--- a/magazyn/settings_io.py
+++ b/magazyn/settings_io.py
@@ -1,0 +1,149 @@
+"""Helpers for loading and persisting configuration values from ``.env`` files."""
+
+from __future__ import annotations
+
+from collections import OrderedDict
+from pathlib import Path
+from typing import Callable, Iterable, Mapping, MutableMapping, Optional
+
+from dotenv import dotenv_values
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+ENV_PATH = ROOT_DIR / ".env"
+EXAMPLE_PATH = ROOT_DIR / ".env.example"
+
+# Settings that should not be editable from the administration panels.
+HIDDEN_KEYS = {"ENABLE_HTTP_SERVER", "HTTP_PORT", "DB_PATH"}
+
+
+def _handle_error(
+    error: Exception,
+    *,
+    logger: Optional[Callable[[str, Exception], None]] = None,
+    on_error: Optional[Callable[[str], None]] = None,
+    message: str,
+) -> None:
+    if logger is not None:
+        logger(message, error)
+    if on_error is not None:
+        on_error(message)
+
+
+def _load_values(path: Path) -> Mapping[str, str]:
+    try:
+        return dotenv_values(path)
+    except Exception:  # pragma: no cover - defensive
+        # ``dotenv_values`` already swallows many errors and returns an empty dict
+        # but keep the behaviour explicit for clarity.
+        return {}
+
+
+def load_settings(
+    *,
+    include_hidden: bool = False,
+    example_path: Path = EXAMPLE_PATH,
+    env_path: Path = ENV_PATH,
+    logger: Optional[Callable[[str, Exception], None]] = None,
+    on_error: Optional[Callable[[str], None]] = None,
+) -> "OrderedDict[str, str]":
+    """Return merged configuration values from ``.env`` files.
+
+    The values are based on ``.env.example`` for ordering and fall back to
+    ``.env`` when present. Unknown keys from the current ``.env`` file are
+    appended to the end of the ordered dictionary.
+    """
+
+    if not example_path.exists():
+        _handle_error(
+            FileNotFoundError(example_path),
+            logger=logger,
+            on_error=on_error,
+            message=f"Settings template missing: {example_path}",
+        )
+        return OrderedDict()
+
+    try:
+        example = _load_values(example_path)
+        current = _load_values(env_path) if env_path.exists() else {}
+    except Exception as exc:  # pragma: no cover - defensive
+        _handle_error(
+            exc,
+            logger=logger,
+            on_error=on_error,
+            message=f"Failed to load .env files: {exc}",
+        )
+        return OrderedDict()
+
+    values: "OrderedDict[str, str]" = OrderedDict()
+
+    for key in example.keys():
+        values[key] = current.get(key, example[key])
+
+    for key, val in current.items():
+        if key not in values:
+            values[key] = val
+
+    if not include_hidden:
+        for hidden in HIDDEN_KEYS:
+            values.pop(hidden, None)
+
+    return values
+
+
+def write_env(
+    values: Mapping[str, str],
+    *,
+    example_path: Path = EXAMPLE_PATH,
+    env_path: Path = ENV_PATH,
+    logger: Optional[Callable[[str, Exception], None]] = None,
+    on_error: Optional[Callable[[str], None]] = None,
+) -> bool:
+    """Persist ``values`` to the ``.env`` file and return success status."""
+
+    try:
+        example = _load_values(example_path)
+        example_keys = list(example.keys())
+        current = _load_values(env_path) if env_path.exists() else {}
+        ordered_keys: Iterable[str] = example_keys + [
+            key for key in values.keys() if key not in example_keys
+        ]
+    except Exception as exc:  # pragma: no cover - defensive
+        _handle_error(
+            exc,
+            logger=logger,
+            on_error=on_error,
+            message=f"Failed to read env template: {exc}",
+        )
+        return False
+
+    try:
+        with env_path.open("w", encoding="utf-8") as handle:
+            for key in ordered_keys:
+                val = values.get(key, current.get(key, example.get(key, "")))
+                handle.write(f"{key}={val}\n")
+    except Exception as exc:  # pragma: no cover - defensive
+        _handle_error(
+            exc,
+            logger=logger,
+            on_error=on_error,
+            message=f"Failed to write .env file: {exc}",
+        )
+        return False
+
+    try:
+        env_path.chmod(0o600)
+    except (AttributeError, NotImplementedError, OSError, PermissionError) as exc:
+        if logger is not None:
+            logger("Failed to set permissions", exc)
+
+    return True
+
+
+__all__ = [
+    "ENV_PATH",
+    "EXAMPLE_PATH",
+    "HIDDEN_KEYS",
+    "load_settings",
+    "write_env",
+]
+

--- a/magazyn/settings_store.py
+++ b/magazyn/settings_store.py
@@ -1,0 +1,324 @@
+"""Persistent settings service backed by the SQLite database."""
+
+from __future__ import annotations
+
+import logging
+import os
+import sqlite3
+from collections import OrderedDict
+from pathlib import Path
+from threading import RLock
+from types import SimpleNamespace
+from typing import Iterable, Mapping, Optional
+
+from . import settings_io
+
+LOGGER = logging.getLogger(__name__)
+
+SCHEMA = """
+CREATE TABLE IF NOT EXISTS app_settings (
+    key TEXT PRIMARY KEY,
+    value TEXT,
+    updated_at TEXT NOT NULL DEFAULT (CURRENT_TIMESTAMP)
+)
+"""
+
+
+def _default_db_path() -> Path:
+    return Path(os.path.join(os.path.dirname(__file__), "database.db"))
+
+
+class SettingsStore:
+    """Store application configuration in the SQLite database."""
+
+    def __init__(self) -> None:
+        self._lock = RLock()
+        self._values: "OrderedDict[str, str]" = OrderedDict()
+        self._namespace: Optional[SimpleNamespace] = None
+        self._db_path: Path = _default_db_path()
+        self._loaded = False
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _resolve_db_path(self, source: Mapping[str, str]) -> Path:
+        db_path = source.get("DB_PATH") or os.environ.get("DB_PATH")
+        if not db_path:
+            return _default_db_path()
+        return Path(db_path)
+
+    def _ensure_loaded(self) -> None:
+        if self._loaded:
+            return
+        with self._lock:
+            if self._loaded:
+                return
+
+            env_values = settings_io.load_settings(
+                include_hidden=True,
+                example_path=settings_io.EXAMPLE_PATH,
+                env_path=settings_io.ENV_PATH,
+            )
+            db_path = self._resolve_db_path(env_values)
+            db_values = self._load_from_db(db_path)
+
+            if db_values is not None and db_values:
+                values = db_values
+            elif env_values:
+                values = env_values
+                self._persist_many(values, db_path)
+            else:
+                values = OrderedDict()
+
+            self._db_path = db_path
+            self._values = OrderedDict(
+                (key, "" if value is None else str(value)) for key, value in values.items()
+            )
+            self._namespace = self._build_namespace(self._values)
+            self._apply_environment(self._values, replace_all=True)
+            self._loaded = True
+
+    def _connect(self, db_path: Optional[Path] = None) -> Optional[sqlite3.Connection]:
+        path = db_path or self._db_path
+        if not path:
+            return None
+        try:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            conn = sqlite3.connect(path)
+        except sqlite3.Error as exc:
+            LOGGER.warning("Failed to connect to settings database: %s", exc)
+            return None
+        return conn
+
+    def _load_from_db(self, db_path: Path) -> Optional["OrderedDict[str, str]"]:
+        if not db_path.exists():
+            return None
+        try:
+            conn = sqlite3.connect(db_path)
+        except sqlite3.Error as exc:
+            LOGGER.warning("Failed to read settings from %s: %s", db_path, exc)
+            return None
+        try:
+            conn.row_factory = sqlite3.Row
+            cursor = conn.cursor()
+            cursor.execute("SELECT key, value FROM app_settings ORDER BY key")
+            rows = cursor.fetchall()
+        except sqlite3.OperationalError as exc:
+            if "no such table" in str(exc).lower():
+                return OrderedDict()
+            LOGGER.warning("Failed to query app_settings: %s", exc)
+            return None
+        finally:
+            conn.close()
+
+        data: "OrderedDict[str, str]" = OrderedDict()
+        for row in rows:
+            data[row["key"]] = row["value"] if row["value"] is not None else ""
+        return data
+
+    def _persist_many(self, values: Mapping[str, str], db_path: Optional[Path] = None) -> bool:
+        conn = self._connect(db_path)
+        if conn is None:
+            LOGGER.debug("Falling back to .env persistence because database is unavailable")
+            return settings_io.write_env(self._values)
+
+        try:
+            cursor = conn.cursor()
+            cursor.execute(SCHEMA)
+            rows = [
+                (key, "" if value is None else str(value))
+                for key, value in values.items()
+            ]
+            cursor.executemany(
+                """
+                INSERT INTO app_settings(key, value, updated_at)
+                VALUES (?, ?, CURRENT_TIMESTAMP)
+                ON CONFLICT(key) DO UPDATE SET
+                    value=excluded.value,
+                    updated_at=CURRENT_TIMESTAMP
+                """,
+                rows,
+            )
+            conn.commit()
+            return True
+        except sqlite3.Error as exc:
+            LOGGER.exception("Failed to persist settings to database: %s", exc)
+            return settings_io.write_env(self._values)
+        finally:
+            conn.close()
+
+    def _delete_keys(self, keys: Iterable[str], db_path: Optional[Path] = None) -> bool:
+        conn = self._connect(db_path)
+        if conn is None:
+            LOGGER.debug("Falling back to .env persistence because database is unavailable")
+            return settings_io.write_env(self._values)
+
+        try:
+            cursor = conn.cursor()
+            cursor.execute(SCHEMA)
+            cursor.executemany("DELETE FROM app_settings WHERE key=?", [(key,) for key in keys])
+            conn.commit()
+            return True
+        except sqlite3.Error as exc:
+            LOGGER.exception("Failed to delete settings from database: %s", exc)
+            return settings_io.write_env(self._values)
+        finally:
+            conn.close()
+
+    def _build_namespace(self, values: Mapping[str, str]) -> SimpleNamespace:
+        get = values.get
+        excluded = {
+            seller.strip()
+            for seller in (get("ALLEGRO_EXCLUDED_SELLERS") or "").split(",")
+            if seller.strip()
+        }
+        base_dir = os.path.dirname(__file__)
+        db_path = get("DB_PATH") or os.path.join(base_dir, "database.db")
+
+        def _bool(key: str, default: str = "1") -> bool:
+            return (get(key, default) or "0") == "1"
+
+        def _int(key: str, default: str) -> int:
+            return int(get(key, default) or default)
+
+        def _float(key: str, default: str) -> float:
+            return float(get(key, default) or default)
+
+        namespace = SimpleNamespace(
+            API_TOKEN=get("API_TOKEN"),
+            PAGE_ACCESS_TOKEN=get("PAGE_ACCESS_TOKEN"),
+            RECIPIENT_ID=get("RECIPIENT_ID"),
+            STATUS_ID=_int("STATUS_ID", "91618"),
+            PRINTER_NAME=get("PRINTER_NAME", "Xprinter"),
+            CUPS_SERVER=get("CUPS_SERVER"),
+            CUPS_PORT=get("CUPS_PORT"),
+            POLL_INTERVAL=_int("POLL_INTERVAL", "60"),
+            QUIET_HOURS_START=get("QUIET_HOURS_START", "10:00"),
+            QUIET_HOURS_END=get("QUIET_HOURS_END", "22:00"),
+            TIMEZONE=get("TIMEZONE", "Europe/Warsaw"),
+            PRINTED_EXPIRY_DAYS=_int("PRINTED_EXPIRY_DAYS", "5"),
+            LOG_LEVEL=(get("LOG_LEVEL", "INFO") or "INFO").upper(),
+            LOG_FILE=get("LOG_FILE", os.path.join(base_dir, "agent.log")),
+            DB_PATH=db_path,
+            SECRET_KEY=get("SECRET_KEY", "default_secret_key"),
+            FLASK_DEBUG=_bool("FLASK_DEBUG", "0"),
+            FLASK_ENV=get("FLASK_ENV", "production"),
+            COMMISSION_ALLEGRO=float(get("COMMISSION_ALLEGRO", "0") or 0),
+            ALLEGRO_SELLER_ID=get("ALLEGRO_SELLER_ID"),
+            ALLEGRO_EXCLUDED_SELLERS=excluded,
+            LOW_STOCK_THRESHOLD=_int("LOW_STOCK_THRESHOLD", "1"),
+            ALERT_EMAIL=get("ALERT_EMAIL"),
+            SMTP_SERVER=get("SMTP_SERVER"),
+            SMTP_PORT=get("SMTP_PORT", "25"),
+            SMTP_USERNAME=get("SMTP_USERNAME"),
+            SMTP_PASSWORD=get("SMTP_PASSWORD"),
+            ENABLE_MONTHLY_REPORTS=_bool("ENABLE_MONTHLY_REPORTS", "1"),
+            ENABLE_WEEKLY_REPORTS=_bool("ENABLE_WEEKLY_REPORTS", "1"),
+            API_RATE_LIMIT_CALLS=_int("API_RATE_LIMIT_CALLS", "60"),
+            API_RATE_LIMIT_PERIOD=_float("API_RATE_LIMIT_PERIOD", "60"),
+            API_RETRY_ATTEMPTS=_int("API_RETRY_ATTEMPTS", "3"),
+            API_RETRY_BACKOFF_INITIAL=_float("API_RETRY_BACKOFF_INITIAL", "1.0"),
+            API_RETRY_BACKOFF_MAX=_float("API_RETRY_BACKOFF_MAX", "30.0"),
+        )
+        return namespace
+
+    def _apply_environment(
+        self,
+        values: Mapping[str, str],
+        removed: Iterable[str] = (),
+        *,
+        replace_all: bool = False,
+    ) -> None:
+        for key in removed:
+            os.environ.pop(key, None)
+
+        target = values if not replace_all else self._values
+        for key, value in target.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = str(value)
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    @property
+    def settings(self) -> SimpleNamespace:
+        self._ensure_loaded()
+        assert self._namespace is not None
+        return self._namespace
+
+    def reload(self) -> SimpleNamespace:
+        with self._lock:
+            self._loaded = False
+            self._namespace = None
+            self._values = OrderedDict()
+        return self.settings
+
+    def as_ordered_dict(
+        self,
+        *,
+        include_hidden: bool = False,
+        logger=None,
+        on_error=None,
+    ) -> "OrderedDict[str, str]":
+        self._ensure_loaded()
+        ordered = settings_io.load_settings(
+            include_hidden=include_hidden,
+            logger=logger,
+            on_error=on_error,
+            example_path=settings_io.EXAMPLE_PATH,
+            env_path=settings_io.ENV_PATH,
+        )
+        result: "OrderedDict[str, str]" = OrderedDict()
+
+        for key in ordered.keys():
+            if not include_hidden and key in settings_io.HIDDEN_KEYS:
+                continue
+            result[key] = self._values.get(key, ordered[key])
+
+        for key, value in self._values.items():
+            if key not in result and (
+                include_hidden or key not in settings_io.HIDDEN_KEYS
+            ):
+                result[key] = value
+
+        return result
+
+    def update(self, values: Mapping[str, str]) -> None:
+        self._ensure_loaded()
+        with self._lock:
+            changed: OrderedDict[str, str] = OrderedDict()
+            removed: list[str] = []
+            for key, value in values.items():
+                if value is None:
+                    if key in self._values:
+                        self._values.pop(key, None)
+                        removed.append(key)
+                    continue
+                str_value = str(value)
+                current = self._values.get(key)
+                if current == str_value:
+                    continue
+                self._values[key] = str_value
+                changed[key] = str_value
+
+            if not changed and not removed:
+                return
+
+            persisted = True
+            if changed:
+                persisted = self._persist_many(changed)
+            if removed:
+                persisted = self._delete_keys(removed) and persisted
+            if not persisted:
+                LOGGER.warning("Settings stored in .env fallback; database unavailable")
+
+            self._apply_environment(changed, removed)
+            self._namespace = self._build_namespace(self._values)
+
+
+settings_store = SettingsStore()
+
+__all__ = ["settings_store", "SettingsStore"]
+

--- a/magazyn/tests/conftest.py
+++ b/magazyn/tests/conftest.py
@@ -42,6 +42,9 @@ def app_mod(tmp_path, monkeypatch):
     app = create_app({"TESTING": True, "WTF_CSRF_ENABLED": False})
     app_mod.app = app
     app_mod.reset_db()
+    from magazyn.settings_store import settings_store
+
+    settings_store.reload()
     return app_mod
 
 

--- a/magazyn/tests/test_settings.py
+++ b/magazyn/tests/test_settings.py
@@ -1,26 +1,8 @@
 import importlib
 import re
-from collections import OrderedDict
-from dotenv import load_dotenv
 
 import magazyn.config as cfg
-
-
-def test_settings_list_all_keys(app_mod, client, login, tmp_path):
-    app_mod.ENV_PATH = tmp_path / ".env"
-    resp = client.get("/settings")
-    assert resp.status_code == 200
-    text = resp.get_data(as_text=True)
-    values = app_mod.load_settings()
-    from magazyn.sales import _sales_keys
-    from magazyn.env_info import ENV_INFO
-    sales_keys = _sales_keys(values)
-    for key in values.keys():
-        label = ENV_INFO.get(key, (key, None))[0]
-        if key in sales_keys:
-            assert label not in text
-        else:
-            assert label in text
+from magazyn.settings_store import settings_store
 
 
 def _extract_input(html, name):
@@ -32,8 +14,40 @@ def _extract_input(html, name):
     return match.group(0)
 
 
-def test_sensitive_tokens_render_as_password(app_mod, client, login, tmp_path):
-    app_mod.ENV_PATH = tmp_path / ".env"
+def test_settings_list_all_keys(app_mod, client, login):
+    settings_store.reload()
+    resp = client.get("/settings")
+    assert resp.status_code == 200
+    text = resp.get_data(as_text=True)
+    values = app_mod.load_settings()
+    from magazyn.sales import _sales_keys
+    from magazyn.env_info import ENV_INFO
+
+    sales_keys = _sales_keys(values)
+    for key in values.keys():
+        label = ENV_INFO.get(key, (key, None))[0]
+        if key in sales_keys:
+            assert label not in text
+        else:
+            assert label in text
+
+
+def test_store_populates_database_when_empty(app_mod):
+    from magazyn import DB_PATH
+    from magazyn.db import sqlite_connect
+
+    with sqlite_connect(DB_PATH) as conn:
+        conn.execute("DELETE FROM app_settings")
+        conn.commit()
+
+    settings_store.reload()
+    values = settings_store.as_ordered_dict(include_hidden=True)
+
+    assert values
+
+
+def test_sensitive_tokens_render_as_password(app_mod, client, login):
+    settings_store.reload()
     resp = client.get("/settings")
     assert resp.status_code == 200
     html = resp.get_data(as_text=True)
@@ -48,73 +62,57 @@ def test_sensitive_tokens_render_as_password(app_mod, client, login, tmp_path):
         assert "type=\"password\"" in field_html.lower()
 
 
-def test_settings_post_saves_and_reloads(
-    app_mod, client, login, tmp_path, monkeypatch
-):
-    app_mod.ENV_PATH = tmp_path / ".env"
+def test_settings_post_updates_store(app_mod, client, login, monkeypatch):
     reloaded = {"called": False}
     monkeypatch.setattr(
         app_mod.print_agent,
         "reload_config",
         lambda: reloaded.update(called=True),
     )
-    values = {k: f"val{i}" for i, k in enumerate(app_mod.load_settings().keys())}
+    values = app_mod.load_settings(include_hidden=True)
     from magazyn.sales import _sales_keys
+
     for skey in _sales_keys(values):
-        values.pop(skey)
+        values.pop(skey, None)
+    values["QUIET_HOURS_START"] = "10:00"
+    values["QUIET_HOURS_END"] = "22:00"
+    values["API_TOKEN"] = "val0"
+    resp = client.post("/settings", data=values)
+    assert resp.status_code == 302
+    stored = settings_store.as_ordered_dict(include_hidden=True)
+    assert stored["API_TOKEN"] == "val0"
+    assert reloaded["called"] is True
+
+
+def test_weekly_reports_setting_saved(app_mod, client, login):
+    values = app_mod.load_settings(include_hidden=True)
+    assert "ENABLE_WEEKLY_REPORTS" in values
+    from magazyn.sales import _sales_keys
+
+    for skey in _sales_keys(values):
+        values.pop(skey, None)
+    values["ENABLE_WEEKLY_REPORTS"] = "0"
     values["QUIET_HOURS_START"] = "10:00"
     values["QUIET_HOURS_END"] = "22:00"
     resp = client.post("/settings", data=values)
     assert resp.status_code == 302
-    env_text = app_mod.ENV_PATH.read_text()
-    assert "API_TOKEN=val0" in env_text
-    assert reloaded["called"] is True
+    stored = settings_store.as_ordered_dict()
+    assert stored["ENABLE_WEEKLY_REPORTS"] == "0"
 
 
-def test_weekly_reports_setting_saved(app_mod, client, login, tmp_path):
-    app_mod.ENV_PATH = tmp_path / ".env"
-    resp = client.get("/settings")
-    assert resp.status_code == 200
-    html = resp.get_data(as_text=True)
-    assert "Raport tygodniowy" in html
-
-    values = app_mod.load_settings()
-    assert "ENABLE_WEEKLY_REPORTS" in values
-    values["ENABLE_WEEKLY_REPORTS"] = "0"
+def test_settings_reload_updates_print_agent(app_mod, client, login, monkeypatch):
+    values = app_mod.load_settings(include_hidden=True)
+    values["API_TOKEN"] = "v0"
     from magazyn.sales import _sales_keys
+
     for skey in _sales_keys(values):
-        values.pop(skey)
+        values.pop(skey, None)
     values["QUIET_HOURS_START"] = "10:00"
     values["QUIET_HOURS_END"] = "22:00"
     client.post("/settings", data=values)
-    env_text = app_mod.ENV_PATH.read_text()
-    assert "ENABLE_WEEKLY_REPORTS=0" in env_text
+    assert settings_store.settings.API_TOKEN == "v0"
 
-
-def test_env_updates_persist_and_reload(
-    app_mod, client, login, tmp_path, monkeypatch
-):
-    app_mod.ENV_PATH = tmp_path / ".env"
-
-    original_load = cfg.load_config
-
-    def reload_cfg():
-        load_dotenv(app_mod.ENV_PATH, override=True)
-        return original_load()
-
-    monkeypatch.setattr(cfg, "load_config", reload_cfg)
-    monkeypatch.setattr(app_mod.print_agent, "load_config", reload_cfg)
-
-    values = app_mod.load_settings()
-    values["API_TOKEN"] = "v0"
-    client.post("/settings", data=values)
-    assert "API_TOKEN=v0" in app_mod.ENV_PATH.read_text()
-    assert app_mod.print_agent.API_TOKEN == "v0"
-
-    new_text = app_mod.ENV_PATH.read_text().replace(
-        "API_TOKEN=v0", "API_TOKEN=new0"
-    )
-    app_mod.ENV_PATH.write_text(new_text)
+    settings_store.update({"API_TOKEN": "new0"})
     app_mod.print_agent.reload_config()
     assert app_mod.print_agent.API_TOKEN == "new0"
     cfg.settings = app_mod.print_agent.settings
@@ -123,39 +121,45 @@ def test_env_updates_persist_and_reload(
     assert pa.API_TOKEN == "new0"
 
 
-def test_extra_keys_display_and_save(
-    app_mod, client, login, tmp_path, monkeypatch
-):
-    app_mod.ENV_PATH = tmp_path / ".env"
-    # create env file with an additional key
-    app_mod.ENV_PATH.write_text("EXTRA_KEY=foo\n")
+def test_extra_keys_display_and_save(app_mod, client, login, monkeypatch):
+    settings_store.update({"EXTRA_KEY": "foo"})
 
     resp = client.get("/settings")
     assert resp.status_code == 200
     html = resp.get_data(as_text=True)
     from magazyn.env_info import ENV_INFO
+
     label = ENV_INFO.get("EXTRA_KEY", ("EXTRA_KEY", None))[0]
     assert label in html
     extra_field = _extract_input(html, "EXTRA_KEY")
     assert "type=\"password\"" in extra_field.lower()
 
-    values = app_mod.load_settings()
-    assert values.get("EXTRA_KEY") == "foo"
+    values = app_mod.load_settings(include_hidden=True)
     values["EXTRA_KEY"] = "bar"
+    from magazyn.sales import _sales_keys
+
+    for skey in _sales_keys(values):
+        values.pop(skey, None)
+    values["QUIET_HOURS_START"] = "10:00"
+    values["QUIET_HOURS_END"] = "22:00"
     client.post("/settings", data=values)
-    env_lines = app_mod.ENV_PATH.read_text().strip().splitlines()
-    assert env_lines[-1] == "EXTRA_KEY=bar"
-    assert "EXTRA_KEY" in app_mod.load_settings()
+    stored = settings_store.as_ordered_dict(include_hidden=True)
+    assert stored["EXTRA_KEY"] == "bar"
 
 
 def test_missing_example_file(app_mod, client, login, tmp_path, monkeypatch):
-    app_mod.ENV_PATH = tmp_path / ".env"
-    app_mod.EXAMPLE_PATH = tmp_path / "no.env.example"
+    from magazyn import settings_io
+
+    monkeypatch.setattr(settings_io, "EXAMPLE_PATH", tmp_path / "no.env.example")
+    settings_store.reload()
 
     resp = client.get("/settings")
     assert resp.status_code == 200
-    html = resp.get_data(as_text=True)
-    assert "plik .env.example" in html.lower()
+
+    from flask import get_flashed_messages
 
     with app_mod.app.test_request_context():
-        assert app_mod.load_settings() == OrderedDict()
+        values = app_mod.load_settings()
+        flashes = get_flashed_messages()
+        assert any("plik .env.example" in msg.lower() for msg in flashes)
+        assert values  # fallback still provides stored values


### PR DESCRIPTION
## Summary
- add an `AppSetting` ORM model and standalone migration to create the `app_settings` table
- implement a SQLite-backed `SettingsStore` service with `.env` fallback helpers and wire it into configuration loading, token handling, and sales settings
- refresh the settings views/tests to exercise the database migration path and persisting updates via the new store

## Testing
- `PYTHONPATH=. pytest`
- `PYTHONPATH=. pytest magazyn/tests/test_settings.py magazyn/tests/test_sales_settings.py magazyn/tests/test_migrations.py`


------
https://chatgpt.com/codex/tasks/task_e_68d03f5c99cc832a8ca2a079f75f9a55