### PR TITLE
Handle settings persistence failures

### DIFF
--- a/magazyn/metrics.py
+++ b/magazyn/metrics.py
@@ -70,4 +70,5 @@ ALLEGRO_API_RATE_LIMIT_SLEEP_SECONDS.labels(endpoint="listing").inc(0)
 ALLEGRO_SYNC_ERRORS_TOTAL.labels(reason="http").inc(0)
 ALLEGRO_SYNC_ERRORS_TOTAL.labels(reason="token_refresh").inc(0)
 ALLEGRO_SYNC_ERRORS_TOTAL.labels(reason="unexpected").inc(0)
+ALLEGRO_SYNC_ERRORS_TOTAL.labels(reason="settings_store").inc(0)
 


### PR DESCRIPTION
## Summary
- add a dedicated `SettingsPersistenceError` and ensure the settings store raises when neither the database nor the `.env` fallback can be written
- surface read-only guidance during the Allegro sync flow while counting the new failure mode
- extend the Allegro refresh tests to cover the fatal path where credential persistence is unavailable

## Testing
- PYTHONPATH=. pytest magazyn/tests/test_allegro_refresh.py

------
https://chatgpt.com/codex/tasks/task_e_68d06c3aadd0832aafc123c7d1ece9ec