### PR TITLE
Use settings store credentials for Allegro token refresh

### DIFF
--- a/magazyn/tests/test_allegro_refresh.py
+++ b/magazyn/tests/test_allegro_refresh.py
@@ -1175,7 +1175,7 @@ def test_token_refresher_retries_after_failure(monkeypatch):
 
     _set_tokens()
 
-def test_refresh_token_prefers_environment(monkeypatch):
+def test_refresh_token_uses_settings_store_even_if_env_present(monkeypatch):
     original_values = {}
     for key in ("ALLEGRO_CLIENT_ID", "ALLEGRO_CLIENT_SECRET"):
         try:
@@ -1202,7 +1202,7 @@ def test_refresh_token_prefers_environment(monkeypatch):
 
     def fake_post(url, data, auth=None, timeout=None):
         assert url == AUTH_URL
-        assert auth == ("env-client-id", "env-client-secret")
+        assert auth == ("settings-client-id", "settings-client-secret")
         assert data == {"grant_type": "refresh_token", "refresh_token": "refresh-token"}
         return DummyResponse()
 


### PR DESCRIPTION
## Summary
- update allegro refresh_token helper to read client credentials solely from the settings store
- adjust tests to confirm settings-backed credentials are used even when environment variables are unset or set differently

## Testing
- PYTHONPATH=. pytest magazyn/tests/test_allegro_refresh.py

------
https://chatgpt.com/codex/tasks/task_e_68d17a68baec832aab76cfd1fd151870