### PR TITLE
Add debug steps to Allegro price check responses

### DIFF
--- a/magazyn/static/price_check.js
+++ b/magazyn/static/price_check.js
@@ -25,6 +25,40 @@
         return link;
     }
 
+    function renderDebugSteps(steps) {
+        const debugContainer = document.getElementById('price-check-debug-container');
+        const debugList = document.getElementById('price-check-debug-list');
+
+        if (!debugContainer || !debugList) {
+            return;
+        }
+
+        const items = Array.isArray(steps) ? steps : [];
+        debugList.innerHTML = '';
+
+        if (!items.length) {
+            debugContainer.classList.add('d-none');
+            return;
+        }
+
+        debugContainer.classList.remove('d-none');
+
+        items.forEach((step) => {
+            const label = document.createElement('dt');
+            label.className = 'fw-semibold';
+            label.textContent = step && step.label ? step.label : '';
+            debugList.appendChild(label);
+
+            const valueWrapper = document.createElement('dd');
+            valueWrapper.className = 'mb-2 text-break';
+            const pre = document.createElement('pre');
+            pre.className = 'mb-0';
+            pre.textContent = step && step.value ? step.value : '';
+            valueWrapper.appendChild(pre);
+            debugList.appendChild(valueWrapper);
+        });
+    }
+
     function renderPriceChecks(data) {
         const loading = document.getElementById('price-check-loading');
         const tableContainer = document.getElementById('price-check-table-container');
@@ -36,6 +70,7 @@
         }
 
         loading.classList.add('d-none');
+        renderDebugSteps(data.debug_steps);
 
         if (data.auth_error) {
             errorContainer.className = 'alert alert-warning';

--- a/magazyn/templates/allegro/price_check.html
+++ b/magazyn/templates/allegro/price_check.html
@@ -12,6 +12,16 @@
     <span>Pobieramy aktualne ceny konkurencji…</span>
 </div>
 <div id="price-check-error" class="d-none"></div>
+<div id="price-check-debug-container" class="mb-4{% if not debug_steps %} d-none{% endif %}">
+    <h2 class="h4 mb-3">Szczegóły diagnostyczne</h2>
+    <dl id="price-check-debug-list" class="mb-0">
+        {% for step in debug_steps %}
+        <dt class="fw-semibold">{{ step.label }}</dt>
+        <dd class="mb-2 text-break"><pre class="mb-0">{{ step.value }}</pre></dd>
+        {% else %}
+        {% endfor %}
+    </dl>
+</div>
 <div id="price-check-table-container" class="table-responsive d-none">
     <table class="table table-striped align-middle" aria-live="polite">
         <thead class="table-dark">

--- a/magazyn/tests/test_allegro_price_check.py
+++ b/magazyn/tests/test_allegro_price_check.py
@@ -1,0 +1,112 @@
+import re
+from decimal import Decimal
+
+import pytest
+from magazyn.db import get_session
+from magazyn.models import AllegroOffer, Product, ProductSize
+
+
+@pytest.mark.usefixtures("login")
+class TestAllegroPriceCheckDebug:
+    def test_price_check_html_displays_debug_steps(
+        self, client, allegro_tokens
+    ) -> None:
+        allegro_tokens("token", "refresh")
+
+        response = client.get("/allegro/price-check")
+        assert response.status_code == 200
+
+        body = response.data.decode("utf-8")
+        assert "Szczegóły diagnostyczne" in body
+        assert "Czy dostępny access token Allegro" in body
+        # Value rendered within <pre> tag
+        assert re.search(r"<pre[^>]*>True</pre>", body)
+
+    def test_price_check_json_includes_debug_steps_on_success(
+        self, client, allegro_tokens, monkeypatch
+    ) -> None:
+        allegro_tokens("token", "refresh")
+        with get_session() as session:
+            product = Product(name="Szelki", color="Niebieskie")
+            session.add(product)
+            session.flush()
+            size = ProductSize(
+                product_id=product.id,
+                size="M",
+                barcode="321",
+            )
+            session.add(size)
+            session.flush()
+            session.add(
+                AllegroOffer(
+                    offer_id="offer-debug",
+                    title="Oferta debug",
+                    price=Decimal("123.00"),
+                    product_size_id=size.id,
+                )
+            )
+
+        def fake_listing(barcode, *, debug=None):
+            if debug is not None:
+                debug("Testowy listing", {"ean": barcode})
+            return [
+                {
+                    "id": "competitor-offer",
+                    "seller": {"id": "competitor"},
+                    "sellingMode": {"price": {"amount": "120.00"}},
+                }
+            ]
+
+        monkeypatch.setattr("magazyn.allegro.fetch_product_listing", fake_listing)
+
+        response = client.get("/allegro/price-check?format=json")
+        assert response.status_code == 200
+
+        payload = response.get_json()
+        assert payload["auth_error"] is None
+        assert payload["price_checks"]
+        labels = [step["label"] for step in payload["debug_steps"]]
+        assert "Testowy listing" in labels
+        assert "Listing Allegro – liczba ofert" in labels
+
+    def test_price_check_json_reports_refresh_error_steps(
+        self, client, allegro_tokens, monkeypatch
+    ) -> None:
+        allegro_tokens("token", "refresh")
+        with get_session() as session:
+            product = Product(name="Obroża")
+            session.add(product)
+            session.flush()
+            size = ProductSize(product_id=product.id, size="L", barcode="654")
+            session.add(size)
+            session.flush()
+            session.add(
+                AllegroOffer(
+                    offer_id="offer-error",
+                    title="Oferta z błędem",
+                    price=Decimal("150.00"),
+                    product_size_id=size.id,
+                )
+            )
+
+        def failing_listing(barcode, *, debug=None):
+            if debug is not None:
+                debug("Listing Allegro: odświeżanie nieudane", "Błąd testowy")
+            raise RuntimeError(
+                "Failed to refresh Allegro access token for product listing; "
+                "please re-authorize the Allegro integration"
+            )
+
+        monkeypatch.setattr("magazyn.allegro.fetch_product_listing", failing_listing)
+
+        response = client.get("/allegro/price-check?format=json")
+        assert response.status_code == 200
+
+        payload = response.get_json()
+        assert payload["auth_error"] is None
+        assert payload["price_checks"]
+        item = payload["price_checks"][0]
+        assert "Failed to refresh Allegro access token" in item["error"]
+        labels = [step["label"] for step in payload["debug_steps"]]
+        assert "Listing Allegro: odświeżanie nieudane" in labels
+        assert "Błąd pobierania listingu Allegro" in labels


### PR DESCRIPTION
## Summary
- extend the price check view and backend helpers to collect diagnostic steps for Allegro requests
- surface the recorded steps in both the HTML template and JSON API while enriching the listing fetcher with detailed debug hooks
- update the frontend script and add regression tests for success and refresh-error scenarios that assert the diagnostic output

## Testing
- PYTHONPATH=. pytest magazyn/tests/test_allegro_price_check.py magazyn/tests/test_allegro_offers.py magazyn/tests/test_allegro_api_limits.py

------
https://chatgpt.com/codex/tasks/task_e_68d15a0e6a8c832a8724eb0ec7bef9cf