### PR TITLE
Handle Allegro OAuth callback and persist tokens

### DIFF
--- a/magazyn/env_tokens.py
+++ b/magazyn/env_tokens.py
@@ -8,7 +8,9 @@ from .settings_store import settings_store
 
 
 def update_allegro_tokens(
-    access_token: Optional[str] = None, refresh_token: Optional[str] = None
+    access_token: Optional[str] = None,
+    refresh_token: Optional[str] = None,
+    expires_in: Optional[int] = None,
 ) -> None:
     """Persist new Allegro OAuth tokens and update ``os.environ``.
 
@@ -19,9 +21,12 @@ def update_allegro_tokens(
         modified.
     refresh_token:
         The accompanying refresh token. If ``None`` the previous value is kept.
+    expires_in:
+        Lifetime of the access token in seconds. When provided the value is
+        stored alongside the tokens for later reference.
     """
 
-    if access_token is None and refresh_token is None:
+    if access_token is None and refresh_token is None and expires_in is None:
         return
 
     updates = {}
@@ -29,6 +34,8 @@ def update_allegro_tokens(
         updates["ALLEGRO_ACCESS_TOKEN"] = access_token
     if refresh_token is not None:
         updates["ALLEGRO_REFRESH_TOKEN"] = refresh_token
+    if expires_in is not None:
+        updates["ALLEGRO_TOKEN_EXPIRES_IN"] = expires_in
     if updates:
         settings_store.update(updates)
 
@@ -40,6 +47,8 @@ def clear_allegro_tokens() -> None:
         {
             "ALLEGRO_ACCESS_TOKEN": None,
             "ALLEGRO_REFRESH_TOKEN": None,
+            "ALLEGRO_TOKEN_EXPIRES_IN": None,
+            "ALLEGRO_TOKEN_METADATA": None,
         }
     )
 

--- a/magazyn/tests/conftest.py
+++ b/magazyn/tests/conftest.py
@@ -70,6 +70,8 @@ def allegro_tokens():
         {
             "ALLEGRO_ACCESS_TOKEN": None,
             "ALLEGRO_REFRESH_TOKEN": None,
+            "ALLEGRO_TOKEN_EXPIRES_IN": None,
+            "ALLEGRO_TOKEN_METADATA": None,
         }
     )
 
@@ -89,6 +91,8 @@ def allegro_tokens():
                 {
                     "ALLEGRO_ACCESS_TOKEN": None,
                     "ALLEGRO_REFRESH_TOKEN": None,
+                    "ALLEGRO_TOKEN_EXPIRES_IN": None,
+                    "ALLEGRO_TOKEN_METADATA": None,
                 }
             )
 
@@ -98,6 +102,8 @@ def allegro_tokens():
         {
             "ALLEGRO_ACCESS_TOKEN": None,
             "ALLEGRO_REFRESH_TOKEN": None,
+            "ALLEGRO_TOKEN_EXPIRES_IN": None,
+            "ALLEGRO_TOKEN_METADATA": None,
         }
     )
     settings_store.reload()

--- a/magazyn/tests/test_allegro_offers.py
+++ b/magazyn/tests/test_allegro_offers.py
@@ -462,11 +462,15 @@ def test_fetch_product_listing_refreshes_token_on_unauthorized(monkeypatch, alle
 
     original_update = allegro_api.update_allegro_tokens
 
-    def capture_tokens(access_token=None, refresh_token=None):
+    def capture_tokens(access_token=None, refresh_token=None, expires_in=None):
         persisted.append(
-            {"access_token": access_token, "refresh_token": refresh_token}
+            {
+                "access_token": access_token,
+                "refresh_token": refresh_token,
+                "expires_in": expires_in,
+            }
         )
-        original_update(access_token, refresh_token)
+        original_update(access_token, refresh_token, expires_in)
 
     monkeypatch.setattr(
         "magazyn.allegro_api.update_allegro_tokens", capture_tokens
@@ -480,7 +484,11 @@ def test_fetch_product_listing_refreshes_token_on_unauthorized(monkeypatch, alle
     assert settings_store.get("ALLEGRO_ACCESS_TOKEN") == "new-access"
     assert settings_store.get("ALLEGRO_REFRESH_TOKEN") == "new-refresh"
     assert persisted == [
-        {"access_token": "new-access", "refresh_token": "new-refresh"}
+        {
+            "access_token": "new-access",
+            "refresh_token": "new-refresh",
+            "expires_in": None,
+        }
     ]
     assert offers == [
         {


### PR DESCRIPTION
## Summary
- add an Allegro OAuth callback route that validates state, exchanges the code for tokens, and stores metadata
- extend Allegro token helpers and fixtures to persist token expiry information alongside the credentials
- cover OAuth callback success and failure paths with new integration tests and update existing token refresh assertions

## Testing
- PYTHONPATH=. pytest magazyn/tests/test_allegro_refresh.py
- PYTHONPATH=. pytest magazyn/tests/test_allegro_offers.py

------
https://chatgpt.com/codex/tasks/task_e_68d09ae3fea4832aa0ec0c6c9e32dfc3