### PR TITLE
Add automatic Allegro token refresh scheduler

### DIFF
--- a/magazyn/allegro_api.py
+++ b/magazyn/allegro_api.py
@@ -16,6 +16,13 @@ from .metrics import (
     ALLEGRO_API_RETRIES_TOTAL,
 )
 
+
+def _safe_int(value) -> Optional[int]:
+    try:
+        return int(value) if value is not None else None
+    except (TypeError, ValueError):
+        return None
+
 AUTH_URL = "https://allegro.pl/auth/oauth/token"
 API_BASE_URL = "https://api.allegro.pl"
 DEFAULT_TIMEOUT = 10
@@ -288,8 +295,9 @@ def fetch_product_listing(ean: str, page: int = 1) -> list:
             new_refresh = token_data.get("refresh_token")
             if new_refresh:
                 refresh = new_refresh
+            expires_in = _safe_int(token_data.get("expires_in")) if token_data else None
             try:
-                update_allegro_tokens(token, refresh)
+                update_allegro_tokens(token, refresh, expires_in)
             except SettingsPersistenceError as exc:
                 friendly_message = (
                     "Cannot refresh Allegro access token because the settings store is "

--- a/magazyn/allegro_sync.py
+++ b/magazyn/allegro_sync.py
@@ -88,8 +88,9 @@ def sync_offers():
             new_refresh = token_data.get("refresh_token")
             if new_refresh:
                 refresh = new_refresh
+            expires_in = _parse_int(token_data.get("expires_in")) if token_data else None
             if token:
-                update_allegro_tokens(token, refresh)
+                update_allegro_tokens(token, refresh, expires_in)
         except SettingsPersistenceError as exc:
             _raise_settings_store_read_only(exc)
         except Exception as exc:
@@ -149,8 +150,9 @@ def sync_offers():
                         new_refresh = token_data.get("refresh_token")
                         if new_refresh:
                             refresh = new_refresh
+                        expires_in = _parse_int(token_data.get("expires_in")) if token_data else None
                         try:
-                            update_allegro_tokens(token, refresh)
+                            update_allegro_tokens(token, refresh, expires_in)
                         except SettingsPersistenceError as persistence_exc:
                             _raise_settings_store_read_only(persistence_exc)
                         continue

--- a/magazyn/allegro_token_refresher.py
+++ b/magazyn/allegro_token_refresher.py
@@ -1,0 +1,222 @@
+"""Background task refreshing Allegro OAuth tokens before expiry."""
+
+from __future__ import annotations
+
+import json
+import logging
+import threading
+import time
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+from requests.exceptions import HTTPError, RequestException
+
+from . import allegro_api
+from .env_tokens import update_allegro_tokens
+from .metrics import (
+    ALLEGRO_TOKEN_REFRESH_ATTEMPTS_TOTAL,
+    ALLEGRO_TOKEN_REFRESH_LAST_SUCCESS,
+    ALLEGRO_TOKEN_REFRESH_RETRIES_TOTAL,
+)
+from .settings_store import SettingsPersistenceError, settings_store
+
+LOGGER = logging.getLogger(__name__)
+
+
+def _parse_int(value: object) -> Optional[int]:
+    try:
+        if value is None:
+            return None
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _parse_datetime(value: object) -> Optional[datetime]:
+    if not isinstance(value, str):
+        return None
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+class AllegroTokenRefresher:
+    """Refresh Allegro OAuth tokens shortly before they expire."""
+
+    def __init__(
+        self,
+        margin_seconds: int = 300,
+        idle_interval_seconds: float = 60.0,
+        error_backoff_initial: float = 30.0,
+        error_backoff_max: float = 600.0,
+    ) -> None:
+        self._margin_seconds = margin_seconds
+        self._idle_interval = idle_interval_seconds
+        self._error_backoff_initial = error_backoff_initial
+        self._error_backoff_max = error_backoff_max
+        self._lock = threading.Lock()
+        self._stop_event = threading.Event()
+        self._thread: Optional[threading.Thread] = None
+
+    def start(self) -> bool:
+        """Start the background refresher thread."""
+
+        with self._lock:
+            if self._thread and self._thread.is_alive():
+                return False
+            self._stop_event.clear()
+            thread = threading.Thread(
+                target=self._run,
+                name="AllegroTokenRefresher",
+                daemon=True,
+            )
+            thread.start()
+            self._thread = thread
+            LOGGER.info(
+                "Started Allegro token refresher with margin=%ss and idle interval=%ss",
+                self._margin_seconds,
+                self._idle_interval,
+            )
+            return True
+
+    def stop(self) -> None:
+        """Stop the background refresher thread."""
+
+        with self._lock:
+            if not self._thread:
+                return
+            self._stop_event.set()
+            thread = self._thread
+        thread.join()
+        with self._lock:
+            self._thread = None
+            self._stop_event.clear()
+            LOGGER.info("Stopped Allegro token refresher")
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _seconds_until_refresh(self) -> Optional[float]:
+        access_token = settings_store.get("ALLEGRO_ACCESS_TOKEN")
+        refresh_token = settings_store.get("ALLEGRO_REFRESH_TOKEN")
+        if not access_token or not refresh_token:
+            return None
+
+        metadata_raw = settings_store.get("ALLEGRO_TOKEN_METADATA")
+        metadata: dict[str, object] = {}
+        if metadata_raw:
+            try:
+                loaded = json.loads(metadata_raw)
+                if isinstance(loaded, dict):
+                    metadata.update(loaded)
+            except (TypeError, ValueError):
+                LOGGER.debug("Failed to decode Allegro token metadata", exc_info=True)
+
+        expires_at = _parse_datetime(metadata.get("expires_at"))
+        if expires_at is None:
+            expires_in = metadata.get("expires_in")
+            if expires_in is None:
+                expires_in = settings_store.get("ALLEGRO_TOKEN_EXPIRES_IN")
+            expires_in_value = _parse_int(expires_in)
+            obtained_at = _parse_datetime(metadata.get("obtained_at"))
+            if expires_in_value is not None and obtained_at is not None:
+                expires_at = obtained_at + timedelta(seconds=expires_in_value)
+
+        if expires_at is None:
+            return None
+
+        refresh_at = expires_at - timedelta(seconds=self._margin_seconds)
+        now = datetime.now(timezone.utc)
+        return (refresh_at - now).total_seconds()
+
+    def _refresh_tokens(self) -> bool:
+        refresh_token = settings_store.get("ALLEGRO_REFRESH_TOKEN")
+        if not refresh_token:
+            LOGGER.debug(
+                "Skipping automatic Allegro token refresh because no refresh token is stored",
+            )
+            ALLEGRO_TOKEN_REFRESH_ATTEMPTS_TOTAL.labels(result="skipped").inc()
+            return True
+
+        try:
+            payload = allegro_api.refresh_token(refresh_token)
+        except HTTPError as exc:
+            status_code = getattr(getattr(exc, "response", None), "status_code", None)
+            LOGGER.warning(
+                "Automatic Allegro token refresh failed with HTTP status %s",
+                status_code or "unknown",
+                exc_info=True,
+            )
+            ALLEGRO_TOKEN_REFRESH_ATTEMPTS_TOTAL.labels(result="error").inc()
+            return False
+        except RequestException as exc:
+            LOGGER.warning("Automatic Allegro token refresh failed: %s", exc, exc_info=True)
+            ALLEGRO_TOKEN_REFRESH_ATTEMPTS_TOTAL.labels(result="error").inc()
+            return False
+        except Exception:
+            LOGGER.exception("Unexpected error while refreshing Allegro tokens automatically")
+            ALLEGRO_TOKEN_REFRESH_ATTEMPTS_TOTAL.labels(result="error").inc()
+            return False
+
+        access_token = None
+        new_refresh_token = refresh_token
+        expires_in: Optional[int] = None
+        metadata: dict[str, object] = {}
+        if isinstance(payload, dict):
+            access_token = payload.get("access_token")
+            new_refresh_raw = payload.get("refresh_token")
+            if new_refresh_raw:
+                new_refresh_token = new_refresh_raw
+            expires_in = _parse_int(payload.get("expires_in"))
+            if payload.get("scope"):
+                metadata["scope"] = payload["scope"]
+            if payload.get("token_type"):
+                metadata["token_type"] = payload["token_type"]
+
+        if not access_token:
+            LOGGER.error("Automatic Allegro token refresh returned no access token")
+            ALLEGRO_TOKEN_REFRESH_ATTEMPTS_TOTAL.labels(result="error").inc()
+            return False
+
+        try:
+            update_allegro_tokens(access_token, new_refresh_token, expires_in, metadata)
+        except SettingsPersistenceError:
+            LOGGER.exception(
+                "Failed to persist refreshed Allegro tokens; the settings store might be read-only",
+            )
+            ALLEGRO_TOKEN_REFRESH_ATTEMPTS_TOTAL.labels(result="error").inc()
+            return False
+
+        ALLEGRO_TOKEN_REFRESH_ATTEMPTS_TOTAL.labels(result="success").inc()
+        ALLEGRO_TOKEN_REFRESH_LAST_SUCCESS.set(time.time())
+        LOGGER.info(
+            "Successfully refreshed Allegro access token automatically (expires in %s seconds)",
+            expires_in if expires_in is not None else "unknown",
+        )
+        return True
+
+    def _run(self) -> None:
+        backoff = self._error_backoff_initial
+        while not self._stop_event.is_set():
+            seconds_until_refresh = self._seconds_until_refresh()
+            if seconds_until_refresh is None:
+                wait_time = self._idle_interval
+            elif seconds_until_refresh <= 0:
+                if self._refresh_tokens():
+                    backoff = self._error_backoff_initial
+                    continue
+                ALLEGRO_TOKEN_REFRESH_RETRIES_TOTAL.inc()
+                wait_time = backoff
+                backoff = min(backoff * 2, self._error_backoff_max)
+            else:
+                wait_time = min(seconds_until_refresh, self._idle_interval)
+            self._stop_event.wait(max(wait_time, 0.01))
+
+
+token_refresher = AllegroTokenRefresher()
+
+__all__ = ["AllegroTokenRefresher", "token_refresher"]

--- a/magazyn/env_tokens.py
+++ b/magazyn/env_tokens.py
@@ -2,15 +2,21 @@
 
 from __future__ import annotations
 
-from typing import Optional
+import json
+import logging
+from datetime import datetime, timedelta, timezone
+from typing import Mapping, Optional
 
 from .settings_store import settings_store
+
+LOGGER = logging.getLogger(__name__)
 
 
 def update_allegro_tokens(
     access_token: Optional[str] = None,
     refresh_token: Optional[str] = None,
     expires_in: Optional[int] = None,
+    metadata: Optional[Mapping[str, object]] = None,
 ) -> None:
     """Persist new Allegro OAuth tokens and update ``os.environ``.
 
@@ -23,10 +29,21 @@ def update_allegro_tokens(
         The accompanying refresh token. If ``None`` the previous value is kept.
     expires_in:
         Lifetime of the access token in seconds. When provided the value is
-        stored alongside the tokens for later reference.
+        stored alongside the tokens for later reference. The timestamp when the
+        token expires is derived from this value and stored in
+        ``ALLEGRO_TOKEN_METADATA``.
+    metadata:
+        Optional mapping with additional metadata values that should be stored
+        alongside the tokens. When present these values are merged with any
+        existing metadata.
     """
 
-    if access_token is None and refresh_token is None and expires_in is None:
+    if (
+        access_token is None
+        and refresh_token is None
+        and expires_in is None
+        and metadata is None
+    ):
         return
 
     updates = {}
@@ -34,8 +51,47 @@ def update_allegro_tokens(
         updates["ALLEGRO_ACCESS_TOKEN"] = access_token
     if refresh_token is not None:
         updates["ALLEGRO_REFRESH_TOKEN"] = refresh_token
+    expires_value: Optional[int] = None
     if expires_in is not None:
+        try:
+            expires_value = int(expires_in)
+        except (TypeError, ValueError):
+            expires_value = None
         updates["ALLEGRO_TOKEN_EXPIRES_IN"] = expires_in
+
+    metadata_payload: dict[str, object] = {}
+    existing_metadata_raw = settings_store.get("ALLEGRO_TOKEN_METADATA")
+    if existing_metadata_raw:
+        try:
+            existing_metadata = json.loads(existing_metadata_raw)
+            if isinstance(existing_metadata, dict):
+                metadata_payload.update(existing_metadata)
+        except (TypeError, ValueError):
+            LOGGER.debug("Ignoring malformed Allegro token metadata", exc_info=True)
+
+    now = datetime.now(timezone.utc)
+    tokens_modified = (
+        access_token is not None
+        or refresh_token is not None
+        or expires_in is not None
+    )
+    if tokens_modified:
+        metadata_payload["obtained_at"] = now.isoformat()
+
+    if expires_value is not None:
+        metadata_payload["expires_in"] = expires_value
+        metadata_payload["expires_at"] = (
+            now + timedelta(seconds=expires_value)
+        ).isoformat()
+
+    if metadata:
+        metadata_payload.update(metadata)
+
+    if metadata_payload:
+        updates["ALLEGRO_TOKEN_METADATA"] = json.dumps(
+            metadata_payload, ensure_ascii=False
+        )
+
     if updates:
         settings_store.update(updates)
 

--- a/magazyn/metrics.py
+++ b/magazyn/metrics.py
@@ -53,6 +53,19 @@ ALLEGRO_SYNC_ERRORS_TOTAL = Counter(
     "Total number of unrecoverable Allegro synchronisation errors.",
     ["reason"],
 )
+ALLEGRO_TOKEN_REFRESH_ATTEMPTS_TOTAL = Counter(
+    "magazyn_allegro_token_refresh_attempts_total",
+    "Total number of automatic Allegro token refresh attempts grouped by result.",
+    ["result"],
+)
+ALLEGRO_TOKEN_REFRESH_RETRIES_TOTAL = Counter(
+    "magazyn_allegro_token_refresh_retries_total",
+    "Total number of retry attempts performed after refresh failures.",
+)
+ALLEGRO_TOKEN_REFRESH_LAST_SUCCESS = Gauge(
+    "magazyn_allegro_token_refresh_last_success_timestamp",
+    "Unix timestamp of the last successful automatic Allegro token refresh.",
+)
 
 PRINT_QUEUE_SIZE.set(0)
 PRINT_QUEUE_OLDEST_AGE_SECONDS.set(0)
@@ -71,4 +84,9 @@ ALLEGRO_SYNC_ERRORS_TOTAL.labels(reason="http").inc(0)
 ALLEGRO_SYNC_ERRORS_TOTAL.labels(reason="token_refresh").inc(0)
 ALLEGRO_SYNC_ERRORS_TOTAL.labels(reason="unexpected").inc(0)
 ALLEGRO_SYNC_ERRORS_TOTAL.labels(reason="settings_store").inc(0)
+ALLEGRO_TOKEN_REFRESH_ATTEMPTS_TOTAL.labels(result="success").inc(0)
+ALLEGRO_TOKEN_REFRESH_ATTEMPTS_TOTAL.labels(result="error").inc(0)
+ALLEGRO_TOKEN_REFRESH_ATTEMPTS_TOTAL.labels(result="skipped").inc(0)
+ALLEGRO_TOKEN_REFRESH_RETRIES_TOTAL.inc(0)
+ALLEGRO_TOKEN_REFRESH_LAST_SUCCESS.set(0)
 

--- a/magazyn/print_agent.py
+++ b/magazyn/print_agent.py
@@ -24,6 +24,7 @@ from .db import sqlite_connect
 from .notifications import send_report
 from .parsing import parse_product_info
 from .services import consume_order_stock, get_sales_summary
+from .allegro_token_refresher import token_refresher
 from .metrics import (
     PRINT_AGENT_DOWNTIME_SECONDS,
     PRINT_AGENT_ITERATION_SECONDS,
@@ -1146,6 +1147,7 @@ class LabelAgent:
                 os.remove(self.config.lock_file)
             except OSError:
                 pass
+        token_refresher.stop()
 
 
 def shorten_product_name(full_name: str) -> str:

--- a/magazyn/tests/test_allegro_offers.py
+++ b/magazyn/tests/test_allegro_offers.py
@@ -454,7 +454,11 @@ def test_fetch_product_listing_refreshes_token_on_unauthorized(monkeypatch, alle
 
     def fake_refresh(refresh_value):
         assert refresh_value == "refresh-token"
-        return {"access_token": "new-access", "refresh_token": "new-refresh"}
+        return {
+            "access_token": "new-access",
+            "refresh_token": "new-refresh",
+            "expires_in": 3600,
+        }
 
     monkeypatch.setattr("magazyn.allegro_api.requests.get", fake_get)
     monkeypatch.setattr("magazyn.allegro_api.refresh_token", fake_refresh)
@@ -462,7 +466,9 @@ def test_fetch_product_listing_refreshes_token_on_unauthorized(monkeypatch, alle
 
     original_update = allegro_api.update_allegro_tokens
 
-    def capture_tokens(access_token=None, refresh_token=None, expires_in=None):
+    def capture_tokens(
+        access_token=None, refresh_token=None, expires_in=None, metadata=None
+    ):
         persisted.append(
             {
                 "access_token": access_token,
@@ -470,7 +476,7 @@ def test_fetch_product_listing_refreshes_token_on_unauthorized(monkeypatch, alle
                 "expires_in": expires_in,
             }
         )
-        original_update(access_token, refresh_token, expires_in)
+        original_update(access_token, refresh_token, expires_in, metadata)
 
     monkeypatch.setattr(
         "magazyn.allegro_api.update_allegro_tokens", capture_tokens
@@ -487,7 +493,7 @@ def test_fetch_product_listing_refreshes_token_on_unauthorized(monkeypatch, alle
         {
             "access_token": "new-access",
             "refresh_token": "new-refresh",
-            "expires_in": None,
+            "expires_in": 3600,
         }
     ]
     assert offers == [


### PR DESCRIPTION
## Summary
- persist Allegro token expiry metadata and merge Allegro response details when saving tokens
- introduce a background token refresher with metrics, retry/backoff handling and integrate it with the app startup/shutdown flow
- update Allegro synchronization flows and tests to pass expiry data and cover automatic refresh behaviour

## Testing
- PYTHONPATH=. pytest magazyn/tests/test_allegro_refresh.py
- PYTHONPATH=. pytest magazyn/tests/test_allegro_offers.py

------
https://chatgpt.com/codex/tasks/task_e_68d09da7a290832aa8745e5829d02fa1