### PR TITLE
Stream Allegro price-check logs and drop token requirement

### DIFF
--- a/magazyn/allegro.py
+++ b/magazyn/allegro.py
@@ -1,11 +1,14 @@
 import json
 import secrets
 from decimal import Decimal
-from typing import Optional
+from typing import Callable, Optional
+from queue import Queue
+from threading import Thread
 from urllib.parse import urlencode
 
 from flask import (
     Blueprint,
+    Response,
     current_app,
     render_template,
     request,
@@ -14,6 +17,7 @@ from flask import (
     flash,
     jsonify,
     session,
+    stream_with_context,
 )
 
 from sqlalchemy import case, or_
@@ -54,14 +58,22 @@ def _record_debug_step(steps: list[dict[str, str]], label: str, value: object) -
     steps.append({"label": label, "value": _format_debug_value(value)})
 
 
-def _append_debug_log(logs: Optional[list[str]], label: str, value: object) -> None:
-    if logs is None:
-        return
+def _append_debug_log(
+    logs: Optional[list[str]], label: str, value: object
+) -> tuple[str, str]:
     formatted = _format_debug_value(value)
     if formatted:
-        logs.append(f"{label}: {formatted}")
+        line = f"{label}: {formatted}"
     else:
-        logs.append(label)
+        line = label
+    if logs is not None:
+        logs.append(line)
+    return formatted, line
+
+
+def _sse_event(event: str, payload: dict[str, object]) -> str:
+    data = json.dumps(payload, ensure_ascii=False)
+    return f"event: {event}\ndata: {data}\n\n"
 
 
 def _process_oauth_response() -> dict[str, object]:
@@ -356,11 +368,14 @@ def _format_decimal(value: Optional[Decimal]) -> Optional[str]:
 def build_price_checks(
     debug_steps: Optional[list[dict[str, str]]] = None,
     debug_logs: Optional[list[str]] = None,
+    log_callback: Optional[Callable[[str, str], None]] = None,
 ) -> list[dict]:
     def record_debug(label: str, value: object) -> None:
         if debug_steps is not None:
             _record_debug_step(debug_steps, label, value)
-        _append_debug_log(debug_logs, label, value)
+        formatted, _ = _append_debug_log(debug_logs, label, value)
+        if log_callback is not None:
+            log_callback(label, formatted)
 
     with get_session() as db:
         rows = (
@@ -614,16 +629,6 @@ def price_check():
         _record_debug_step(debug_steps, label, value)
         _append_debug_log(debug_log_lines, label, value)
 
-    access_token = settings_store.get("ALLEGRO_ACCESS_TOKEN")
-    refresh_token = settings_store.get("ALLEGRO_REFRESH_TOKEN")
-
-    auth_error = None
-    if not access_token or not refresh_token:
-        auth_error = (
-            "Brak połączenia z Allegro. Kliknij „Połącz z Allegro” w ustawieniach, "
-            "aby ponownie autoryzować aplikację."
-        )
-
     wants_json = (
         request.args.get("format") == "json"
         or request.accept_mimetypes.best == "application/json"
@@ -632,15 +637,6 @@ def price_check():
     record_debug("Żądany format odpowiedzi", "json" if wants_json else "html")
 
     if wants_json:
-        if auth_error:
-            return jsonify(
-                {
-                    "price_checks": [],
-                    "auth_error": auth_error,
-                    "debug_steps": debug_steps,
-                    "debug_log": "\n".join(debug_log_lines),
-                }
-            )
         price_checks = build_price_checks(debug_steps, debug_log_lines)
         return jsonify(
             {
@@ -653,10 +649,75 @@ def price_check():
 
     return render_template(
         "allegro/price_check.html",
-        auth_error=auth_error,
+        auth_error=None,
         debug_steps=debug_steps,
         debug_log="\n".join(debug_log_lines),
     )
+
+
+@bp.route("/allegro/price-check/stream")
+@login_required
+def price_check_stream():
+    def event_stream():
+        queue: "Queue[Optional[str]]" = Queue()
+        debug_steps: list[dict[str, str]] = []
+        debug_log_lines: list[str] = []
+
+        def push_log(label: str, value: str) -> None:
+            line = f"{label}: {value}" if value else label
+            queue.put(
+                _sse_event(
+                    "log",
+                    {
+                        "label": label,
+                        "value": value,
+                        "line": line,
+                    },
+                )
+            )
+
+        def run_price_check() -> None:
+            try:
+                price_checks = build_price_checks(
+                    debug_steps,
+                    debug_log_lines,
+                    log_callback=push_log,
+                )
+                queue.put(
+                    _sse_event(
+                        "result",
+                        {
+                            "price_checks": price_checks,
+                            "auth_error": None,
+                            "debug_steps": debug_steps,
+                            "debug_log": "\n".join(debug_log_lines),
+                        },
+                    )
+                )
+            except Exception as exc:  # pragma: no cover - unexpected errors
+                current_app.logger.exception("Price check stream failed")
+                queue.put(
+                    _sse_event("error", {"message": str(exc)})
+                )
+            finally:
+                queue.put(None)
+
+        worker = Thread(target=run_price_check, daemon=True)
+        worker.start()
+
+        while True:
+            item = queue.get()
+            if item is None:
+                break
+            yield item
+
+    response = Response(
+        stream_with_context(event_stream()),
+        mimetype="text/event-stream",
+    )
+    response.headers["Cache-Control"] = "no-cache"
+    response.headers["X-Accel-Buffering"] = "no"
+    return response
 
 
 @bp.route("/allegro/refresh", methods=["POST"])

--- a/magazyn/tests/test_allegro_offers.py
+++ b/magazyn/tests/test_allegro_offers.py
@@ -214,7 +214,9 @@ def test_offers_without_inventory_are_listed_first(client, login):
     assert linked_titles == sorted(linked_titles)
 
 
-def test_price_check_requires_allegro_authorization(client, login, allegro_tokens):
+def test_price_check_does_not_require_allegro_authorization(
+    client, login, allegro_tokens
+):
     allegro_tokens()
 
     response = client.get("/allegro/price-check")
@@ -223,19 +225,16 @@ def test_price_check_requires_allegro_authorization(client, login, allegro_token
     body = response.data.decode("utf-8")
     assert (
         "Brak połączenia z Allegro. Kliknij „Połącz z Allegro” w ustawieniach, aby ponownie autoryzować aplikację."
-        in body
+        not in body
     )
-    assert "Missing Allegro access token" not in body
-    assert "<table" not in body
+    assert 'id="price-check-loading"' in body
+    assert 'id="price-check-table-body"' in body
 
     json_response = client.get("/allegro/price-check?format=json")
     assert json_response.status_code == 200
     payload = json_response.get_json()
     assert payload["price_checks"] == []
-    assert (
-        payload["auth_error"]
-        == "Brak połączenia z Allegro. Kliknij „Połącz z Allegro” w ustawieniach, aby ponownie autoryzować aplikację."
-    )
+    assert payload["auth_error"] is None
     assert isinstance(payload["debug_steps"], list)
     labels = [step["label"] for step in payload["debug_steps"]]
     assert "Żądany format odpowiedzi" in labels

--- a/magazyn/tests/test_allegro_price_check.py
+++ b/magazyn/tests/test_allegro_price_check.py
@@ -119,3 +119,39 @@ class TestAllegroPriceCheckDebug:
         assert "Log Selenium" in labels
         assert "Błąd pobierania ofert Allegro" in payload["debug_log"]
         assert "Start Selenium" in payload["debug_log"]
+
+    def test_price_check_stream_emits_events(
+        self, client, allegro_tokens, monkeypatch
+    ) -> None:
+        allegro_tokens("token", "refresh")
+        with get_session() as session:
+            product = Product(name="Smycz")
+            session.add(product)
+            session.flush()
+            size = ProductSize(product_id=product.id, size="XL", barcode="987")
+            session.add(size)
+            session.flush()
+            session.add(
+                AllegroOffer(
+                    offer_id="offer-stream",
+                    title="Oferta stream",
+                    price=Decimal("75.00"),
+                    product_size_id=size.id,
+                )
+            )
+
+        def fake_competitors(offer_id, *, stop_seller=None, limit=30, headless=True):
+            return (
+                [],
+                ["Stream log"],
+            )
+
+        monkeypatch.setattr("magazyn.allegro.fetch_competitors_for_offer", fake_competitors)
+
+        response = client.get("/allegro/price-check/stream")
+        assert response.status_code == 200
+        assert response.mimetype == "text/event-stream"
+        body = response.get_data(as_text=True)
+        assert "event: log" in body
+        assert "Stream log" in body
+        assert "event: result" in body


### PR DESCRIPTION
## Summary
- allow `/allegro/price-check` to run without Allegro tokens and expose a new `/stream` endpoint that emits Server-Sent Events with every debug entry
- update the price check frontend to listen to the SSE stream so logs appear immediately while keeping the existing table rendering for the final result
- adjust tests to cover the new behaviour and ensure streaming responses include log and result events

## Testing
- PYTHONPATH=. pytest magazyn/tests/test_allegro_price_check.py magazyn/tests/test_allegro_offers.py

------
https://chatgpt.com/codex/tasks/task_e_68d45ce5b690832a8a318dc37488a877