### PR TITLE
Handle Allegro credential fallback and add tests

### DIFF
--- a/magazyn/allegro_api.py
+++ b/magazyn/allegro_api.py
@@ -187,19 +187,24 @@ def refresh_token(refresh_token: str) -> dict:
     def _normalize(value: Optional[str]) -> Optional[str]:
         return value or None
 
-    client_id: Optional[str] = None
-    client_secret: Optional[str] = None
+    client_id = _normalize(os.getenv("ALLEGRO_CLIENT_ID"))
+    client_secret = _normalize(os.getenv("ALLEGRO_CLIENT_SECRET"))
 
-    try:
-        client_id = _normalize(settings_store.get("ALLEGRO_CLIENT_ID"))
-        client_secret = _normalize(settings_store.get("ALLEGRO_CLIENT_SECRET"))
-    except SettingsPersistenceError:
-        client_id = client_secret = None
+    if not client_id or not client_secret:
+        store_client_id: Optional[str] = None
+        store_client_secret: Optional[str] = None
+        try:
+            store_client_id = _normalize(settings_store.get("ALLEGRO_CLIENT_ID"))
+            store_client_secret = _normalize(
+                settings_store.get("ALLEGRO_CLIENT_SECRET")
+            )
+        except SettingsPersistenceError:
+            store_client_id = store_client_secret = None
 
-    if not client_id:
-        client_id = _normalize(os.getenv("ALLEGRO_CLIENT_ID"))
-    if not client_secret:
-        client_secret = _normalize(os.getenv("ALLEGRO_CLIENT_SECRET"))
+        if not client_id:
+            client_id = store_client_id
+        if not client_secret:
+            client_secret = store_client_secret
 
     if not client_id or not client_secret:
         raise ValueError(


### PR DESCRIPTION
## Summary
- ensure Allegro token refresh retrieves client credentials from the environment first and falls back to the settings store when needed
- prevent refresh attempts without credentials by raising a clear error
- extend Allegro refresh tests to cover environment precedence and settings-store fallback scenarios

## Testing
- PYTHONPATH=. pytest magazyn/tests/test_allegro_refresh.py::test_refresh_token_prefers_environment magazyn/tests/test_allegro_refresh.py::test_refresh_token_uses_settings_store_when_env_missing

------
https://chatgpt.com/codex/tasks/task_e_68d15cbd5a94832ab7e260b01929c63c