### PR TITLE
Expose Selenium debug view on price-check page

### DIFF
--- a/magazyn/templates/allegro/price_check.html
+++ b/magazyn/templates/allegro/price_check.html
@@ -1,6 +1,13 @@
 {% extends "base.html" %}
 
 {% block content %}
+<div id="price-check-visual-container" class="mb-4 d-none">
+    <h2 class="h4 mb-3">Podgląd przeglądarki Selenium</h2>
+    <div class="border rounded overflow-hidden">
+        <img id="price-check-visual-image" class="img-fluid" alt="Zrzut ekranu z Selenium" />
+    </div>
+    <p id="price-check-visual-meta" class="text-muted small mt-2 mb-0"></p>
+</div>
 <div id="price-check-log-container" class="mb-4{% if not debug_log %} d-none{% endif %}">
     <h2 class="h4 mb-3">Pełne logi price-check</h2>
     <pre id="price-check-log-content" class="bg-dark text-white p-3 rounded small mb-0">{{ debug_log }}</pre>
@@ -16,15 +23,6 @@
     <span>Pobieramy aktualne ceny konkurencji…</span>
 </div>
 <div id="price-check-error" class="d-none"></div>
-<div id="price-check-debug-container" class="mb-4{% if not debug_steps %} d-none{% endif %}">
-    <dl id="price-check-debug-list" class="mb-0">
-        {% for step in debug_steps %}
-        <dt class="fw-semibold">{{ step.label }}</dt>
-        <dd class="mb-2 text-break"><pre class="mb-0">{{ step.value }}</pre></dd>
-        {% else %}
-        {% endfor %}
-    </dl>
-</div>
 <div id="price-check-table-container" class="table-responsive d-none">
     <table class="table table-striped align-middle" aria-live="polite">
         <thead class="table-dark">

--- a/magazyn/tests/test_allegro_offers.py
+++ b/magazyn/tests/test_allegro_offers.py
@@ -284,7 +284,13 @@ def test_price_check_table_and_lowest_flag(client, login, monkeypatch, allegro_t
     monkeypatch.setattr(settings, "ALLEGRO_SELLER_NAME", "Retriever Shop")
 
     def fake_competitors(
-        offer_id, *, stop_seller=None, limit=30, headless=True, log_callback=None
+        offer_id,
+        *,
+        stop_seller=None,
+        limit=30,
+        headless=True,
+        log_callback=None,
+        screenshot_callback=None,
     ):
         if offer_id == "offer-low":
             if log_callback is not None:
@@ -403,7 +409,13 @@ def test_price_check_product_level_aggregates_barcodes(client, login, monkeypatc
     called_offers: list[str] = []
 
     def fake_competitors(
-        offer_id, *, stop_seller=None, limit=30, headless=True, log_callback=None
+        offer_id,
+        *,
+        stop_seller=None,
+        limit=30,
+        headless=True,
+        log_callback=None,
+        screenshot_callback=None,
     ):
         called_offers.append(offer_id)
         if offer_id == "offer-product":

--- a/magazyn/tests/test_allegro_price_monitor.py
+++ b/magazyn/tests/test_allegro_price_monitor.py
@@ -14,7 +14,15 @@ from magazyn.allegro_scraper import Offer
 def test_check_prices_grouped(monkeypatch, app_mod):
     calls = {}
 
-    def fake_fetch(offer_id, *, stop_seller=None, limit=30, headless=True):
+    def fake_fetch(
+        offer_id,
+        *,
+        stop_seller=None,
+        limit=30,
+        headless=True,
+        log_callback=None,
+        screenshot_callback=None,
+    ):
         calls[offer_id] = calls.get(offer_id, 0) + 1
         if offer_id == "o1":
             return [Offer("Oferta", "40,00 zł", "Sprzedawca", "https://allegro.pl/oferta/other")], []
@@ -83,7 +91,15 @@ def test_check_prices_grouped(monkeypatch, app_mod):
 
 
 def test_check_prices_readonly_db(monkeypatch, app_mod, caplog):
-    def fake_fetch(offer_id, *, stop_seller=None, limit=30, headless=True):
+    def fake_fetch(
+        offer_id,
+        *,
+        stop_seller=None,
+        limit=30,
+        headless=True,
+        log_callback=None,
+        screenshot_callback=None,
+    ):
         return [Offer("Oferta", "40,00 zł", "Sprzedawca", "https://allegro.pl/oferta/other")], []
 
     messages: list[str] = []

--- a/magazyn/tests/test_allegro_refresh.py
+++ b/magazyn/tests/test_allegro_refresh.py
@@ -1286,7 +1286,13 @@ def test_price_check_uses_selenium_listing(client, login, monkeypatch, allegro_t
     calls: list[str] = []
 
     def fake_competitors(
-        offer_id, *, stop_seller=None, limit=30, headless=True, log_callback=None
+        offer_id,
+        *,
+        stop_seller=None,
+        limit=30,
+        headless=True,
+        log_callback=None,
+        screenshot_callback=None,
     ):
         calls.append(offer_id)
         if log_callback is not None:


### PR DESCRIPTION
## Summary
- stream Selenium screenshots while scraping Allegro offers and forward them through the price-check SSE channel
- display a Selenium preview at the top of the price-check page and reduce the debug UI to a single consolidated log feed
- update the price-check tests (and supporting fixtures) to cover the new screenshot hook and HTML expectations

## Testing
- PYTHONPATH=. pytest magazyn/tests/test_allegro_price_check.py


------
https://chatgpt.com/codex/tasks/task_e_68d50751d0e4832ab345e54bb2893097