### PR TITLE
Ensure settings refresh before exposing cached values

### DIFF
--- a/magazyn/settings_store.py
+++ b/magazyn/settings_store.py
@@ -359,6 +359,10 @@ class SettingsStore:
         on_error=None,
     ) -> "OrderedDict[str, str]":
         self._ensure_loaded()
+        self._refresh_if_stale()
+        # _refresh_if_stale() may trigger reload() which resets the loaded flag.
+        # Ensure the values are available before reading from the cached mapping.
+        self._ensure_loaded()
         ordered = settings_io.load_settings(
             include_hidden=include_hidden,
             logger=logger,


### PR DESCRIPTION
## Summary
- refresh the cached settings mapping before generating the ordered dict so it reflects DB updates

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d17e9daa40832ab302570ad6021128