### PR TITLE
Fix price check log visibility on fetch errors

### DIFF
--- a/magazyn/static/price_check.js
+++ b/magazyn/static/price_check.js
@@ -191,18 +191,27 @@
         });
     }
 
+    function handleFetchError() {
+        const loading = document.getElementById('price-check-loading');
+        const errorContainer = document.getElementById('price-check-error');
+
+        if (loading) {
+            loading.classList.add('d-none');
+        }
+
+        if (errorContainer) {
+            errorContainer.className = 'alert alert-warning';
+            errorContainer.textContent =
+                'Nie udało się pobrać danych cenowych. Odśwież stronę i spróbuj ponownie.';
+        }
+    }
+
     function fetchPriceChecks() {
         const url = window.location.pathname + '?format=json';
         fetch(url, { headers: { Accept: 'application/json' } })
             .then((response) => response.json())
             .then(renderPriceChecks)
-            .catch(() => {
-                renderLogs('');
-                renderPriceChecks({
-                    price_checks: [],
-                    auth_error: 'Nie udało się pobrać danych cenowych. Odśwież stronę i spróbuj ponownie.',
-                });
-            });
+            .catch(handleFetchError);
     }
 
     document.addEventListener('DOMContentLoaded', fetchPriceChecks);


### PR DESCRIPTION
## Summary
- prevent the Allegro price check view from clearing previously rendered logs when the JSON fetch fails
- show the data loading error message without overwriting the existing debug information

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d3e74b4d98832aa52cec40751a541b