### PR TITLE
Refine Allegro price check debug output

### DIFF
--- a/magazyn/allegro.py
+++ b/magazyn/allegro.py
@@ -605,9 +605,6 @@ def price_check():
     access_token = settings_store.get("ALLEGRO_ACCESS_TOKEN")
     refresh_token = settings_store.get("ALLEGRO_REFRESH_TOKEN")
 
-    record_debug("Czy dostępny access token Allegro", bool(access_token))
-    record_debug("Czy dostępny refresh token Allegro", bool(refresh_token))
-
     auth_error = None
     if not access_token or not refresh_token:
         auth_error = (

--- a/magazyn/static/price_check.js
+++ b/magazyn/static/price_check.js
@@ -191,18 +191,27 @@
         });
     }
 
+    function handleFetchError() {
+        const loading = document.getElementById('price-check-loading');
+        const errorContainer = document.getElementById('price-check-error');
+
+        if (loading) {
+            loading.classList.add('d-none');
+        }
+
+        if (errorContainer) {
+            errorContainer.className = 'alert alert-warning';
+            errorContainer.textContent =
+                'Nie udało się pobrać danych cenowych. Odśwież stronę i spróbuj ponownie.';
+        }
+    }
+
     function fetchPriceChecks() {
         const url = window.location.pathname + '?format=json';
         fetch(url, { headers: { Accept: 'application/json' } })
             .then((response) => response.json())
             .then(renderPriceChecks)
-            .catch(() => {
-                renderLogs('');
-                renderPriceChecks({
-                    price_checks: [],
-                    auth_error: 'Nie udało się pobrać danych cenowych. Odśwież stronę i spróbuj ponownie.',
-                });
-            });
+            .catch(handleFetchError);
     }
 
     document.addEventListener('DOMContentLoaded', fetchPriceChecks);

--- a/magazyn/templates/allegro/price_check.html
+++ b/magazyn/templates/allegro/price_check.html
@@ -17,7 +17,6 @@
 </div>
 <div id="price-check-error" class="d-none"></div>
 <div id="price-check-debug-container" class="mb-4{% if not debug_steps %} d-none{% endif %}">
-    <h2 class="h4 mb-3">Szczegóły diagnostyczne</h2>
     <dl id="price-check-debug-list" class="mb-0">
         {% for step in debug_steps %}
         <dt class="fw-semibold">{{ step.label }}</dt>

--- a/magazyn/tests/test_allegro_offers.py
+++ b/magazyn/tests/test_allegro_offers.py
@@ -238,7 +238,6 @@ def test_price_check_requires_allegro_authorization(client, login, allegro_token
     )
     assert isinstance(payload["debug_steps"], list)
     labels = [step["label"] for step in payload["debug_steps"]]
-    assert "Czy dostępny access token Allegro" in labels
     assert "Żądany format odpowiedzi" in labels
 
 

--- a/magazyn/tests/test_allegro_price_check.py
+++ b/magazyn/tests/test_allegro_price_check.py
@@ -21,10 +21,9 @@ class TestAllegroPriceCheckDebug:
         body = response.data.decode("utf-8")
         assert "Pełne logi price-check" in body
         assert "id=\"price-check-log-content\"" in body
-        assert "Szczegóły diagnostyczne" in body
-        assert "Czy dostępny access token Allegro" in body
+        assert "Żądany format odpowiedzi" in body
         # Value rendered within <pre> tag
-        assert re.search(r"<pre[^>]*>True</pre>", body)
+        assert re.search(r"<pre[^>]*>html</pre>", body)
 
     def test_price_check_json_includes_debug_steps_on_success(
         self, client, allegro_tokens, monkeypatch


### PR DESCRIPTION
## Summary
- stop recording Allegro token availability in the price-check debug output and remove the unused diagnostics header from the template
- update the Allegro price check tests to look for the remaining response format step and revised debug value

## Testing
- PYTHONPATH=. pytest magazyn/tests/test_allegro_price_check.py magazyn/tests/test_allegro_offers.py

------
https://chatgpt.com/codex/tasks/task_e_68d3e74b4d98832aa52cec40751a541b