### PR TITLE
Stream Selenium logs in real time

### DIFF
--- a/magazyn/tests/test_allegro_price_check.py
+++ b/magazyn/tests/test_allegro_price_check.py
@@ -49,9 +49,13 @@ class TestAllegroPriceCheckDebug:
                 )
             )
 
-        def fake_competitors(offer_id, *, stop_seller=None, limit=30, headless=True):
+        def fake_competitors(
+            offer_id, *, stop_seller=None, limit=30, headless=True, log_callback=None
+        ):
             if stop_seller:
                 assert stop_seller == settings.ALLEGRO_SELLER_NAME
+            if log_callback is not None:
+                log_callback("Testowy listing")
             return (
                 [
                     Offer(
@@ -98,7 +102,11 @@ class TestAllegroPriceCheckDebug:
                 )
             )
 
-        def failing_competitors(offer_id, *, stop_seller=None, limit=30, headless=True):
+        def failing_competitors(
+            offer_id, *, stop_seller=None, limit=30, headless=True, log_callback=None
+        ):
+            if log_callback is not None:
+                log_callback("Start Selenium")
             raise AllegroScrapeError(
                 "Selenium error: brak danych",
                 ["Start Selenium", "Zamykanie przeglądarki Selenium"],
@@ -119,3 +127,43 @@ class TestAllegroPriceCheckDebug:
         assert "Log Selenium" in labels
         assert "Błąd pobierania ofert Allegro" in payload["debug_log"]
         assert "Start Selenium" in payload["debug_log"]
+
+    def test_price_check_stream_emits_events(
+        self, client, allegro_tokens, monkeypatch
+    ) -> None:
+        allegro_tokens("token", "refresh")
+        with get_session() as session:
+            product = Product(name="Smycz")
+            session.add(product)
+            session.flush()
+            size = ProductSize(product_id=product.id, size="XL", barcode="987")
+            session.add(size)
+            session.flush()
+            session.add(
+                AllegroOffer(
+                    offer_id="offer-stream",
+                    title="Oferta stream",
+                    price=Decimal("75.00"),
+                    product_size_id=size.id,
+                )
+            )
+
+        def fake_competitors(
+            offer_id, *, stop_seller=None, limit=30, headless=True, log_callback=None
+        ):
+            if log_callback is not None:
+                log_callback("Stream log")
+            return (
+                [],
+                ["Stream log"],
+            )
+
+        monkeypatch.setattr("magazyn.allegro.fetch_competitors_for_offer", fake_competitors)
+
+        response = client.get("/allegro/price-check/stream")
+        assert response.status_code == 200
+        assert response.mimetype == "text/event-stream"
+        body = response.get_data(as_text=True)
+        assert "event: log" in body
+        assert "Stream log" in body
+        assert "event: result" in body

--- a/magazyn/tests/test_allegro_refresh.py
+++ b/magazyn/tests/test_allegro_refresh.py
@@ -1285,8 +1285,12 @@ def test_price_check_uses_selenium_listing(client, login, monkeypatch, allegro_t
 
     calls: list[str] = []
 
-    def fake_competitors(offer_id, *, stop_seller=None, limit=30, headless=True):
+    def fake_competitors(
+        offer_id, *, stop_seller=None, limit=30, headless=True, log_callback=None
+    ):
         calls.append(offer_id)
+        if log_callback is not None:
+            log_callback("log")
         return (
             [
                 Offer(


### PR DESCRIPTION
## Summary
- add a context-variable driven callback in the Selenium scraper so every `_log_step` emits to listeners while the browser session is running
- have the price check flow forward scraper callbacks directly to the SSE queue while keeping the existing JSON logging behaviour for non-streaming clients
- adjust the Allegro price check tests to accept the optional log callback and assert the streaming logs continue to surface

## Testing
- PYTHONPATH=. pytest magazyn/tests/test_allegro_price_check.py magazyn/tests/test_allegro_offers.py magazyn/tests/test_allegro_refresh.py

------
https://chatgpt.com/codex/tasks/task_e_68d45ce5b690832a8a318dc37488a877