### PR TITLE
Handle read-only settings store without .env fallback

### DIFF
--- a/magazyn/env_tokens.py
+++ b/magazyn/env_tokens.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import os
 from typing import Optional
 
 from .settings_store import settings_store
@@ -25,11 +24,6 @@ def update_allegro_tokens(
     if access_token is None and refresh_token is None:
         return
 
-    if access_token is not None:
-        os.environ["ALLEGRO_ACCESS_TOKEN"] = access_token
-    if refresh_token is not None:
-        os.environ["ALLEGRO_REFRESH_TOKEN"] = refresh_token
-
     updates = {}
     if access_token is not None:
         updates["ALLEGRO_ACCESS_TOKEN"] = access_token
@@ -41,9 +35,6 @@ def update_allegro_tokens(
 
 def clear_allegro_tokens() -> None:
     """Remove Allegro OAuth tokens from the environment and persisted settings."""
-
-    os.environ.pop("ALLEGRO_ACCESS_TOKEN", None)
-    os.environ.pop("ALLEGRO_REFRESH_TOKEN", None)
 
     settings_store.update(
         {

--- a/magazyn/tests/test_allegro_refresh.py
+++ b/magazyn/tests/test_allegro_refresh.py
@@ -848,8 +848,8 @@ def test_sync_offers_aborts_when_settings_store_is_read_only(
 
     assert "settings store is read-only" in str(excinfo.value)
     assert metric._value.get() == initial_value + 1
-    assert os.environ.get("ALLEGRO_ACCESS_TOKEN") == "new-access-token"
-    assert os.environ.get("ALLEGRO_REFRESH_TOKEN") == "new-refresh-token"
+    assert os.environ.get("ALLEGRO_ACCESS_TOKEN") is None
+    assert os.environ.get("ALLEGRO_REFRESH_TOKEN") == "refresh-token"
 
     os.environ.pop("ALLEGRO_ACCESS_TOKEN", None)
     os.environ.pop("ALLEGRO_REFRESH_TOKEN", None)

--- a/magazyn/tests/test_settings_read_only.py
+++ b/magazyn/tests/test_settings_read_only.py
@@ -1,0 +1,97 @@
+import os
+import sqlite3
+
+import pytest
+
+from magazyn import settings_io
+from magazyn.env_tokens import clear_allegro_tokens, update_allegro_tokens
+from magazyn.settings_store import (
+    SCHEMA,
+    SettingsPersistenceError,
+    settings_store,
+)
+
+
+@pytest.fixture
+def read_only_settings_store(tmp_path):
+    monkeypatch = pytest.MonkeyPatch()
+    example_path = tmp_path / ".env.example"
+    example_path.write_text(
+        settings_io.EXAMPLE_PATH.read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+    env_path = tmp_path / ".env"
+    db_path = tmp_path / "settings.db"
+
+    with sqlite3.connect(db_path) as conn:
+        conn.executescript(SCHEMA)
+
+    original_connect = sqlite3.connect
+
+    def read_only_connect(target, *args, **kwargs):
+        if str(target) == str(db_path):
+            ro_kwargs = dict(kwargs)
+            ro_kwargs.setdefault("uri", True)
+            return original_connect(
+                f"file:{db_path}?mode=ro", *args, **ro_kwargs
+            )
+        return original_connect(target, *args, **kwargs)
+
+    monkeypatch.setattr(sqlite3, "connect", read_only_connect)
+    monkeypatch.setattr("magazyn.settings_store.sqlite3.connect", read_only_connect)
+
+    env_path.write_text(
+        "\n".join(
+            [
+                "ALLEGRO_ACCESS_TOKEN=stored-access",
+                "ALLEGRO_REFRESH_TOKEN=stored-refresh",
+                f"DB_PATH={db_path}",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(settings_io, "ENV_PATH", env_path)
+    monkeypatch.setattr(settings_io, "EXAMPLE_PATH", example_path)
+    monkeypatch.setenv("DB_PATH", str(db_path))
+
+    settings_store.reload()
+
+    try:
+        yield env_path
+    finally:
+        monkeypatch.undo()
+        settings_store.reload()
+
+
+def test_update_tokens_read_only_database_preserves_tokens(read_only_settings_store):
+    env_path = read_only_settings_store
+    original_env = env_path.read_text(encoding="utf-8")
+    original_access = settings_store.get("ALLEGRO_ACCESS_TOKEN")
+    original_refresh = settings_store.get("ALLEGRO_REFRESH_TOKEN")
+
+    with pytest.raises(SettingsPersistenceError):
+        update_allegro_tokens("new-access", "new-refresh")
+
+    assert settings_store.get("ALLEGRO_ACCESS_TOKEN") == original_access
+    assert settings_store.get("ALLEGRO_REFRESH_TOKEN") == original_refresh
+    assert os.environ.get("ALLEGRO_ACCESS_TOKEN") == original_access
+    assert os.environ.get("ALLEGRO_REFRESH_TOKEN") == original_refresh
+    assert env_path.read_text(encoding="utf-8") == original_env
+
+
+def test_clear_tokens_read_only_database_preserves_tokens(read_only_settings_store):
+    env_path = read_only_settings_store
+    original_env = env_path.read_text(encoding="utf-8")
+    original_access = settings_store.get("ALLEGRO_ACCESS_TOKEN")
+    original_refresh = settings_store.get("ALLEGRO_REFRESH_TOKEN")
+
+    with pytest.raises(SettingsPersistenceError):
+        clear_allegro_tokens()
+
+    assert settings_store.get("ALLEGRO_ACCESS_TOKEN") == original_access
+    assert settings_store.get("ALLEGRO_REFRESH_TOKEN") == original_refresh
+    assert os.environ.get("ALLEGRO_ACCESS_TOKEN") == original_access
+    assert os.environ.get("ALLEGRO_REFRESH_TOKEN") == original_refresh
+    assert env_path.read_text(encoding="utf-8") == original_env


### PR DESCRIPTION
## Summary
- raise `SettingsPersistenceError` when SQLite writes fail and stop falling back to `.env`
- surface configuration persistence failures in the admin UI and Allegro integrations
- cover read-only database scenarios with new regression tests

## Testing
- PYTHONPATH=. pytest magazyn/tests/test_settings_read_only.py -q
- PYTHONPATH=. pytest magazyn/tests/test_allegro_refresh.py::test_sync_offers_aborts_when_settings_store_is_read_only -q
- PYTHONPATH=. pytest magazyn/tests/test_settings.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d0850d3d6c832a9b2e5f2668fba09c