### PR TITLE
Add Allegro OAuth authorize route and tests

### DIFF
--- a/magazyn/app.py
+++ b/magazyn/app.py
@@ -11,10 +11,8 @@ from flask import (
     has_app_context,
 )
 from datetime import datetime
-import secrets
 import os
 import sys
-from urllib.parse import urlencode
 from werkzeug.security import check_password_hash
 from collections import OrderedDict
 
@@ -32,6 +30,7 @@ from .db import (
 from .sales import _sales_keys
 from .auth import login_required
 from . import print_agent
+from .allegro import ALLEGRO_AUTHORIZATION_URL
 from .allegro_token_refresher import token_refresher
 from .env_info import ENV_INFO
 from magazyn import DB_PATH
@@ -52,8 +51,6 @@ BOOLEAN_KEYS = {
 
 
 bp = Blueprint("main", __name__)
-
-ALLEGRO_AUTHORIZATION_URL = "https://allegro.pl/auth/oauth/authorize"
 
 # Backward compatibility placeholder populated in tests and scripts
 app = None
@@ -275,28 +272,6 @@ def settings_page():
         db_path_notice=db_path_notice,
         boolean_keys=BOOLEAN_KEYS,
     )
-
-
-@bp.post("/allegro/authorize")
-@login_required
-def allegro_authorize():
-    client_id = settings_store.get("ALLEGRO_CLIENT_ID")
-    redirect_uri = settings_store.get("ALLEGRO_REDIRECT_URI")
-    if not client_id or not redirect_uri:
-        flash("Uzupełnij konfigurację Allegro, aby rozpocząć autoryzację.")
-        return redirect(url_for("settings_page"))
-
-    state = secrets.token_urlsafe(16)
-    session["allegro_oauth_state"] = state
-
-    params = {
-        "response_type": "code",
-        "client_id": client_id,
-        "redirect_uri": redirect_uri,
-        "state": state,
-    }
-    authorization_url = f"{ALLEGRO_AUTHORIZATION_URL}?{urlencode(params)}"
-    return redirect(authorization_url)
 
 
 @bp.route("/logs")

--- a/magazyn/templates/settings.html
+++ b/magazyn/templates/settings.html
@@ -66,7 +66,7 @@
 </form>
 <div class="form-actions text-center mt-3">
     <button type="submit" form="settingsForm" class="btn btn-primary">Zapisz</button>
-    <form method="post" action="{{ url_for('main.allegro_authorize') }}" class="d-inline ms-2">
+    <form method="post" action="{{ url_for('allegro.authorize') }}" class="d-inline ms-2">
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
         <button type="submit" class="btn btn-outline-secondary">Połącz z Allegro</button>
     </form>

--- a/magazyn/tests/test_allegro_oauth.py
+++ b/magazyn/tests/test_allegro_oauth.py
@@ -1,0 +1,164 @@
+import json
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+from requests.exceptions import HTTPError
+
+from magazyn import allegro_api
+from magazyn.allegro import ALLEGRO_AUTHORIZATION_URL
+from magazyn.settings_store import settings_store
+
+
+@pytest.fixture
+def allegro_oauth_config():
+    original_values = {
+        key: settings_store.get(key)
+        for key in (
+            "ALLEGRO_CLIENT_ID",
+            "ALLEGRO_CLIENT_SECRET",
+            "ALLEGRO_REDIRECT_URI",
+            "ALLEGRO_ACCESS_TOKEN",
+            "ALLEGRO_REFRESH_TOKEN",
+            "ALLEGRO_TOKEN_EXPIRES_IN",
+            "ALLEGRO_TOKEN_METADATA",
+        )
+    }
+    settings_store.update(
+        {
+            "ALLEGRO_CLIENT_ID": "client-123",
+            "ALLEGRO_CLIENT_SECRET": "secret-456",
+            "ALLEGRO_REDIRECT_URI": "https://example.com/callback",
+            "ALLEGRO_ACCESS_TOKEN": None,
+            "ALLEGRO_REFRESH_TOKEN": None,
+            "ALLEGRO_TOKEN_EXPIRES_IN": None,
+            "ALLEGRO_TOKEN_METADATA": None,
+        }
+    )
+
+    try:
+        yield
+    finally:
+        cleanup = {
+            key: value if value is not None else None
+            for key, value in original_values.items()
+        }
+        settings_store.update(cleanup)
+        settings_store.reload()
+
+
+def _get_flashes(client):
+    with client.session_transaction() as session:
+        return session.get("_flashes") or []
+
+
+def _start_authorization(client):
+    response = client.post("/allegro/authorize")
+    assert response.status_code == 302
+    location = response.headers["Location"]
+    assert location.startswith(ALLEGRO_AUTHORIZATION_URL)
+    params = parse_qs(urlparse(location).query)
+    state = params.get("state", [""])[0]
+    assert state
+    return state
+
+
+def test_full_oauth_flow(client, login, monkeypatch, allegro_oauth_config):
+    state = _start_authorization(client)
+
+    def fake_get_access_token(client_id, client_secret, code, redirect_uri=None):
+        assert client_id == "client-123"
+        assert client_secret == "secret-456"
+        assert code == "auth-code"
+        assert redirect_uri == "https://example.com/callback"
+        return {
+            "access_token": "access-token",
+            "refresh_token": "refresh-token",
+            "expires_in": 3600,
+            "scope": "sale:offers",
+            "token_type": "bearer",
+        }
+
+    monkeypatch.setattr(allegro_api, "get_access_token", fake_get_access_token)
+
+    response = client.get(
+        "/allegro/oauth/callback",
+        query_string={"state": state, "code": "auth-code"},
+    )
+    assert response.status_code == 302
+    assert response.headers["Location"].endswith("/settings")
+
+    with client.session_transaction() as session:
+        assert "allegro_oauth_state" not in session
+
+    flashes = _get_flashes(client)
+    assert any("sukcesem" in message.lower() for _, message in flashes)
+
+    assert settings_store.get("ALLEGRO_ACCESS_TOKEN") == "access-token"
+    assert settings_store.get("ALLEGRO_REFRESH_TOKEN") == "refresh-token"
+    assert settings_store.get("ALLEGRO_TOKEN_EXPIRES_IN") == "3600"
+
+    metadata_raw = settings_store.get("ALLEGRO_TOKEN_METADATA")
+    assert metadata_raw
+    metadata = json.loads(metadata_raw)
+    assert metadata["scope"] == "sale:offers"
+    assert metadata["token_type"] == "bearer"
+    assert metadata["expires_in"] == 3600
+
+
+def test_oauth_callback_state_mismatch(client, login, allegro_oauth_config):
+    _start_authorization(client)
+
+    response = client.get(
+        "/allegro/oauth/callback",
+        query_string={"state": "invalid", "code": "auth-code"},
+    )
+    assert response.status_code == 302
+    assert response.headers["Location"].endswith("/settings")
+
+    flashes = _get_flashes(client)
+    assert any("state" in message.lower() for _, message in flashes)
+
+    assert settings_store.get("ALLEGRO_ACCESS_TOKEN") is None
+
+
+def test_oauth_callback_missing_code(client, login, allegro_oauth_config):
+    state = _start_authorization(client)
+
+    response = client.get(
+        "/allegro/oauth/callback",
+        query_string={"state": state},
+    )
+    assert response.status_code == 302
+    assert response.headers["Location"].endswith("/settings")
+
+    flashes = _get_flashes(client)
+    assert any("brak kodu" in message.lower() for _, message in flashes)
+
+    assert settings_store.get("ALLEGRO_ACCESS_TOKEN") is None
+
+
+def test_oauth_callback_handles_api_error(
+    client, login, monkeypatch, allegro_oauth_config
+):
+    state = _start_authorization(client)
+
+    class DummyResponse:
+        status_code = 400
+
+    def failing_get_access_token(*_, **__):
+        raise HTTPError(response=DummyResponse())
+
+    monkeypatch.setattr(allegro_api, "get_access_token", failing_get_access_token)
+
+    response = client.get(
+        "/allegro/oauth/callback",
+        query_string={"state": state, "code": "auth-code"},
+    )
+    assert response.status_code == 302
+    assert response.headers["Location"].endswith("/settings")
+
+    flashes = _get_flashes(client)
+    assert any("http status 400" in message.lower() for _, message in flashes)
+
+    assert settings_store.get("ALLEGRO_ACCESS_TOKEN") is None
+


### PR DESCRIPTION
## Summary
- move the Allegro OAuth authorize flow into the allegro blueprint with detailed logging and configuration validation
- update the settings template to call the new authorization endpoint and re-export the authorization URL constant
- cover the full OAuth happy-path and failure scenarios with dedicated tests

## Testing
- PYTHONPATH=. pytest magazyn/tests/test_allegro_oauth.py magazyn/tests/test_allegro_refresh.py magazyn/tests/test_settings.py

------
https://chatgpt.com/codex/tasks/task_e_68d0a53f5dd8832ab9324a0aad0aed16