### PR TITLE
Implement SettingsStore staleness detection for Allegro tokens

### DIFF
--- a/magazyn/allegro_api.py
+++ b/magazyn/allegro_api.py
@@ -262,6 +262,15 @@ def fetch_product_listing(ean: str, page: int = 1) -> list:
             "please re-authorize the Allegro integration"
         )
 
+        latest_token = settings_store.get("ALLEGRO_ACCESS_TOKEN")
+        latest_refresh = settings_store.get("ALLEGRO_REFRESH_TOKEN")
+        if latest_token and latest_token != token:
+            token = latest_token
+            refresh = latest_refresh
+            return True
+        if latest_refresh and latest_refresh != refresh:
+            refresh = latest_refresh
+
         if refresh and not refreshed:
             refreshed = True
             try:


### PR DESCRIPTION
## Summary
- add a lightweight staleness check to `SettingsStore` so cached values reload when the SQLite store updates
- update Allegro sync helpers to re-read credentials before retrying API calls after an unauthorized response
- add an integration test that simulates a second process updating the Allegro tokens and verifies the worker picks them up without restarting

## Testing
- PYTHONPATH=. pytest magazyn/tests/test_allegro_refresh.py


------
https://chatgpt.com/codex/tasks/task_e_68d088d39da8832ab35828fcf88f3bb0