### PR TITLE
Add shared Allegro OAuth handler and tests for new route

### DIFF
--- a/magazyn/allegro.py
+++ b/magazyn/allegro.py
@@ -61,9 +61,7 @@ def authorize():
     return redirect(authorization_url)
 
 
-@bp.get("/allegro/oauth/callback")
-@login_required
-def allegro_oauth_callback():
+def _process_allegro_oauth_callback() -> object:
     expected_state = session.pop("allegro_oauth_state", None)
     state = request.args.get("state")
     if not state or not expected_state or state != expected_state:
@@ -152,6 +150,18 @@ def allegro_oauth_callback():
     current_app.logger.info("Successfully obtained Allegro OAuth tokens")
     flash("Autoryzacja Allegro zakończona sukcesem.")
     return redirect(url_for("settings_page"))
+
+
+@bp.get("/allegro/oauth/callback")
+@login_required
+def allegro_oauth_callback():
+    return _process_allegro_oauth_callback()
+
+
+@bp.get("/allegro")
+@login_required
+def allegro_oauth_entrypoint():
+    return _process_allegro_oauth_callback()
 
 
 @bp.route("/allegro/offers")


### PR DESCRIPTION
## Summary
- extract Allegro OAuth callback logic into a shared helper
- register GET /allegro to reuse the same callback processing and flash behaviour
- extend Allegro OAuth tests to cover the new entrypoint for success and error scenarios

## Testing
- `PYTHONPATH=. pytest magazyn/tests/test_allegro_oauth.py`


------
https://chatgpt.com/codex/tasks/task_e_68d1253dde4c832a8315c5767f3fe4af