### PR TITLE
Ensure Selenium logs surface on scraping failures

### DIFF
--- a/magazyn/allegro_scraper.py
+++ b/magazyn/allegro_scraper.py
@@ -13,6 +13,14 @@ from typing import List, Optional, Sequence, Tuple
 
 logger = logging.getLogger(__name__)
 
+
+class AllegroScrapeError(RuntimeError):
+    """Raised when scraping Allegro listings fails and carries Selenium logs."""
+
+    def __init__(self, message: str, logs: Sequence[str]):
+        super().__init__(message)
+        self.logs = list(logs)
+
 try:  # pragma: no cover - optional dependency during import time
     from selenium import webdriver
     from selenium.webdriver.chrome.options import Options
@@ -501,6 +509,9 @@ def fetch_competitors(
                 break
 
         return offers, logs
+    except Exception as exc:
+        _log_step(logs, f"Błąd Selenium: {exc}")
+        raise AllegroScrapeError(str(exc), logs) from exc
     finally:
         _log_step(logs, "Zamykanie przeglądarki Selenium")
         driver.quit()

--- a/magazyn/tests/test_allegro_price_check.py
+++ b/magazyn/tests/test_allegro_price_check.py
@@ -5,7 +5,7 @@ import pytest
 from magazyn.config import settings
 from magazyn.db import get_session
 from magazyn.models import AllegroOffer, Product, ProductSize
-from magazyn.allegro_scraper import Offer
+from magazyn.allegro_scraper import Offer, AllegroScrapeError
 
 
 @pytest.mark.usefixtures("login")
@@ -99,7 +99,10 @@ class TestAllegroPriceCheckDebug:
             )
 
         def failing_competitors(offer_id, *, stop_seller=None, limit=30, headless=True):
-            raise RuntimeError("Selenium error: brak danych")
+            raise AllegroScrapeError(
+                "Selenium error: brak danych",
+                ["Start Selenium", "Zamykanie przeglądarki Selenium"],
+            )
 
         monkeypatch.setattr("magazyn.allegro.fetch_competitors_for_offer", failing_competitors)
 
@@ -113,4 +116,6 @@ class TestAllegroPriceCheckDebug:
         assert "Selenium error" in item["error"]
         labels = [step["label"] for step in payload["debug_steps"]]
         assert "Błąd pobierania ofert Allegro" in labels
+        assert "Log Selenium" in labels
         assert "Błąd pobierania ofert Allegro" in payload["debug_log"]
+        assert "Start Selenium" in payload["debug_log"]


### PR DESCRIPTION
## Summary
- add an AllegroScrapeError that carries Selenium log steps when scraping fails
- ensure price monitor and price check views always record Selenium logs, even on failures
- update automated tests to cover the new error propagation and logging behaviour

## Testing
- PYTHONPATH=. pytest magazyn/tests/test_allegro_scraper_driver.py
- PYTHONPATH=. pytest magazyn/tests/test_allegro_price_monitor.py
- PYTHONPATH=. pytest magazyn/tests/test_allegro_price_check.py

------
https://chatgpt.com/codex/tasks/task_e_68d4245bc4f8832ab3981cf49e68ddf4